### PR TITLE
Task/eparker71/tlt 2349 fix success and error messages stackup

### DIFF
--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -457,7 +457,6 @@
         };
 
         $scope.clearMessages = function(){
-            //$scope.partialFailureData = null;
             $scope.addPartialFailure = null;
             $scope.removeFailure = null;
             $scope.addWarning = null;

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -37,6 +37,8 @@
             var url = djangoUrl.reverse('icommons_rest_api_proxy',
                                         ['api/course/v2/course_instances/'
                                          + $scope.courseInstanceId + '/people/']);
+            $scope.clearMessages();
+            $scope.partialFailureData = null;
 
             // called on actual post success, and on error-but-partial-success
             var handlePostSuccess = function() {
@@ -108,6 +110,9 @@
         };
         $scope.closeAlert = function(source) {
             $scope[source] = null;
+            if($scope.partialFailureData){
+                $scope.partialFailureData = null;
+            }
         };
         $scope.compareRoles = function(a, b) {
             /*
@@ -452,7 +457,7 @@
         };
 
         $scope.clearMessages = function(){
-            $scope.partialFailureData = null;
+            //$scope.partialFailureData = null;
             $scope.addPartialFailure = null;
             $scope.removeFailure = null;
             $scope.addWarning = null;

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -110,9 +110,7 @@
         };
         $scope.closeAlert = function(source) {
             $scope[source] = null;
-            if($scope.partialFailureData){
-                $scope.partialFailureData = null;
-            }
+            $scope.partialFailureData = null;
         };
         $scope.compareRoles = function(a, b) {
             /*

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -436,14 +436,13 @@ describe('Unit testing PeopleController', function() {
 
         describe('clearMessages', function(){
             it('should set all messages to null', function(){
-                scope.partialFailureData = 'data for partial failure';
                 scope.addPartialFailure = 'There has been a failure';
                 scope.addWarning = 'There has been an error';
                 scope.success = 'User added';
                 scope.removeFailure = 'Error removing user';
 
                 scope.clearMessages();
-                ['success', 'addWarning', 'addPartialFailure',
+                ['success', 'addWarning',
                     'partialFailureData', 'removeFailure'].forEach(function(scopeAttr) {
                     var thing = scope[scopeAttr];
                     expect(thing).toBeNull();


### PR DESCRIPTION
we need to call clear messages before success to make sure there are no other message boxs in the display but we dont' want to clear the partial failure data if it exists. 