### PR TITLE
tlt-2511: course info tool course instance list registrar code fix

### DIFF
--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -465,7 +465,7 @@
             // and is combination of existing logic in
             // Searchcontroller.courseInstanceToTable and Searchcontroller cell
             // render functions.
-            courseInstance = {};
+            var courseInstance = {};
             if (ci) {
                 courseInstance['title']= ci.title;
                 courseInstance['school'] = ci.course ?
@@ -474,8 +474,8 @@
                 courseInstance['year'] = ci.term ? ci.term.academic_year : '';
                 courseInstance['cid'] = ci.course_instance_id;
                 courseInstance['registrar_code_display'] = ci.course ?
-                        ci.course.registrar_code_display +
-                        ' (' + ci.course.course_id + ')'.trim() : '';
+                        (ci.course.registrar_code_display
+                        || ci.course.registrar_code).trim() : '';
                 if (ci.secondary_xlist_instances &&
                     ci.secondary_xlist_instances.length > 0) {
                         courseInstance['xlist_status'] = 'Primary';
@@ -486,7 +486,7 @@
                         courseInstance['xlist_status'] = 'N/A';
                 }
                 var sites = ci.sites || [];
-                var siteIds =[]
+                var siteIds =[];
                 sites.forEach(function (site) {
                     site.site_id = site.external_id;
                     if (site.site_id.indexOf('http') === 0) {

--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -126,8 +126,7 @@
                 });
                 if (course.course) {
                     cinfo['code'] = (course.course.registrar_code_display
-                        || course.course.registrar_code
-                        + ' (' + course.course.course_id + ')').trim();
+                        || course.course.registrar_code).trim();
                     cinfo['school'] = course.course.school_id.toUpperCase();
                 } else {
                     cinfo['code'] = '';

--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -126,7 +126,8 @@
                 });
                 if (course.course) {
                     cinfo['code'] = (course.course.registrar_code_display
-                    + ' (' + course.course.course_id + ')').trim();
+                        || course.course.registrar_code
+                        + ' (' + course.course.course_id + ')').trim();
                     cinfo['school'] = course.course.school_id.toUpperCase();
                 } else {
                     cinfo['code'] = '';

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -174,7 +174,8 @@ describe('Unit testing PeopleController', function() {
                 ],
                 course: {
                     school_id: 'abc',
-                    registrar_code_display: '2222',
+                    registrar_code_display: '4x2',
+                    registrar_code: '2222',
                     course_id : '789',
                 },
                 term: {
@@ -185,8 +186,9 @@ describe('Unit testing PeopleController', function() {
             };
         });
 
-        it('format the course instance data for the UI ', function() {
+        it('formats the course instance data for the UI', function() {
             courseInstances.instances[ci.course_instance_id] = ci;
+
             controller = $controller('PeopleController', {$scope: scope});
 
             expect(scope.courseInstance['title']).toEqual(ci.title);
@@ -196,7 +198,24 @@ describe('Unit testing PeopleController', function() {
             expect(scope.courseInstance['year']).toEqual(ci.term.academic_year);
             expect(scope.courseInstance['cid']).toEqual(ci.course_instance_id);
             expect(scope.courseInstance['registrar_code_display']).toEqual(
-                    ci.course.registrar_code_display+' ('+ci.course.course_id+')');
+                    ci.course.registrar_code_display);
+            expect(scope.courseInstance['sites']).toEqual('888');
+            expect(scope.courseInstance['xlist_status']).toEqual('N/A');
+        });
+        it('uses registrar_code if registrar_code_display is blank', function() {
+            courseInstances.instances[ci.course_instance_id] = angular.copy(ci);
+            courseInstances.instances[ci.course_instance_id].course.registrar_code_display = '';
+
+            controller = $controller('PeopleController', {$scope: scope});
+
+            expect(scope.courseInstance['title']).toEqual(ci.title);
+            expect(scope.courseInstance['school']).toEqual
+                    (ci.course.school_id.toUpperCase());
+            expect(scope.courseInstance['term']).toEqual(ci.term.display_name);
+            expect(scope.courseInstance['year']).toEqual(ci.term.academic_year);
+            expect(scope.courseInstance['cid']).toEqual(ci.course_instance_id);
+            expect(scope.courseInstance['registrar_code_display']).toEqual(
+                    ci.course.registrar_code);
             expect(scope.courseInstance['sites']).toEqual('888');
             expect(scope.courseInstance['xlist_status']).toEqual('N/A');
 


### PR DESCRIPTION
Course info search page results table and people page course summary box updates:

- if the registrar_code_display is blank for a course (which sometimes happens in course feeds), falls back on the registrar_code (which we expect to always be present) (AC 1, 2)
- Course Code column no longer includes the course_id field (AC 3)