### PR TITLE
Revert "Sprint 33 TLT-1312 Handle new term_codes return structure"

### DIFF
--- a/course_info/static/course_info/js/controllers/IndexController.js
+++ b/course_info/static/course_info/js/controllers/IndexController.js
@@ -47,7 +47,7 @@
         $http.get('/icommons_rest_api/api/course/v2/term_codes')
             .then(function successCallback(response) {
                 $scope.filterOptions.terms =
-                    $scope.filterOptions.terms.concat(response.data.map(function (tc) {
+                    $scope.filterOptions.terms.concat(response.data.results.map(function (tc) {
                         return {
                             key: 'term_code',
                             value: tc.term_code,


### PR DESCRIPTION
Looks like we had an old version of the rest api running on dev, and this change should never have been made.

Reverts Harvard-University-iCommons/canvas_account_admin_tools#16