### PR TITLE
Change 'Teaching Fellow' to 'TA' in the UI

### DIFF
--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -347,6 +347,12 @@
         $scope.renderName = function(data, type, full, meta) {
             return full.profile.name_last + ', ' + full.profile.name_first;
         };
+        // hotfix added to address TA role name
+        // will be addressed with a database change as soon as
+        // devops determines viability of change
+        $scope.renderRole = function(data, type, full, meta) {
+            return /^Teaching Fellow$/.test(data) ? 'TA' : data;
+        };
         $scope.renderRemove = function(data, type, full, meta) {
             // TODO - maybe make this a directive?  the isolate scope
             //        in a directive complicates things.  anything has
@@ -404,7 +410,7 @@
             {roleId: 1, roleName: 'Course Head'},
             {roleId: 2, roleName: 'Faculty'},
             {roleId: 12, roleName: 'Teaching Staff'},
-            {roleId: 5, roleName: 'Teaching Fellow'},
+            {roleId: 5, roleName: 'TA'},
             {roleId: 11, roleName: 'Course Support Staff'},
             {roleId: 7, roleName: 'Designer'},
             {roleId: 15, roleName: 'Observer'},
@@ -477,6 +483,8 @@
             searching: false,
             serverSide: true,
         };
+
+        // see hotfix note above for renderRole
         $scope.dtColumns = [
             {
                 data: '',
@@ -490,6 +498,7 @@
             },
             {
                 data: 'role.role_name',
+                render: $scope.renderRole,
                 title: 'Role'
             },
             {


### PR DESCRIPTION
This change changes the name of the role in the dropdown list as well as the name of the role in the data table. The change to the data table requires a test that checks to see if the role is 'Teaching Fellow' if it is, it returns 'TA', if not, it just returns the current value. This is really a temp fix until the decision is made about changing the values in the UserRoles table.

Jill and Colin are going to discuss making the change to the role name in the database. The icommons rest api returns the values of the UserRoles table which has the role name 'Teaching Fellow'. 
