### PR TITLE
Sprint 32 TLT-1312 Clean up icommons_rest_api proxy

### DIFF
--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -93,7 +94,12 @@ def dashboard_account(request):
 
 @login_required
 def icommons_rest_api_proxy(request, path):
-    url = "{}/{}".format(settings.ICOMMONS_REST_API_HOST, path)
+    # Remove resource_link_id query param
+    # request.GET is immutable, so we need to copy before modifying
+    request.GET = request.GET.copy()
+    request.GET.pop('resource_link_id', None)
+
+    url = "{}/{}".format(settings.ICOMMONS_REST_API_HOST, os.path.join(path, ''))
     return proxy_view(request, url, {
         'headers': {
             'Authorization': "Token {}".format(settings.ICOMMONS_REST_API_TOKEN)


### PR DESCRIPTION
* Strip resource_link_id query param from requests made to icommons_rest_api
* Ensure a trailing slash on requests made to icommons_rest_api