### PR TITLE
Sprint 38 TLT-1155 Fix alert for canvas enrollment failure

### DIFF
--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -35,14 +35,26 @@
             $http.post(url, user)
                 .success(function(data, status, headers, config, statusText) {
                     if (data.detail) {
-                        // TODO - only add a failed-to-add-to-canvas partialFailure
-                        //        if the course instance has a canvas site.
-                        // TODO - put more details into this warning, like
-                        //        user/role details.
-                        $scope.partialFailures.push({
-                            searchTerm: searchTerm,
-                            text: data.detail,
-                        });
+                        if (data.detail ==
+                                'User could not be enrolled in Canvas course/section.') {
+                            var ci = courseInstances.instances[$scope.courseInstanceId];
+                            var externalSites = (ci.sites || []).filter(
+                                                    function(site) {
+                                                        return site.site_type_id == 'external';
+                                                    });
+                            if (externalSites.length > 0) {
+                                $scope.partialFailures.push({
+                                    searchTerm: searchTerm,
+                                    text: data.detail,
+                                });
+                            }
+                        }
+                        else {
+                            $scope.partialFailures.push({
+                                searchTerm: searchTerm,
+                                text: data.detail,
+                            });
+                        }
                     }
 
                     $http.get(url, {params: {user_id: user.user_id}})
@@ -174,7 +186,6 @@
                     });
                 }
                 else if (filteredResults.length == 1) {
-                    console.log(filteredResults);
                     $scope.addUserToCourse(peopleResult.config.searchTerm,
                                            {user_id: filteredResults[0].univ_id,
                                             role_id: $scope.selectedRole.roleId});


### PR DESCRIPTION
Only show the warning about Canvas enrollment failure if we know the course has external sites.

* also, remove unnecessary `console.log`