### PR TITLE
Sprint 42 Fix jasmine testing under phantomjs

### DIFF
--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -149,7 +149,8 @@
 
             // this is a temp fix to change the display text of the role "Teaching Fellow" to "TA"
             // a more perm solution is being discussed, but will invlove talking to the schools.
-            if ( membership.role.role_name == "Teaching Fellow") {
+            if (membership && membership.role &&
+                    membership.role.role_name == "Teaching Fellow") {
                 membership.role.role_name = "TA";
             }
 
@@ -220,7 +221,9 @@
 
             // this is a temp fix to change the display text of the role "Teaching Fellow" to "TA"
             // a more perm solution is being discussed, but will invlove talking to the schools.
-            if ( memberResult.data.results.length > 0 && memberResult.data.results[0].role.role_name == "Teaching Fellow") {
+            if (memberResult.data.results.length > 0 &&
+                    memberResult.data.results[0].role &&
+                    memberResult.data.results[0].role.role_name == "Teaching Fellow") {
                 memberResult.data.results[0].role.role_name = "TA";
             }
 

--- a/course_info/tests/libraries/polyfill.js
+++ b/course_info/tests/libraries/polyfill.js
@@ -1,0 +1,9 @@
+(function(){
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#Polyfill
+    if (!String.prototype.startsWith) {
+        String.prototype.startsWith = function(searchString, position){
+            position = position || 0;
+            return this.substr(position, searchString.length) === searchString;
+        };
+    }
+})();

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -61,9 +61,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    // NOTE: reenable PhantomJS once we've resolved its issue.  passes in chrome/ff.
-    //browsers: ['PhantomJS'],
-    browsers: [],
+    browsers: ['PhantomJS'],
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -10,13 +10,12 @@
     "angular-ui-bootstrap": "^0.14.3",
     "datatables.net": "^1.10.9",
     "datatables.net-bs": "^1.10.9",
-    "jasmine-core": "~2.3",
+    "jasmine-core": "^2.4.1",
     "jquery": "^2.1.4",
-    "karma": "~0.13",
-    "karma-jasmine": "~0.3.6",
+    "karma": "^0.13.21",
+    "karma-jasmine": "^0.3.7",
     "karma-jasmine-jquery": "^0.1.1",
-    "karma-phantomjs-launcher": "~0.2",
-    "phantomjs": "^1.9.18",
-    "phantomjs-bin": "^1.0.1"
+    "karma-phantomjs-launcher": "^1.0.0",
+    "phantomjs-prebuilt": "^2.1.4"
   }
 }


### PR DESCRIPTION
The issue turned out to be PhantomJS's `String.prototype` missing `startsWith()`.  I've added a new `polyfill.js` under `course_info/tests/libraries`, which will only be pulled in during jasmine testing, let's please confine polyfills needed for testing to that file.

Once that was fixed, I discovered the unit tests were blowing up our `s/Teaching Fellow/TA/` cosmetic change, since it assumed a field existed that didn't when run under unit test.  Fixed that as well.