### PR TITLE
Task/elliottyates/tlt 2025/course info ui fixes

### DIFF
--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -14,7 +14,8 @@ from ims_lti_py.tool_config import ToolConfig
 from canvas_account_admin_tools.models import ExternalTool
 
 from proxy.views import proxy_view
-
+from django_auth_lti import const
+from django_auth_lti.decorators import lti_role_required
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,8 @@ def lti_launch(request):
 
 
 @login_required
+@lti_role_required(const.ADMINISTRATOR)
+@require_http_methods(['GET'])
 def dashboard_account(request):
     custom_canvas_account_id = request.LTI['custom_canvas_account_id']
 

--- a/course_info/static/course_info/js/controllers/IndexController.js
+++ b/course_info/static/course_info/js/controllers/IndexController.js
@@ -6,7 +6,6 @@
         $scope.searchInProgress = false;
         $scope.queryString = '';
         $scope.showDataTable = false;
-        $scope.filtersApplied = false;
         $scope.columnFieldMap = {
             1: 'title',
             2: 'term__academic_year',
@@ -83,19 +82,6 @@
                 function(option){ return option.value == selectedValue})[0];
         };
 
-        $scope.checkIfFiltersApplied = function() {
-            for (var key in $scope.filters) {
-                if ($scope.filters[key].query) {
-                    $scope.filtersApplied = true;
-                    break;
-                }
-                $scope.filtersApplied = false;
-            }
-        };
-
-        // deep object compare
-        $scope.$watch('filters', $scope.checkIfFiltersApplied, true);
-
         $scope.courseInstanceToTable = function(course) {
             var cinfo = {};
             cinfo['description'] = course.title;
@@ -148,12 +134,10 @@
                     if ($scope.queryString.trim() != '') {
                         queryParameters.search = $scope.queryString.trim();
                     }
-                    if ($scope.filtersApplied) {
-                        for (var key in $scope.filters) {
-                            var f = $scope.filters[key];
-                            if (f.query) {
-                                queryParameters[f.key] = f.query_value ? f.query_value : f.value;
-                            }
+                    for (var key in $scope.filters) {
+                        var f = $scope.filters[key];
+                        if (f.query) {
+                            queryParameters[f.key] = f.query_value ? f.query_value : f.value;
                         }
                     }
                     queryParameters.offset = data.start;

--- a/course_info/static/course_info/js/controllers/IndexController.js
+++ b/course_info/static/course_info/js/controllers/IndexController.js
@@ -12,6 +12,7 @@
             3: 'term__display_name',
             5: 'course__registrar_code_display'
         };
+        $scope.columnOrderable = {};
         $scope.filterOptions = {
             // `key` and `value` are the GET params sent to the server when
             // the option is chosen. `value` must be unique in its option list,
@@ -82,6 +83,20 @@
                 function(option){ return option.value == selectedValue})[0];
         };
 
+        $scope.enableColumnSorting = function(toggle) {
+            var cols = $('#courseInfoDT').dataTable().fnSettings().aoColumns;
+            $.each(cols, function(index, column){
+                if (toggle) {
+                    // restore state
+                    column.bSortable = $scope.columnOrderable[column.idx];
+                } else {
+                    // save state before disabling
+                    $scope.columnOrderable[column.idx] = column.bSortable;
+                    column.bSortable = toggle;
+                }
+            });
+        };
+
         $scope.courseInstanceToTable = function(course) {
             var cinfo = {};
             cinfo['description'] = course.title;
@@ -130,6 +145,7 @@
                     $scope.$apply(function(){
                         $scope.searchInProgress = true;
                     });
+                    $scope.enableColumnSorting(false);
                     var queryParameters = {};
                     if ($scope.queryString.trim() != '') {
                         queryParameters.search = $scope.queryString.trim();
@@ -173,6 +189,7 @@
                             $scope.$apply(function(){
                                 $scope.searchInProgress = false;
                             });
+                            $scope.enableColumnSorting(true);
                             //reset request when complete
                             request = null;
                         }

--- a/course_info/templates/course_info/index.html
+++ b/course_info/templates/course_info/index.html
@@ -108,7 +108,6 @@
     <div class="row">
       <div class="col-mid-12">
         <button type="button" class="btn btn-primary btn-block center-block"
-                ng-disabled="!searchEnabled"
                 ng-click="searchCourseInstances($event)">
           <i class="fa fa-search"></i>
           Search
@@ -139,7 +138,7 @@
         <thead>
           <th class="sorting" tabindex="0">School&nbsp;&nbsp;</th>
           <th class="sorting" tabindex="0">Course Details&nbsp;&nbsp;</th>
-          <th class="sorting" tabindex="0">Academic year&nbsp;&nbsp;</th>
+          <th class="sorting" tabindex="0">Academic Year&nbsp;&nbsp;</th>
           <th class="sorting" tabindex="0">Academic Term&nbsp;&nbsp;</th>
           <th class="sorting" tabindex="0">Associated Site&nbsp;&nbsp;</th>
           <th class="sorting" tabindex="0">Course Code&nbsp;&nbsp;</th>


### PR DESCRIPTION
- restricts access to admin dashboard to LTI administrator roles only
- default sorting is by the Course Details column in ascending order
- For the BAs, the default selection is "All schools" and the current year
- For the liaisons, the default selection is their school (and associated schools, if any), and the current year
- The search button is always active
- Non cross listed courses don't have any Cross Listing label, rather an "N/A"
- Courses without sites show an "N/A" in place of the site link
- column header capitalization
- disables column sorting (i.e. a new search) while an existing search is underway on course_info index page