### PR TITLE
Sprint 39 TLT-2299 Don't couple the search bar and the success alert

### DIFF
--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -182,7 +182,7 @@
 
       <uib-alert ng-repeat="person in successes" type="success"
                                                  close="closeAlert('successes', $index)" class="col-md-12">
-        <p><strong>{{ searchTerm }}</strong> was just added to this course:</p>
+        <p><strong>{{ person.searchTerm }}</strong> was just added to this course:</p>
         <div style="border-style: solid; border-width: 1px 0px 1px 0px; border-color: #ccc; padding:.5em; margin-top:1em;">
           {{ person.profile.name_last }}, {{ person.profile.name_first }}
           <badge role="{{ person.profile.role_type_cd }}"></badge> {{ person.profile.univ_id }}


### PR DESCRIPTION
We were just referencing the scope variable, instead of the copy from the success entry.