### PR TITLE
Fix jasmine tests

### DIFF
--- a/course_info/tests/jasmine/indexSpec.js
+++ b/course_info/tests/jasmine/indexSpec.js
@@ -22,28 +22,30 @@ describe('course_info IndexController', function() {
     };
 
     // instantiate the controller, give it a $scope
-    scope = $rootScope.new();
+    scope = $rootScope.$new();
     controller = $controller('IndexController', { $scope: scope });
 
     // always expect the controller constructor to call for term codes
-    var term_codes = [
-        {
-            "term_code": 0,
-            "term_name": "Summer",
-            "sort_order": 40
-        },
-        {
-            "term_code": 1,
-            "term_name": "Fall",
-            "sort_order": 60
-        },
-        {
-            "term_code": 2,
-            "term_name": "Spring",
-            "sort_order": 30
-        },
-    ];
-    $httpBackend.expectGET('/icommons_rest_api/api/course/v2/term_codes')
+    var term_codes = {
+        "results": [
+            {
+                "term_code": 0,
+                "term_name": "Summer",
+                "sort_order": 40
+            },
+            {
+                "term_code": 1,
+                "term_name": "Fall",
+                "sort_order": 60
+            },
+            {
+                "term_code": 2,
+                "term_name": "Spring",
+                "sort_order": 30
+            },
+        ],
+    };
+    $httpBackend.expectGET('/icommons_rest_api/api/course/v2/term_codes/?limit=100')
         .respond(200, JSON.stringify(term_codes));
     $httpBackend.flush(1); // flush the term_codes request
   }));

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "karma": "~0.13",
     "karma-jasmine": "~0.3.6",
     "karma-jasmine-jquery": "^0.1.1",
-    "karma-phantomjs-launcher": "~0.2"
+    "karma-phantomjs-launcher": "~0.2",
+    "phantomjs": "^1.9.18"
   }
 }


### PR DESCRIPTION
* there's no such thing as scope.new(), it's .$new().
* update the term_codes url and response to match what we're using now
* add phantomjs as dev dependency