### PR TITLE
Task/elliottyates/tlt 2254/add people ux improvements

### DIFF
--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -57,3 +57,10 @@ table.course-info-table {
     /* pad add people button and its expand-o-widget equally */
     margin-bottom: 20px;
 }
+
+.bring-forward {
+    /* hack to ensure some page regions can be interacted with when partially
+    occluded by other regions (e.g. so privacy disclaimer button can be clicked
+    despite the div to the left of it spilling over into its page space) */
+    z-index: 10;
+}

--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -52,3 +52,8 @@ table.dataTable thead .sorting.sorting_disabled {
 table.course-info-table {
     margin-top: 1em;
 }
+
+#people {
+    /* pad add people button and its expand-o-widget equally */
+    margin-bottom: 20px;
+}

--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -50,6 +50,7 @@ table.dataTable thead .sorting.sorting_disabled {
 }
 
 table.course-info-table {
+    border: solid 1px #ccc;
     margin-top: 1em;
 }
 

--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -1,9 +1,26 @@
-table.dataTable thead .sorting.sorting_disabled {
-    background-image: none;
+.btn-group {
+  margin-top: 1em;
+}
+
+#directoryLink {
+    margin-bottom: 1em;
 }
 
 div.btn-toolbar div.input-group {
     width: 56%;
+}
+
+div.course-membership-entry {
+    border-color: #ccc;
+    border-style: solid;
+    border-width: 1px 0 1px 0;
+    margin-bottom: 1em;
+    margin-top: 1em;
+    padding: .5em;
+}
+
+div.progress div.progress-bar {
+    width: 100%;
 }
 
 div.row div.col-mid-12 button.center-block {
@@ -11,38 +28,25 @@ div.row div.col-mid-12 button.center-block {
     min-width: 15%;
 }
 
-div.progress div.progress-bar {
-    width: 100%;
+h3.breadcrumbs {
+    line-height: 1.5em;
 }
 
 i.fa-trash-disabled {
     color: #ccc;
 }
 
-div.course-membership-entry {
-    border-color: #ccc;
-    border-style: solid;
-    border-width: 1px 0px 1px 0px;
-    margin-bottom: 1em;
-    margin-top: 1em;
-    padding: .5em;
-}
-
-ul#privacyDropdown {
+#privacyDropdown {
     padding: 1em;
     width: 30em;
 }
 
-div#directoryLink {
-    margin-bottom: 1em;
-}
-
-div#progressBarOuterWrapper {
+#progressBarOuterWrapper {
     padding-top: 1em;
 }
 
-.btn-group {
-  margin-top: 1em;
+table.dataTable thead .sorting.sorting_disabled {
+    background-image: none;
 }
 
 table.course-info-table {

--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -1,3 +1,10 @@
+.bring-forward {
+    /* hack to ensure some page regions can be interacted with when partially
+    occluded by other regions (e.g. so privacy disclaimer button can be clicked
+    despite the div to the left of it spilling over into its page space) */
+    z-index: 10;
+}
+
 .btn-group {
   margin-top: 1em;
 }
@@ -36,6 +43,11 @@ i.fa-trash-disabled {
     color: #ccc;
 }
 
+#people {
+    /* pad add people button and its expand-o-widget equally */
+    margin-bottom: 20px;
+}
+
 #privacyDropdown {
     padding: 1em;
     width: 30em;
@@ -52,16 +64,4 @@ table.dataTable thead .sorting.sorting_disabled {
 table.course-info-table {
     border: solid 1px #ccc;
     margin-top: 1em;
-}
-
-#people {
-    /* pad add people button and its expand-o-widget equally */
-    margin-bottom: 20px;
-}
-
-.bring-forward {
-    /* hack to ensure some page regions can be interacted with when partially
-    occluded by other regions (e.g. so privacy disclaimer button can be clicked
-    despite the div to the left of it spilling over into its page space) */
-    z-index: 10;
 }

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -514,7 +514,7 @@
                     previous: '',
                 },
             },
-            lengthMenu: [ 10, 25, 50, 75, 100 ],
+            lengthMenu: [10, 25, 50, 100],
             // yes, this is a deprecated param.  yes, it's still required.
             // see https://datatables.net/forums/discussion/27287/using-an-ajax-custom-get-function-don-t-forget-to-set-sajaxdataprop
             sAjaxDataProp: 'data',

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -514,7 +514,7 @@
                     previous: '',
                 },
             },
-            lengthChange: false,
+            lengthMenu: [ 10, 25, 50, 75, 100 ],
             // yes, this is a deprecated param.  yes, it's still required.
             // see https://datatables.net/forums/discussion/27287/using-an-ajax-custom-get-function-don-t-forget-to-set-sajaxdataprop
             sAjaxDataProp: 'data',

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -52,9 +52,11 @@
 
           <div class="col-md-6">
             <div class="form-group">
-              <label class="sr-only" for="emailHUID">Enter Harvard University ID or email addresses</label>
+              <label class="sr-only" for="emailHUID">
+                Enter Harvard University ID or email address
+              </label>
               <input class="form-control" id="emailHUID"
-                     placeholder="Enter Harvard University ID or email addresses"
+                     placeholder="Enter Harvard University ID or email address"
                      ng-model="searchTerm" ng-disabled="searchResults.length > 1">
             </div>
           </div>

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -244,19 +244,17 @@
       </div>
       <div ng-switch-when="serverError">
         There was a problem removing <strong>{{ failure.profile.name_last }},
-          {{ failure.profile.name_first }}</strong> from the database.  Please
-        try again.  If the error persists, please contact your local school
-        support staff.
+        {{ failure.profile.name_first }}</strong> from the database. Please
+        try again.
       </div>
       <div ng-switch-when="canvasError">
         There was a problem removing <strong>{{ failure.profile.name_last }},
-          {{ failure.profile.name_first }}</strong> from the Canvas site.  If the
-        error persists, please contact your local school support staff.
+        {{ failure.profile.name_first }}</strong> from the Canvas site. Please
+        try again.
       </div>
       <div ng-switch-default>
         There was a problem removing <strong>{{ failure.profile.name_last }},
-          {{ failure.profile.name_first }}</strong>.  Please try again.  If the
-        error persists, please contact your local school support staff.
+        {{ failure.profile.name_first }}</strong>. Please try again.
       </div>
     </div>
     <div class="course-membership-entry">

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -81,7 +81,7 @@
             </ul>
           </div>
 
-          <div class="col-md-4">
+          <div class="col-md-4 bring-forward">
             <button type="button" class="btn btn-default dropdown-toggle pull-right"
                     data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <i class="fa fa-info-circle"></i> Privacy Disclaimer <span class="caret"></span>

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -1,9 +1,10 @@
 {% verbatim %}
 
 <nav>
-  <h3>
+  <h3 class="breadcrumbs">
     {% endverbatim %}
-    <h3><a href="{% url 'dashboard_account' %}">Admin Console</a> > <a href="#/">Find Course</a>
+    <a href="{% url 'dashboard_account' %}">Admin Console</a>
+    &gt; <a href="#/">Find Course Info</a>
     {% verbatim %}
     <small><i class="fa fa-chevron-right"></i></small>
     People in {{courseInstance.title}}


### PR DESCRIPTION
AC 1: not implemented (see comments in [ticket](https://jira.huit.harvard.edu/browse/TLT-2254))
AC 2: course info people results table has new menu for choosing table page size
AC 3: fixes padding on add people breadcrumbs with long course names
AC 4: course info remove people error message updates
AC 5: quick hack fix to ensure privacy button is still clickable at different screen sizes
AC 6: updated placeholder and label text for course_info people search form

Also includes a UI tweak that didn't make it into tlt-2350: course info box on people page now has the border we always wanted it to