### PR TITLE
Sprint 32 TLT-2038 Proxy icommons_rest_api requests

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -10,6 +10,7 @@ django-angular==0.7.13
 ndg-httpsclient==0.4.0
 boto==2.38.0
 kitchen==1.2.1
+django-proxy==1.0.2
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.1#egg=canvas-python-sdk==0.8.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.7#egg=django-icommons-common==1.10.7
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = (
     'django_auth_lti',
     'icommons_common',
     'icommons_ui',
+    'proxy',
     'canvas_account_admin_tools',
 )
 
@@ -240,3 +241,6 @@ CONCLUDE_COURSES_URL = SECURE_SETTINGS.get(
     'conclude_courses_url',
     'https://icommons-tools.dev.tlt.harvard.edu/course_conclusion'
 )
+
+ICOMMONS_REST_API_HOST = SECURE_SETTINGS.get('icommons_rest_api_host', 'http://localhost:8000')
+ICOMMONS_REST_API_TOKEN = SECURE_SETTINGS.get('icommons_rest_api_token')

--- a/canvas_account_admin_tools/urls.py
+++ b/canvas_account_admin_tools/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     url(r'^not_authorized$', icommons_ui_views.not_authorized, name='not_authorized'),
     url(r'^tool_config$', views.tool_config, name='tool_config'),
     url(r'^lti_launch$', views.lti_launch, name='lti_launch'),
+    url(r'^icommons_rest_api/(?P<path>.*)$', views.icommons_rest_api_proxy, name='icommons_rest_api_proxy'),
     url(r'^account_dashboard$', views.dashboard_account, name='dashboard_account'),
 ]

--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from django.conf import settings
@@ -12,6 +11,8 @@ from django.views.decorators.http import require_http_methods
 from ims_lti_py.tool_config import ToolConfig
 
 from canvas_account_admin_tools.models import ExternalTool
+
+from proxy.views import proxy_view
 
 
 logger = logging.getLogger(__name__)
@@ -87,4 +88,14 @@ def dashboard_account(request):
         'conclude_courses': conclude_courses,
         'lti_tools_usage': lti_tools_usage,
         'courses_in_this_account': courses_in_this_account
+    })
+
+
+@login_required
+def icommons_rest_api_proxy(request, path):
+    url = "{}/{}".format(settings.ICOMMONS_REST_API_HOST, path)
+    return proxy_view(request, url, {
+        'headers': {
+            'Authorization': "Token {}".format(settings.ICOMMONS_REST_API_TOKEN)
+        }
     })


### PR DESCRIPTION
* Use django-proxy to proxy requests to icommons_rest_api with an Authentication token
* This allows requests to be made to this application with the following url structure and those requests will be forwarded on to the configured icommons_rest_api deployment:
```
[canvas_account_admin_tools host]/icommons_rest_api/api/course/v2/course_instances?format=json&canvas_course_id=6402
```