### PR TITLE
Sprint 43: tlt-2449: fixes issues handling course members without profile entries

### DIFF
--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -211,6 +211,20 @@
             // return the filtered list
             return filteredResults;
         };
+        $scope.getProfileFullName = function(profile) {
+            if (profile) {
+                return profile.name_last + ', ' + profile.name_first;
+            } else {
+                return '';
+            }
+        };
+        $scope.getProfileRoleTypeCd = function (profile) {
+            if (profile) {
+                return profile.role_type_cd;
+            } else {
+                return '';
+            }
+        };
         $scope.handleAjaxError = function(data, status, headers, config, statusText) {
             $log.error('Error attempting to ' + config.method + ' ' + config.url +
                        ': ' + status + ' ' + statusText + ': ' + JSON.stringify(data));
@@ -244,7 +258,7 @@
                 $scope.clearMessages();
                 $scope.addWarning = {
                     type: 'alreadyInCourse',
-                    fullName: profile.name_last + ', ' + profile.name_first,
+                    fullName: $scope.getProfileFullName(profile),
                     memberships: memberResult.data.results,
                     searchTerm: memberResult.config.searchTerm,
                 };
@@ -335,8 +349,8 @@
             $http.delete(courseMemberURL, config)
                 .success(function(data, status, headers, config, statusText) {
                     var success = membership; // TODO - copy to avoid stomping the original?
-                    success.searchTerm = membership.profile.name_last +
-                                         ', ' + membership.profile.name_first;
+                    success.searchTerm = $scope.getProfileFullName(membership.profile)
+                        || membership.user_id;
                     success.action = 'removed from';
                     $scope.clearMessages();
                     $scope.success = success;
@@ -385,11 +399,16 @@
                 });
         };
         $scope.renderId = function(data, type, full, meta) {
-            return '<badge ng-cloak role="' + full.profile.role_type_cd 
-                   + '"></badge> ' + full.user_id;
+            if (full.profile) {
+                return '<badge ng-cloak role="'
+                    + $scope.getProfileRoleTypeCd(full.profile)
+                    + '"></badge> ' + full.user_id;
+            } else {
+                return '<badge ng-cloak role=""></badge> ' + full.user_id;
+            }
         };
         $scope.renderName = function(data, type, full, meta) {
-            return full.profile.name_last + ', ' + full.profile.name_first;
+            return $scope.getProfileFullName(full.profile) || full.user_id;
         };
         // hotfix added to address TA role name
         // will be addressed with a database change as soon as

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -102,14 +102,21 @@
         <!-- begin add warning alerts -->
         <uib-alert ng-if="addWarning" type="warning"
                    close="closeAlert('addWarning')" class="col-md-12">
-          <div ng-switch on="addWarning.type">
+          <div ng-switch="addWarning.type">
             <!-- user was already enrolled -->
             <div ng-switch-when="alreadyInCourse">
-              <p><strong>{{ addWarning.searchTerm }}</strong> was found in the course:</p>
-              <p>{{ addWarning.fullName }} has the following email/id and role associated with this course:</p>
-              <div ng-repeat="membership in addWarning.memberships" class="course-membership-entry">
+              <p>
+                <strong>{{ addWarning.searchTerm }}</strong> was found in
+                the course:
+              </p>
+              <p>{{ addWarning.fullName || addWarning.searchTerm}} has the
+                following email/id and role associated with this course:
+              </p>
+              <div ng-repeat="membership in addWarning.memberships"
+                   class="course-membership-entry">
                 {{ addWarning.fullName }}
-                <badge role="{{ membership.profile.role_type_cd }}"></badge> {{ membership.user_id }}
+                <badge role="{{ getProfileRoleTypeCd(membership.profile) }}">
+                </badge> {{ membership.user_id }}
                 <strong>Enrolled as {{ membership.role.role_name }}</strong>
               </div>
             </div>
@@ -215,8 +222,8 @@
              close="closeAlert('success')" class="col-md-12">
     <p><strong>{{ success.searchTerm }}</strong> was just {{ success.action }} this course:</p>
     <div class="course-membership-entry">
-      {{ success.profile.name_last }}, {{ success.profile.name_first }}
-      <badge role="{{ success.profile.role_type_cd }}"></badge> {{ success.profile.univ_id }}
+      {{ getFullName(success.profile) }}
+      <badge role="{{ getProfileRoleTypeCd(success.profile) }}"></badge> {{ success.user_id }}
       <strong>Enrolled as {{ success.role.role_name }}</strong>
     </div>
 
@@ -242,33 +249,35 @@
   <!-- begin remove failure warning alerts -->
   <uib-alert ng-if="removeFailure" type="warning"
              close="closeAlert('removeFailure')" class="col-md-12">
-    <div ng-switch on="failure.type">
+    <div ng-switch="removeFailure.type">
       <div ng-switch-when="noSuchUser">
-        <strong>{{ removeFailure.profile.name_last }}, {{ removeFailure.profile.name_first }}</strong>
+        <strong>{{ getProfileFullName(removeFailure.profile) || removeFailure.user_id }}</strong>
         has already been removed from this course.
       </div>
       <div ng-switch-when="noSuchCourse">
-        <strong>{{ removeFailure.profile.name_last }}, {{ removeFailure.profile.name_first }}</strong>
+        <strong>{{ getProfileFullName(removeFailure.profile) || removeFailure.user_id }}</strong>
         cannot be removed from this course because it no longer exists.
       </div>
       <div ng-switch-when="serverError">
-        There was a problem removing <strong>{{ removeFailure.profile.name_last }},
-        {{ removeFailure.profile.name_first }}</strong> from the database. Please
-        try again.
+        There was a problem removing
+        <strong>{{ getProfileFullName(removeFailure.profile) || removeFailure.user_id }}</strong>
+        from the database. Please try again.
       </div>
       <div ng-switch-when="canvasError">
-        There was a problem removing <strong>{{ removeFailure.profile.name_last }},
-        {{ removeFailure.profile.name_first }}</strong> from the Canvas site. Please
-        try again.
+        There was a problem removing
+        <strong>{{ getProfileFullName(removeFailure.profile) || removeFailure.user_id }}</strong>
+        from the Canvas site. Please try again.
       </div>
       <div ng-switch-default>
-        There was a problem removing <strong>{{ removeFailure.profile.name_last }},
-        {{ removeFailure.profile.name_first }}</strong>. Please try again.
+        There was a problem removing
+        <strong>{{ getProfileFullName(removeFailure.profile) || removeFailure.user_id }}</strong>.
+        Please try again.
       </div>
     </div>
     <div class="course-membership-entry">
-      {{ removeFailure.profile.name_last }}, {{ removeFailure.profile.name_first }}
-      <badge role="{{ removeFailure.profile.role_type_cd }}"></badge> {{ removeFailure.profile.univ_id }}
+      {{ getProfileFullName(removeFailure.profile) }}
+      <badge role="{{ getProfileRoleTypeCd(removeFailure.profile) }}">
+      </badge> {{ removeFailure.user_id }}
       <strong>Enrolled as {{ removeFailure.role.role_name }}</strong>
     </div>
   </uib-alert>

--- a/course_info/templates/course_info/partials/remove-course-membership-confirmation.html
+++ b/course_info/templates/course_info/partials/remove-course-membership-confirmation.html
@@ -9,8 +9,9 @@
 <div class="modal-body">
   <p>Are you sure you want to remove</p>
   <div class="course-membership-entry">
-    {{ membership.profile.name_last }}, {{ membership.profile.name_first }}
-    <badge role="{{ membership.profile.role_type_cd }}"></badge> {{ membership.profile.univ_id }}
+    {{ getProfileFullName(membership.profile) }}
+    <badge role="{{ getProfileRoleTypeCd(membership.profile) }}">
+    </badge> {{ membership.user_id }}
     <strong>Enrolled as {{ membership.role.role_name }}</strong>
   </div>
   <p>from this course?</p>


### PR DESCRIPTION
- display names are set to the user_id or the search term, as appropriate, where full name is not available from the profile, or blank if duplication would look awkward
- badges fixed to handle missing profile
- ng-switch fixed so that alerts are being displayed properly

plus some refactoring, apologies for the mess.