### PR TITLE
course info add people: fixes issue where some valid email addresses …

### DIFF
--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -287,21 +287,25 @@
                 }
             }
         };
-        $scope.isEmailAddress = function(searchTerm) {
-            // TODO - better regex
-            var re = /^\s*\w+@\w+(\.\w+)+\s*$/;
+        $scope.isHUID = function(searchTerm) {
+            var re = /^[A-Za-z0-9]{8}$/;
             return re.test(searchTerm);
         };
         $scope.lookup = function(searchTerm) {
+            var peopleParams = {page_size: 100};
+            var memberParams = {page_size: 100};
+
+            if ($scope.isHUID(searchTerm)) {
+                peopleParams.univ_id = searchTerm;
+                memberParams.user_id = searchTerm;
+            } else {
+                peopleParams.email_address = searchTerm;
+                memberParams['profile.email_address'] = searchTerm;
+            }
+
             // first the general people lookup
             var peopleURL = djangoUrl.reverse('icommons_rest_api_proxy',
                                               ['api/course/v2/people/']);
-            var peopleParams = {page_size: 100};
-            if ($scope.isEmailAddress(searchTerm)) {
-                peopleParams.email_address = searchTerm;
-            } else {
-                peopleParams.univ_id = searchTerm;
-            }
             var peoplePromise = $http.get(peopleURL, {params: peopleParams,
                                                       searchTerm: searchTerm})
                                      .error($scope.handleAjaxError);
@@ -311,15 +315,6 @@
                                               ['api/course/v2/course_instances/'
                                                + $scope.courseInstanceId
                                                + '/people/']);
-
-
-            var memberParams = {page_size: 100};
-            if ($scope.isEmailAddress(searchTerm)) {
-                memberParams['profile.email_address'] = searchTerm;
-            } else {
-                memberParams.user_id = searchTerm;
-            }
-
             var memberPromise = $http.get(memberURL, {params: memberParams,
                                                       searchTerm: searchTerm})
                                      .error($scope.handleAjaxError);

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -287,7 +287,7 @@
                 }
             }
         };
-        $scope.isHUID = function(searchTerm) {
+        $scope.isUnivID = function(searchTerm) {
             var re = /^[A-Za-z0-9]{8}$/;
             return re.test(searchTerm);
         };
@@ -295,7 +295,7 @@
             var peopleParams = {page_size: 100};
             var memberParams = {page_size: 100};
 
-            if ($scope.isHUID(searchTerm)) {
+            if ($scope.isUnivID(searchTerm)) {
                 peopleParams.univ_id = searchTerm;
                 memberParams.user_id = searchTerm;
             } else {

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -403,25 +403,24 @@ describe('Unit testing PeopleController', function() {
             });
         });
 
-        describe('isEmailAddress', function() {
-            // TODO - steal test addresses from real email parsing library?
-            // all valid addresses, should return true
-            [{description: 'simple email address', testString: 'bob_dobbs@harvard.edu'},
-             {description: 'email address with long domain',
-              testString: 'bob_dobbs@very.specific.server.harvard.edu'},
+        describe('isUnivID', function() {
+            // all valid IDs, should return true
+            [{description: 'numbers', testString: '12345678'},
+             {description: 'letters', testString: 'abcdefgh'},
+             {description: 'alphanumeric', testString: 'a1b2c3d4'},
             ].forEach(function(test) {
                 it('should return true for ' + test.description, function() {
-                    expect(scope.isEmailAddress(test.testString)).toBe(true);
+                    expect(scope.isUnivID(test.testString)).toBe(true);
                 });
             });
 
-            // not addresses, should return false
-            [{description: 'series of digits', testString: '123456789'},
-             {description: '@ but no .', testString: 'bob_dobbs@harvard'},
-             {description: '. but no @', testString: 'bob_dobbs.harvard.edu'},
+            // not valid IDs, should return false
+            [{description: 'has @', testString: '1234@678'},
+             {description: 'too short', testString: '1234567'},
+             {description: 'too long', testString: 'abcdefghi'},
             ].forEach(function(test) {
                 it('should return false for ' + test.description, function() {
-                    expect(scope.isEmailAddress(test.testString)).toBe(false);
+                    expect(scope.isUnivID(test.testString)).toBe(false);
                 });
             });
         });


### PR DESCRIPTION
…were not being found

Noticed this while testing 2449. 

- valid, existing email addresses were giving a not found message in the UI due to a limited regex
- this fix switches the regex to match a HUID, and if the match fails assume it's an email (the opposite of the previous behavior)
- the benefit here is that HUID rules are easier to get right than email rules, whereas the downside is that if HUID rules change in the future this code will need to be updated

This is a suggested approach; another would be to find a better javascript regex. An example of a user with a valid email that fails the existing isEmailAddress regex test is `aa011ce0 `.

Also includes some minor refactoring that I apparently could not resist, apologies.