### PR TITLE
Task/elliottyates/tlt 2350/course info people page ux fixes

### DIFF
--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -44,3 +44,7 @@ div#progressBarOuterWrapper {
 .btn-group {
   margin-top: 1em;
 }
+
+table.course-info-table {
+    margin-top: 1em;
+}

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -382,7 +382,7 @@
                 $http.get(url)
                     .success(function(data, status, headers, config, statusText) {
                         //check if the right data was obtained before storing it
-                        if (data.course_instance_id === id){
+                        if (data.course_instance_id == id){
                             courseInstances.instances[data.course_instance_id] = data;
                             $scope.courseInstance = $scope.getFormattedCourseInstance(data)
                         }else{

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -17,9 +17,9 @@
   <div class="col-md-12">
       <div id="courseInfoDT_wrapper" class="dataTables_wrapper form-inline no-footer">
         <!-- UI comment - inline style for a table border until table-box makes it to Bootrsap 4 -->
-        <table id="courseInfoDT" class="display dataTable" cellspacing="0"
+        <table id="courseInfoDT" class="display dataTable course-info-table"
                role="grid" aria-describedby="courseInfoDT_info"
-               style="width: 978px; border: solid 1px #ccc; margin-top: 1em;">
+               cellspacing="0">
           <tbody>
             <tr role="row" class="odd">
               <td class="sorting" tabindex="0">{{courseInstance.school}}</td>


### PR DESCRIPTION
Fixes two issues with TLT-2350:
- course info people page course detail box now responsive (pending @Vittorio2015's approval)
- fixes string/num comparison in course info people controller (pending @rascalking's confirmation and successful jasmine tests)