### PR TITLE
Task/eparker71/tlt 2349 fix success and error messages stackup

### DIFF
--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -70,3 +70,7 @@ table.course-info-table {
     border: solid 1px #ccc;
     margin-top: 1em;
 }
+
+#success-partial-failure-text-id {
+    color: #ac2925;
+}

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -396,8 +396,9 @@
                     .error($scope.handleAjaxError);
             }
         };
-        /* this method clears all messages. This method is called before a new message
-         * is added to any of the message lists contained per TLT-2349
+        /* TLT-2349
+         * This method clears all messages. This method is called before a new message
+         * is added to any of the message lists contained 
          */
         $scope.clearAllMessages = function(){ 
             $scope.addWarnings = [];

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -44,7 +44,7 @@
                     .success(function(data, status, headers, config, statusText) {
                         data.results[0].searchTerm = searchTerm;
                         data.results[0].action = 'added to';
-
+                        $scope.clearMessages();
                         // if there was a partial error, specifically if there was
                         // an error adding the user to the Canvas course (we caught
                         // a Canvas API error). The user has been added to the

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -452,8 +452,12 @@
         };
 
         $scope.clearMessages = function(){
-
-        }
+            $scope.partialFailureData = null;
+            $scope.addPartialFailure = null;
+            $scope.removeFailure = null;
+            $scope.addWarning = null;
+            $scope.success = null;
+        };
 
         // now actually init the controller
         $scope.addPartialFailure = null;

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -44,6 +44,7 @@
                     .success(function(data, status, headers, config, statusText) {
                         data.results[0].searchTerm = searchTerm;
                         data.results[0].action = 'added to';
+                        $scope.clearAllMessages();
                         $scope.successes.push(data.results[0]);
                         $scope.dtInstance.reloadData();
                     })
@@ -51,6 +52,7 @@
                         // log it, then display a warning
                         $scope.handleAjaxError(data, status, headers, config,
                                 statusText);
+                        $scope.clearAllMessages();
                         $scope.addPartialFailures.push({
                             searchTerm: searchTerm,
                             text: 'Add to course seemed to succeed, but ' +
@@ -73,6 +75,7 @@
                             (data.detail.indexOf('Canvas API error details') != -1)) {
                         // partial success, where we enrolled in the coursemanager
                         // db, but got an error trying to enroll in canvas
+                        $scope.clearAllMessages();
                         $scope.addPartialFailures.push({
                             searchTerm: searchTerm,
                             text: data.detail,
@@ -80,6 +83,7 @@
                         handlePostSuccess();
                     }
                     else {
+                        $scope.clearAllMessages();
                         $scope.addWarnings.push({
                             type: 'addFailed',
                             searchTerm: searchTerm,
@@ -200,7 +204,8 @@
             // if the user is already in the course, show their current enrollment
             if (memberResult.data.results.length > 0) {
                 // just pick the first one to find the name
-                var profile = memberResult.data.results[0].profile
+                var profile = memberResult.data.results[0].profile;
+                $scope.clearAllMessages();
                 $scope.addWarnings.push({
                     type: 'alreadyInCourse',
                     fullName: profile.name_last + ', ' + profile.name_first,
@@ -214,6 +219,7 @@
                                           peopleResult.data.results);
                 if (filteredResults.length == 0) {
                     // didn't find any people for the search term
+                    $scope.clearAllMessages();
                     $scope.addWarnings.push({
                         type: 'notFound',
                         searchTerm: peopleResult.config.searchTerm,
@@ -296,6 +302,7 @@
                     success.searchTerm = membership.profile.name_last +
                                          ', ' + membership.profile.name_first;
                     success.action = 'removed from';
+                    $scope.clearAllMessages();
                     $scope.successes.push(success);
                     $scope.dtInstance.reloadData()
                 })
@@ -334,6 +341,7 @@
                             failure.type = 'unknown';
                             break;
                     }
+                    $scope.clearAllMessages();
                     $scope.removeFailures.push(failure);
                     if (reloadData) {
                         $scope.dtInstance.reloadData();
@@ -388,6 +396,15 @@
                     .error($scope.handleAjaxError);
             }
         };
+        /* this method clears all messages. This method is called before a new message
+         * is added to any of the message lists contained per TLT-2349
+         */
+        $scope.clearAllMessages = function(){ 
+            $scope.addWarnings = [];
+            $scope.successes = []; 
+            $scope.addPartialFailures = [];
+            $scope.removeFailures = []; 
+        }; 
 
         // now actually init the controller
         $scope.addPartialFailures = [];

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -44,21 +44,21 @@
                     .success(function(data, status, headers, config, statusText) {
                         data.results[0].searchTerm = searchTerm;
                         data.results[0].action = 'added to';
-                        $scope.clearAllMessages();
-                        $scope.successes.push(data.results[0]);
+                        $scope.success = null;
+                        $scope.success = data.results[0];
                         $scope.dtInstance.reloadData();
                     })
                     .error(function(data, status, headers, config, statusText) {
                         // log it, then display a warning
                         $scope.handleAjaxError(data, status, headers, config,
                                 statusText);
-                        $scope.clearAllMessages();
-                        $scope.addPartialFailures.push({
+                        $scope.partialFailure = null;
+                        $scope.partialFailure = {
                             searchTerm: searchTerm,
                             text: 'Add to course seemed to succeed, but ' +
                                 'we received an error trying to retrieve ' +
                                 "the user's course details.",
-                        });
+                        };
                     })
                     .finally(function(){
                         $scope.clearSearchResults();
@@ -75,19 +75,19 @@
                             (data.detail.indexOf('Canvas API error details') != -1)) {
                         // partial success, where we enrolled in the coursemanager
                         // db, but got an error trying to enroll in canvas
-                        $scope.clearAllMessages();
-                        $scope.addPartialFailures.push({
+                        $scope.partialFailure = null;
+                        $scope.partialFailure = {
                             searchTerm: searchTerm,
                             text: data.detail,
-                        });
+                        };
                         handlePostSuccess();
                     }
                     else {
-                        $scope.clearAllMessages();
-                        $scope.addWarnings.push({
+                        $scope.addWarning = null;
+                        $scope.addWarning = {
                             type: 'addFailed',
                             searchTerm: searchTerm,
-                        });
+                        };
                         $scope.clearSearchResults();
                         $scope.searchInProgress = false;
                     }
@@ -96,8 +96,8 @@
         $scope.clearSearchResults = function() {
             $scope.searchResults = [];
         };
-        $scope.closeAlert = function(source, index) {
-            $scope[source].splice(index, 1);
+        $scope.closeAlert = function(source) {
+            $scope[source] = null;
         };
         $scope.compareRoles = function(a, b) {
             /*
@@ -205,13 +205,13 @@
             if (memberResult.data.results.length > 0) {
                 // just pick the first one to find the name
                 var profile = memberResult.data.results[0].profile;
-                $scope.clearAllMessages();
-                $scope.addWarnings.push({
+                $scope.addWarning = null;
+                $scope.addWarning = {
                     type: 'alreadyInCourse',
                     fullName: profile.name_last + ', ' + profile.name_first,
                     memberships: memberResult.data.results,
                     searchTerm: memberResult.config.searchTerm,
-                });
+                };
                 $scope.searchInProgress = false;
             }
             else {
@@ -219,11 +219,11 @@
                                           peopleResult.data.results);
                 if (filteredResults.length == 0) {
                     // didn't find any people for the search term
-                    $scope.clearAllMessages();
-                    $scope.addWarnings.push({
+                    $scope.addWarning = null;
+                    $scope.addWarning = {
                         type: 'notFound',
                         searchTerm: peopleResult.config.searchTerm,
-                    });
+                    };
                     $scope.searchInProgress = false;
                 }
                 else if (filteredResults.length == 1) {
@@ -302,8 +302,8 @@
                     success.searchTerm = membership.profile.name_last +
                                          ', ' + membership.profile.name_first;
                     success.action = 'removed from';
-                    $scope.clearAllMessages();
-                    $scope.successes.push(success);
+                    $scope.success = null;
+                    $scope.success = success;
                     $scope.dtInstance.reloadData()
                 })
                 .error(function(data, status, headers, config, statusText) {
@@ -341,8 +341,8 @@
                             failure.type = 'unknown';
                             break;
                     }
-                    $scope.clearAllMessages();
-                    $scope.removeFailures.push(failure);
+                    $scope.removeFailure = null;
+                    $scope.removeFailure = failure;
                     if (reloadData) {
                         $scope.dtInstance.reloadData();
                     }
@@ -396,23 +396,15 @@
                     .error($scope.handleAjaxError);
             }
         };
-        /* TLT-2349
-         * This method clears all messages. This method is called before a new message
-         * is added to any of the message lists contained 
-         */
-        $scope.clearAllMessages = function(){ 
-            $scope.addWarnings = [];
-            $scope.successes = []; 
-            $scope.addPartialFailures = [];
-            $scope.removeFailures = []; 
-        }; 
 
         // now actually init the controller
-        $scope.addPartialFailures = [];
-        $scope.addWarnings = [];
+        $scope.partialFailure = null;
+        $scope.addWarning = null;
+        $scope.success = null;
+        $scope.removeFailure = null;
+
         $scope.confirmRemoveModalInstance = null;
         $scope.courseInstanceId = $routeParams.courseInstanceId;
-        $scope.removeFailures = [];
         $scope.roles = [
             // NOTE - these may need to be updated based on the db values
             {roleId: 0, roleName: 'Student'},
@@ -433,7 +425,7 @@
         $scope.selectedResult = {id: undefined};
         $scope.selectedRole = $scope.roles[0];
         $scope.setTitle($routeParams.courseInstanceId);
-        $scope.successes = [];
+
 
         // configure the datatable
         $scope.dtInstance = null;

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -74,15 +74,16 @@
         </div>
 
         <!-- begin add warning alerts -->
-        <uib-alert ng-repeat="warning in addWarnings" type="warning"
-                   close="closeAlert('addWarnings', $index)" class="col-md-12">
-          <div ng-switch on="warning.type">
+        <uib-alert ng-if="addWarning" type="warning"
+                   close="closeAlert('addWarning')" class="col-md-12">
+
+          <div ng-switch on="addWarning.type">
             <!-- user was already enrolled -->
             <div ng-switch-when="alreadyInCourse">
-              <p><strong>{{ warning.searchTerm }}</strong> was found in the course:</p>
-              <p>{{ warning.fullName }} has the following email/id and role associated with this course:</p>
-              <div ng-repeat="membership in warning.memberships" class="course-membership-entry">
-                {{ warning.fullName }}
+              <p><strong>{{ addWarning.searchTerm }}</strong> was found in the course:</p>
+              <p>{{ addWarning.fullName }} has the following email/id and role associated with this course:</p>
+              <div ng-repeat="membership in addWarning.memberships" class="course-membership-entry">
+                {{ addWarning.fullName }}
                 <badge role="{{ membership.profile.role_type_cd }}"></badge> {{ membership.user_id }}
                 <strong>Enrolled as {{ membership.role.role_name }}</strong>
               </div>
@@ -90,17 +91,18 @@
 
             <!-- search term didn't find a user -->
             <div ng-switch-when="notFound">
-              <p>{{ warning.searchTerm }} was not found. Please check the email
+              <p>{{ addWarning.searchTerm }} was not found. Please check the email
               or Harvard University ID and try again.</p>
             </div>
 
             <!-- server error when attempting to add the user -->
             <div ng-switch-when="addFailed">
-              <p><strong>{{ warning.searchTerm }}</strong> could not be added to
+              <p><strong>{{ addWarning.searchTerm }}</strong> could not be added to
               this course at this time.</p>
               <p>Please try again.</p>
             </div>
           </div>
+
         </uib-alert>
         <!-- end add warning alerts -->
 
@@ -185,58 +187,58 @@
   <!-- end add person expand-o-widget -->
 
   <!-- begin success alerts -->
-  <uib-alert ng-repeat="person in successes" type="success"
-             close="closeAlert('successes', $index)" class="col-md-12">
-    <p><strong>{{ person.searchTerm }}</strong> was just {{ person.action }} this course:</p>
+  <uib-alert ng-if="success" type="success"
+             close="closeAlert('success')" class="col-md-12">
+    <p><strong>{{ success.searchTerm }}</strong> was just {{ success.action }} this course:</p>
     <div class="course-membership-entry">
-      {{ person.profile.name_last }}, {{ person.profile.name_first }}
-      <badge role="{{ person.profile.role_type_cd }}"></badge> {{ person.profile.univ_id }}
-      <strong>Enrolled as {{ person.role.role_name }}</strong>
+      {{ success.profile.name_last }}, {{ success.profile.name_first }}
+      <badge role="{{ success.profile.role_type_cd }}"></badge> {{ success.profile.univ_id }}
+      <strong>Enrolled as {{ success.role.role_name }}</strong>
     </div>
   </uib-alert>
   <!-- end success alerts -->
 
   <!-- begin add partial failure warning alerts -->
-  <uib-alert ng-repeat="partial in addPartialFailures" type="warning"
-             close="closeAlert('addPartialFailures', $index)" class="col-md-12">
-    <p>While adding <strong>{{ partial.searchTerm }}</strong> to this course:</p>
-    <p>{{ partial.text }}</p>
+  <uib-alert ng-if="partialFailure" type="warning"
+             close="closeAlert('partialFailure')" class="col-md-12">
+    <p>While adding <strong>{{ partialFailure.searchTerm }}</strong> to this course:</p>
+    <p>{{ partialFailure.text }}</p>
   </uib-alert>
   <!-- end add partial failure warning alerts -->
 
   <!-- begin remove failure warning alerts -->
-  <uib-alert ng-repeat="failure in removeFailures" type="warning"
-             close="closeAlert('removeFailures', $index)" class="col-md-12">
+  <uib-alert ng-if="removeFailure" type="warning"
+             close="closeAlert('removeFailure')" class="col-md-12">
     <div ng-switch on="failure.type">
       <div ng-switch-when="noSuchUser">
-        <strong>{{ failure.profile.name_last }}, {{ failure.profile.name_first }}</strong>
+        <strong>{{ removeFailure.profile.name_last }}, {{ removeFailure.profile.name_first }}</strong>
         has already been removed from this course.
       </div>
       <div ng-switch-when="noSuchCourse">
-        <strong>{{ failure.profile.name_last }}, {{ failure.profile.name_first }}</strong>
+        <strong>{{ removeFailure.profile.name_last }}, {{ removeFailure.profile.name_first }}</strong>
         cannot be removed from this course because it no longer exists.
       </div>
       <div ng-switch-when="serverError">
-        There was a problem removing <strong>{{ failure.profile.name_last }},
-          {{ failure.profile.name_first }}</strong> from the database.  Please
+        There was a problem removing <strong>{{ removeFailure.profile.name_last }},
+          {{ removeFailure.profile.name_first }}</strong> from the database.  Please
         try again.  If the error persists, please contact your local school
         support staff.
       </div>
       <div ng-switch-when="canvasError">
-        There was a problem removing <strong>{{ failure.profile.name_last }},
-          {{ failure.profile.name_first }}</strong> from the Canvas site.  If the
+        There was a problem removing <strong>{{ removeFailure.profile.name_last }},
+          {{ removeFailure.profile.name_first }}</strong> from the Canvas site.  If the
         error persists, please contact your local school support staff.
       </div>
       <div ng-switch-default>
-        There was a problem removing <strong>{{ failure.profile.name_last }},
-          {{ failure.profile.name_first }}</strong>.  Please try again.  If the
+        There was a problem removing <strong>{{ removeFailure.profile.name_last }},
+          {{ removeFailure.profile.name_first }}</strong>.  Please try again.  If the
         error persists, please contact your local school support staff.
       </div>
     </div>
     <div class="course-membership-entry">
-      {{ failure.profile.name_last }}, {{ failure.profile.name_first }}
-      <badge role="{{ failure.profile.role_type_cd }}"></badge> {{ failure.profile.univ_id }}
-      <strong>Enrolled as {{ failure.role.role_name }}</strong>
+      {{ removeFailure.profile.name_last }}, {{ removeFailure.profile.name_first }}
+      <badge role="{{ removeFailure.profile.role_type_cd }}"></badge> {{ removeFailure.profile.univ_id }}
+      <strong>Enrolled as {{ removeFailure.role.role_name }}</strong>
     </div>
   </uib-alert>
   <!-- end remove failure warning alerts -->

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -100,15 +100,15 @@
         </div>
 
         <!-- begin add warning alerts -->
-        <uib-alert ng-repeat="warning in addWarnings" type="warning"
-                   close="closeAlert('addWarnings', $index)" class="col-md-12">
-          <div ng-switch on="warning.type">
+        <uib-alert ng-if="addWarning" type="warning"
+                   close="closeAlert('addWarning')" class="col-md-12">
+          <div ng-switch on="addWarning.type">
             <!-- user was already enrolled -->
             <div ng-switch-when="alreadyInCourse">
-              <p><strong>{{ warning.searchTerm }}</strong> was found in the course:</p>
-              <p>{{ warning.fullName }} has the following email/id and role associated with this course:</p>
-              <div ng-repeat="membership in warning.memberships" class="course-membership-entry">
-                {{ warning.fullName }}
+              <p><strong>{{ addWarning.searchTerm }}</strong> was found in the course:</p>
+              <p>{{ addWarning.fullName }} has the following email/id and role associated with this course:</p>
+              <div ng-repeat="membership in addWarning.memberships" class="course-membership-entry">
+                {{ addWarning.fullName }}
                 <badge role="{{ membership.profile.role_type_cd }}"></badge> {{ membership.user_id }}
                 <strong>Enrolled as {{ membership.role.role_name }}</strong>
               </div>
@@ -116,13 +116,13 @@
 
             <!-- search term didn't find a user -->
             <div ng-switch-when="notFound">
-              <p>{{ warning.searchTerm }} was not found. Please check the email
+              <p>{{ addWarning.searchTerm }} was not found. Please check the email
               or Harvard University ID and try again.</p>
             </div>
 
             <!-- server error when attempting to add the user -->
             <div ng-switch-when="addFailed">
-              <p><strong>{{ warning.searchTerm }}</strong> could not be added to
+              <p><strong>{{ addWarning.searchTerm }}</strong> could not be added to
               this course at this time.</p>
               <p>Please try again.</p>
             </div>
@@ -211,56 +211,65 @@
   <!-- end add person expand-o-widget -->
 
   <!-- begin success alerts -->
-  <uib-alert ng-repeat="person in successes" type="success"
-             close="closeAlert('successes', $index)" class="col-md-12">
-    <p><strong>{{ person.searchTerm }}</strong> was just {{ person.action }} this course:</p>
+  <uib-alert ng-if="success" type="success"
+             close="closeAlert('success')" class="col-md-12">
+    <p><strong>{{ success.searchTerm }}</strong> was just {{ success.action }} this course:</p>
     <div class="course-membership-entry">
-      {{ person.profile.name_last }}, {{ person.profile.name_first }}
-      <badge role="{{ person.profile.role_type_cd }}"></badge> {{ person.profile.univ_id }}
-      <strong>Enrolled as {{ person.role.role_name }}</strong>
+      {{ success.profile.name_last }}, {{ success.profile.name_first }}
+      <badge role="{{ success.profile.role_type_cd }}"></badge> {{ success.profile.univ_id }}
+      <strong>Enrolled as {{ success.role.role_name }}</strong>
     </div>
+
+    <div id="success-partial-failure-text-id" ng-if="success.partialFailureData" type="warning">
+        An partial error occured while adding <strong>{{ success.partialFailureData.searchTerm }}</strong> to this course.
+        It's possible that this error will be corrected when the next Canvas sync occurs, check back in 5 minutes.
+        if <strong>{{ success.partialFailureData.searchTerm }}</strong> is still not in the course, please contact Canvas support.
+        <span class="hidden">{{ success.partialFailureData.text }}</span>
+    </div>
+
+
   </uib-alert>
   <!-- end success alerts -->
 
   <!-- begin add partial failure warning alerts -->
-  <uib-alert ng-repeat="partial in addPartialFailures" type="warning"
-             close="closeAlert('addPartialFailures', $index)" class="col-md-12">
-    <p>While adding <strong>{{ partial.searchTerm }}</strong> to this course:</p>
-    <p>{{ partial.text }}</p>
+  <uib-alert ng-if="addPartialFailure" type="warning"
+             close="closeAlert('addPartialFailure')" class="col-md-12">
+    <p>While adding <strong>{{ addPartialFailure.searchTerm }}</strong> to this course:</p>
+    <p>{{ addPartialFailure.text }}</p>
   </uib-alert>
   <!-- end add partial failure warning alerts -->
 
   <!-- begin remove failure warning alerts -->
-  <uib-alert ng-repeat="failure in removeFailures" type="warning"
-             close="closeAlert('removeFailures', $index)" class="col-md-12">
+  <uib-alert ng-if="removeFailure" type="warning"
+             close="closeAlert('removeFailure')" class="col-md-12">
     <div ng-switch on="failure.type">
       <div ng-switch-when="noSuchUser">
-        <strong>{{ failure.profile.name_last }}, {{ failure.profile.name_first }}</strong>
+        <strong>{{ removeFailure.profile.name_last }}, {{ removeFailure.profile.name_first }}</strong>
         has already been removed from this course.
       </div>
       <div ng-switch-when="noSuchCourse">
-        <strong>{{ failure.profile.name_last }}, {{ failure.profile.name_first }}</strong>
+        <strong>{{ removeFailure.profile.name_last }}, {{ removeFailure.profile.name_first }}</strong>
         cannot be removed from this course because it no longer exists.
       </div>
       <div ng-switch-when="serverError">
-        There was a problem removing <strong>{{ failure.profile.name_last }},
-        {{ failure.profile.name_first }}</strong> from the database. Please
+        There was a problem removing <strong>{{ removeFailure.profile.name_last }},
+        {{ removeFailure.profile.name_first }}</strong> from the database. Please
         try again.
       </div>
       <div ng-switch-when="canvasError">
-        There was a problem removing <strong>{{ failure.profile.name_last }},
-        {{ failure.profile.name_first }}</strong> from the Canvas site. Please
+        There was a problem removing <strong>{{ removeFailure.profile.name_last }},
+        {{ removeFailure.profile.name_first }}</strong> from the Canvas site. Please
         try again.
       </div>
       <div ng-switch-default>
-        There was a problem removing <strong>{{ failure.profile.name_last }},
-        {{ failure.profile.name_first }}</strong>. Please try again.
+        There was a problem removing <strong>{{ removeFailure.profile.name_last }},
+        {{ removeFailure.profile.name_first }}</strong>. Please try again.
       </div>
     </div>
     <div class="course-membership-entry">
-      {{ failure.profile.name_last }}, {{ failure.profile.name_first }}
-      <badge role="{{ failure.profile.role_type_cd }}"></badge> {{ failure.profile.univ_id }}
-      <strong>Enrolled as {{ failure.role.role_name }}</strong>
+      {{ removeFailure.profile.name_last }}, {{ removeFailure.profile.name_first }}
+      <badge role="{{ removeFailure.profile.role_type_cd }}"></badge> {{ removeFailure.profile.univ_id }}
+      <strong>Enrolled as {{ removeFailure.role.role_name }}</strong>
     </div>
   </uib-alert>
   <!-- end remove failure warning alerts -->

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -73,6 +73,7 @@
           to find someone's official email address.
         </div>
 
+
         <!-- begin add warning alerts -->
         <uib-alert ng-if="addWarning" type="warning"
                    close="closeAlert('addWarning')" class="col-md-12">
@@ -105,6 +106,7 @@
 
         </uib-alert>
         <!-- end add warning alerts -->
+
 
         <!-- begin choose between multiple search hits -->
         <div ng-show="searchResults.length > 1">
@@ -194,9 +196,16 @@
       {{ success.profile.name_last }}, {{ success.profile.name_first }}
       <badge role="{{ success.profile.role_type_cd }}"></badge> {{ success.profile.univ_id }}
       <strong>Enrolled as {{ success.role.role_name }}</strong>
+      <p ng-if="success.partialFailureSearchTerm">&nbsp;</p>
+      <uib-alert type="warning">
+        <p ng-if="success.partialFailureSearchTerm">while adding <strong>{{success.partialFailureSearchTerm}}
+        </strong>to this course:</p>
+        <p ng-if="success.partialFailureText">{{ success.partialFailureText }}</p>
+      </uib-alert>
     </div>
   </uib-alert>
   <!-- end success alerts -->
+
 
   <!-- begin add partial failure warning alerts -->
   <uib-alert ng-if="partialFailure" type="warning"
@@ -206,10 +215,11 @@
   </uib-alert>
   <!-- end add partial failure warning alerts -->
 
+
   <!-- begin remove failure warning alerts -->
   <uib-alert ng-if="removeFailure" type="warning"
              close="closeAlert('removeFailure')" class="col-md-12">
-    <div ng-switch on="failure.type">
+    <div ng-switch on="removeFailure.type">
       <div ng-switch-when="noSuchUser">
         <strong>{{ removeFailure.profile.name_last }}, {{ removeFailure.profile.name_first }}</strong>
         has already been removed from this course.

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -98,12 +98,12 @@ describe('Unit testing PeopleController', function() {
         });
 
         it('should have a bunch of non-null variables set up', function() {
-            ['dtColumns', 'dtOptions', 'addPartialFailures', 'roles',
+            ['dtColumns', 'dtOptions', 'partialFailure', 'roles',
              'searchInProgress', 'searchResults', 'searchTerm', 'selectedResult',
-             'selectedRole', 'successes', 'addWarnings'].forEach(function(scopeAttr) {
+             'selectedRole', 'success', 'addWarning'].forEach(function(scopeAttr) {
                 var thing = scope[scopeAttr];
                 expect(thing).not.toBeUndefined();
-                expect(thing).not.toBeNull();
+                //expect(thing).not.toBeNull();
             });
         });
     });
@@ -224,22 +224,17 @@ describe('Unit testing PeopleController', function() {
 
         describe('closeAlert', function() {
             it('should work when an alert is present', function() {
-                scope.testAlerts = [{}];  // contents don't matter
-                scope.closeAlert('testAlerts', 0);
-                expect(scope.testAlerts).toEqual([]);
+                scope.testAlerts = 'This is a test';  // contents don't matter
+                scope.closeAlert('testAlerts');
+                expect(scope.testAlerts).toBeNull();
             });
             
             it('should not blow up when no alert is present', function() {
-                scope.testAlerts = [];
-                scope.closeAlert('testAlerts', 0);
-                expect(scope.testAlerts).toEqual([]);
+                scope.testAlerts = null;
+                scope.closeAlert('testAlerts');
+                expect(scope.testAlerts).toBeNull();
             });
 
-            it('should only remove the index requested', function() {
-                scope.testAlerts = [1, 2, 3];
-                scope.closeAlert('testAlerts', 1);
-                expect(scope.testAlerts).toEqual([1,3]);
-            });
         });
 
         describe('compareRoles', function() {
@@ -480,7 +475,7 @@ describe('Unit testing PeopleController', function() {
             $httpBackend.flush(2);
 
             // check to see if it's reacting correctly
-            expect(scope.successes).toEqual([expectedSuccess]);
+            expect(scope.success).toEqual(expectedSuccess);
             expect(scope.dtInstance.reloadData.calls.count()).toEqual(1);
         });
 
@@ -513,8 +508,8 @@ describe('Unit testing PeopleController', function() {
                $httpBackend.flush(2);
 
                // check to see if it's reacting correctly
-               expect(scope.successes).toEqual([expectedSuccess]);
-               expect(scope.addPartialFailures).toEqual([expectedPartialFailure]);
+               expect(scope.success).toEqual(expectedSuccess);
+               expect(scope.partialFailure).toEqual(expectedPartialFailure);
                expect(scope.dtInstance.reloadData.calls.count()).toEqual(1);
            }
         );
@@ -528,8 +523,8 @@ describe('Unit testing PeopleController', function() {
             $httpBackend.flush(1);
 
             expect(scope.handleAjaxError.calls.count()).toEqual(1);
-            expect(scope.addWarnings).toEqual([{type: 'addFailed',
-                                             searchTerm: searchTerm}]);
+            expect(scope.addWarning).toEqual({type: 'addFailed',
+                                             searchTerm: searchTerm});
         });
 
         it('should handle a failure to get user enrollment after an apparent add success',
@@ -548,7 +543,7 @@ describe('Unit testing PeopleController', function() {
                $httpBackend.expectGET(enrollmentDetailsURL).respond(404, '');
                $httpBackend.flush(2);
 
-               expect(scope.addPartialFailures).toEqual([expectedPartialFailure]);
+               expect(scope.partialFailure).toEqual(expectedPartialFailure);
                expect(scope.handleAjaxError.calls.count()).toEqual(1);
            }
         );
@@ -584,7 +579,7 @@ describe('Unit testing PeopleController', function() {
                };
 
                scope.handleLookupResults([peopleResult, memberResult]);
-               expect(scope.addWarnings).toEqual([expectedWarning]);
+               expect(scope.addWarning).toEqual(expectedWarning);
                expect(scope.searchInProgress).toBe(false);
            }
         );
@@ -603,7 +598,7 @@ describe('Unit testing PeopleController', function() {
 
                scope.searchTerm = 'bob_dobbs@harvard.edu';
                scope.handleLookupResults([peopleResult, memberResult]);
-               expect(scope.addWarnings).toEqual([expectedWarning]);
+               expect(scope.addWarning).toEqual(expectedWarning);
                expect(scope.searchInProgress).toBe(false);
            }
         );
@@ -802,7 +797,7 @@ describe('Unit testing PeopleController', function() {
             $httpBackend.expectDELETE(courseMembershipURL).respond(204, '');
             $httpBackend.flush(1);
 
-            expect(scope.successes).toEqual([expectedSuccess]);
+            expect(scope.success).toEqual(expectedSuccess);
             expect(scope.dtInstance.reloadData).toHaveBeenCalled();
         });
 
@@ -815,7 +810,7 @@ describe('Unit testing PeopleController', function() {
                 .respond(404, '{"detail": "User not found."}');
             $httpBackend.flush(1);
 
-            expect(scope.removeFailures).toEqual([expectedFailure]);
+            expect(scope.removeFailure).toEqual(expectedFailure);
             expect(scope.dtInstance.reloadData).toHaveBeenCalled();
         });
 
@@ -828,7 +823,7 @@ describe('Unit testing PeopleController', function() {
                 .respond(404, '{"detail": "Course instance not found."}');
             $httpBackend.flush(1);
 
-            expect(scope.removeFailures).toEqual([expectedFailure]);
+            expect(scope.removeFailure).toEqual(expectedFailure);
             expect(scope.dtInstance.reloadData).not.toHaveBeenCalled();
         });
 
@@ -842,7 +837,7 @@ describe('Unit testing PeopleController', function() {
                 .respond(404, '{"detail": "Not even if you paid me"}');
             $httpBackend.flush(1);
 
-            expect(scope.removeFailures).toEqual([expectedFailure]);
+            expect(scope.removeFailure).toEqual(expectedFailure);
             expect(scope.dtInstance.reloadData).not.toHaveBeenCalled();
         });
 
@@ -855,7 +850,7 @@ describe('Unit testing PeopleController', function() {
                 .respond(500, '{"detail": "User could not be removed from Canvas."}');
             $httpBackend.flush(1);
 
-            expect(scope.removeFailures).toEqual([expectedFailure]);
+            expect(scope.removeFailure).toEqual(expectedFailure);
             expect(scope.dtInstance.reloadData).toHaveBeenCalled();
         });
 
@@ -868,7 +863,7 @@ describe('Unit testing PeopleController', function() {
                 .respond(500, '{"detail": "Nope."}');
             $httpBackend.flush(1);
 
-            expect(scope.removeFailures).toEqual([expectedFailure]);
+            expect(scope.removeFailure).toEqual(expectedFailure);
             expect(scope.dtInstance.reloadData).not.toHaveBeenCalled();
         });
 
@@ -881,7 +876,7 @@ describe('Unit testing PeopleController', function() {
                 .respond(418, "I'm a teapot!");
             $httpBackend.flush(1);
 
-            expect(scope.removeFailures).toEqual([expectedFailure]);
+            expect(scope.removeFailure).toEqual(expectedFailure);
             expect(scope.dtInstance.reloadData).not.toHaveBeenCalled();
         });
     });

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -97,13 +97,20 @@ describe('Unit testing PeopleController', function() {
             expect(scope.dtInstance).toBeNull();
         });
 
+        it('should set all message vars to null', function(){
+            ['success', 'addWarning',
+                'addPartialFailure', 'removeFailure'].forEach(function(scopeAttr) {
+                var thing = scope[scopeAttr];
+                expect(thing).toBeNull();
+            });
+        });
+
         it('should have a bunch of non-null variables set up', function() {
-            ['dtColumns', 'dtOptions', 'partialFailure', 'roles',
-             'searchInProgress', 'searchResults', 'searchTerm', 'selectedResult',
-             'selectedRole', 'success', 'addWarning'].forEach(function(scopeAttr) {
+            ['dtColumns', 'dtOptions', 'roles', 'searchInProgress',
+                'searchResults', 'searchTerm', 'selectedResult',
+                'selectedRole'].forEach(function(scopeAttr) {
                 var thing = scope[scopeAttr];
                 expect(thing).not.toBeUndefined();
-                //expect(thing).not.toBeNull();
             });
         });
     });
@@ -426,6 +433,23 @@ describe('Unit testing PeopleController', function() {
                 expect(scope.selectedRole).toEqual(role);
             });
         });
+
+        describe('clearMessages', function(){
+            it('should set all messages to null', function(){
+                scope.partialFailureData = 'data for partial failure';
+                scope.addPartialFailure = 'There has been a failure';
+                scope.addWarning = 'There has been an error';
+                scope.success = 'User added';
+                scope.removeFailure = 'Error removing user';
+
+                scope.clearMessages();
+                ['success', 'addWarning', 'addPartialFailure',
+                    'partialFailureData', 'removeFailure'].forEach(function(scopeAttr) {
+                    var thing = scope[scopeAttr];
+                    expect(thing).toBeNull();
+                });
+            });
+        });
     });
 
     describe('addUser', function() {
@@ -548,12 +572,14 @@ describe('Unit testing PeopleController', function() {
                };
                var expectedSuccess =
                    JSON.parse(JSON.stringify(enrollmentDetails.results[0]));
-               expectedSuccess.searchTerm = searchTerm;
-               expectedSuccess.action = 'added to';
-               var expectedPartialFailure = {
+
+               var partialFailureData = {
                    searchTerm: searchTerm,
                    text: partialFailureResponse.detail,
                };
+               expectedSuccess.searchTerm = searchTerm;
+               expectedSuccess.action = 'added to';
+               expectedSuccess.partialFailureData = partialFailureData;
 
                // mock out the datatable so we can verify that it gets reloaded
                scope.dtInstance = {reloadData: function(){}};
@@ -571,7 +597,7 @@ describe('Unit testing PeopleController', function() {
 
                // check to see if it's reacting correctly
                expect(scope.success).toEqual(expectedSuccess);
-               expect(scope.partialFailure).toEqual(expectedPartialFailure);
+               //expect(scope.addPartialFailure).toEqual(expectedPartialFailure);
                expect(scope.dtInstance.reloadData.calls.count()).toEqual(1);
            }
         );
@@ -605,7 +631,7 @@ describe('Unit testing PeopleController', function() {
                $httpBackend.expectGET(enrollmentDetailsURL).respond(404, '');
                $httpBackend.flush(2);
 
-               expect(scope.partialFailure).toEqual(expectedPartialFailure);
+               expect(scope.addPartialFailure).toEqual(expectedPartialFailure);
                expect(scope.handleAjaxError.calls.count()).toEqual(1);
            }
         );

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -597,7 +597,6 @@ describe('Unit testing PeopleController', function() {
 
                // check to see if it's reacting correctly
                expect(scope.success).toEqual(expectedSuccess);
-               //expect(scope.addPartialFailure).toEqual(expectedPartialFailure);
                expect(scope.dtInstance.reloadData.calls.count()).toEqual(1);
            }
         );


### PR DESCRIPTION
converted message list to scalars so they do not stack. In the case of a partial failure, specifically when the user was added to the course manager and not the Canvas course we used to specifically display two messages, a success and a warning. Now we display one message, a success, but we add the warning text to the success.

the warning text is temp text and will most likely change. Added CSS for the warning text in the success alert box.

fixed up unit tests after modifying the controller, also added a new test for the new controller method clearMessages. 