### PR TITLE
Task/eparker71/tlt 1983/build out course details page

### DIFF
--- a/course_info/static/course_info/js/app.js
+++ b/course_info/static/course_info/js/app.js
@@ -34,7 +34,7 @@
             })
             .when('/details/:courseInstanceId', {
                 templateUrl: 'partials/details.html',
-                controller: 'DetailsController',
+                controller: 'DetailsController as dc',
             })
             .when('/people/:courseInstanceId', {
                 templateUrl: 'partials/people.html',

--- a/course_info/static/course_info/js/app.js
+++ b/course_info/static/course_info/js/app.js
@@ -32,6 +32,10 @@
                 templateUrl: 'partials/search.html',
                 controller: 'SearchController',
             })
+            .when('/details/:courseInstanceId', {
+                templateUrl: 'partials/details.html',
+                controller: 'DetailsController',
+            })
             .when('/people/:courseInstanceId', {
                 templateUrl: 'partials/people.html',
                 controller: 'PeopleController',

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -8,7 +8,9 @@
     function DetailsController($scope, $routeParams, courseInstances, $compile,
                                djangoUrl, $http, $q, $log, $uibModal, $sce) {
 
-        dc = this;
+        var dc = this;
+
+        var remove_quotes_regex = new RegExp("^\"|\"$", "g");
 
         dc.handleAjaxError = function (data, status, headers, config, statusText) {
             $log.error('Error attempting to ' + config.method + ' ' + config.url +
@@ -50,12 +52,12 @@
                 .then(dc.handleLookupResults);
         };
 
-        dc.stripQuotes = function(str){
-            // soem fields are coming over with quotes around them and those quotes
-            // are being displayed in the html.
-            // This strips off double quotes from the begining and ending of fields
-            return str ? str.trim().replace(new RegExp("^\"|\"$", "g"), "") : '';
-        };
+        //dc.stripQuotes = function(str){
+        //    // soem fields are coming over with quotes around them and those quotes
+        //    // are being displayed in the html.
+        //    // This strips off double quotes from the begining and ending of fields
+        //    return str ? str.trim().replace(remove_quotes_regex, "") : '';
+        //};
 
         dc.getFormattedCourseInstance = function (ci, members) {
             // This is a helper function that formats the CourseInstance metadata
@@ -64,26 +66,26 @@
             // render functions.
             courseInstance = {};
             if (ci) {
-                courseInstance['title'] = dc.stripQuotes(ci.title);
-                courseInstance['school'] = ci.course ?
-                    ci.course.school_id.toUpperCase() : '';
-                courseInstance['term'] = ci.term ? ci.term.display_name : '';
-                courseInstance['year'] = ci.term ? ci.term.academic_year : '';
-                courseInstance['departments'] = ci.course.departments ? ci.course.departments : [];
-                courseInstance['course_groups'] = ci.course.course_groups ? ci.course.course_groups : [];
-                courseInstance['cid'] = ci.course_instance_id;
-                courseInstance['registrar_code_display'] = ci.course ?
-                ci.course.registrar_code_display +
-                ' (' + ci.course.course_id + ')'.trim() : '';
-                courseInstance['description'] = dc.stripQuotes(ci.description);
-                courseInstance['short_title'] = dc.stripQuotes(ci.short_title);
-                courseInstance['sub_title'] = ci.sub_title ? dc.stripQuotes(ci.sub_title) : '';
-                courseInstance['meeting_time'] = ci.meeting_time ? ci.meeting_time : '';
+                courseInstance['title'] = ci.title;
+                courseInstance['school'] = ci.course.school_id.toUpperCase();
+                courseInstance['term'] = ci.term.display_name;
+                courseInstance['year'] = ci.term.academic_year;
+                courseInstance['departments'] = ci.course.departments;
+                courseInstance['course_groups'] = ci.course.course_groups;
+
+                var registrar_code = ci.course.registrar_code_display ? ci.course.registrar_code_display : ci.course.registrar_code;
+
+                courseInstance['registrar_code_display'] = registrar_code + ' (' + ci.course.course_id + ')'.trim();
+
+                courseInstance['description'] = ci.description;
+                courseInstance['short_title'] = ci.short_title;
+                courseInstance['sub_title'] = ci.sub_title;
+                courseInstance['meeting_time'] = ci.meeting_time;
                 courseInstance['location'] = ci.location;
-                courseInstance['instructors_display'] = ci.instructors_display ? ci.instructors_display : '';
+                courseInstance['instructors_display'] = ci.instructors_display;
                 courseInstance['course_instance_id'] = ci.course_instance_id;
-                courseInstance['notes'] = dc.stripQuotes(ci.notes);
-                courseInstance['conclude_date'] = ci.conclude_date ? ci.conclude_date : '';
+                courseInstance['notes'] = ci.notes;
+                courseInstance['conclude_date'] = ci.conclude_date;
 
                 if (ci.secondary_xlist_instances &&
                     ci.secondary_xlist_instances.length > 0) {
@@ -95,9 +97,9 @@
                     courseInstance['xlist_status'] = 'N/A';
                 }
 
-                courseInstance['sites'] = ci.sites ? ci.sites : [];
+                courseInstance['sites'] = ci.sites;
             }
-            courseInstance['members'] = members.count ? members.count : 0;
+            courseInstance['members'] = members.count;
 
             return courseInstance;
         };

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -1,652 +1,86 @@
-
 // TODO - this is pretty much a copy of the people controller with some mods.
 // TODO - this still needs a lot of clean up, we don't need everything in here
 
-(function() {
+(function () {
     var app = angular.module('CourseInfo');
     app.controller('DetailsController', DetailsController);
 
     function DetailsController($scope, $routeParams, courseInstances, $compile,
-                              djangoUrl, $http, $q, $log, $uibModal) {
-        // set up constants
-        $scope.sortKeyByColumnId = {
-            0: 'name',
-            1: 'user_id',
-            2: 'role__role_name',
-            3: 'source_manual_registrar',
-        };
+                               djangoUrl, $http, $q, $log, $uibModal, $sce) {
 
-        // set up functions we'll be calling later
-        $scope.addUser = function(searchTerm) {
-            $scope.searchInProgress = true;
-            if ($scope.searchResults.length === 0) {
-                $scope.lookup(searchTerm);
-            }
-            else if ($scope.searchResults.length === 1) {
-                $log.error('Add user button pressed while we have a single search result');
-            }
-            else { // $scope.searchResults.length > 1
-                if ($scope.selectedResult.id) {
-                    $scope.addUserToCourse(searchTerm,
-                                           {user_id: $scope.selectedResult.id,
-                                            role_id: $scope.selectedRole.roleId});
-                }
-                else {
-                    $scope.lookup(searchTerm);
-                }
-            }
-        };
-        $scope.addUserToCourse = function(searchTerm, user){
-            var url = djangoUrl.reverse('icommons_rest_api_proxy',
-                                        ['api/course/v2/course_instances/'
-                                         + $scope.courseInstanceId + '/people/']);
-            $scope.clearMessages();
-            $scope.partialFailureData = null;
+        dc = this;
 
-            // called on actual post success, and on error-but-partial-success
-            var handlePostSuccess = function() {
-                $http.get(url, {params: {user_id: user.user_id}})
-                    .success(function(data, status, headers, config, statusText) {
-
-                        // this is a temp fix to change the display text of the role "Teaching Fellow" to "TA"
-                        // a more perm solution is being discussed, but will invlove talking to the schools.
-                        if ( data.results[0].role.role_name == "Teaching Fellow") {
-                            data.results[0].role.role_name = "TA";
-                        }
-
-                        data.results[0].searchTerm = searchTerm;
-                        data.results[0].action = 'added to';
-                        $scope.clearMessages();
-                        // if there was a partial error, specifically if there was
-                        // an error adding the user to the Canvas course (we caught
-                        // a Canvas API error). The user has been added to the
-                        // coursemanager db, but could not be added to Canvas.
-                        // In this case it's possible that the user will be addded
-                        // during the next Canvas sync. We let the user know about
-                        // the partial failure and that it may correct itself.
-                        if($scope.partialFailureData){
-                            data.results[0].partialFailureData = $scope.partialFailureData
-                        }
-
-                        $scope.success = data.results[0];
-                        $scope.dtInstance.reloadData();
-                    })
-                    .error(function(data, status, headers, config, statusText) {
-                        // log it, then display a warning
-                        $scope.handleAjaxError(data, status, headers, config,
-                                statusText);
-                        $scope.clearMessages();
-                        $scope.addPartialFailure = {
-                            searchTerm: searchTerm,
-                            text: 'Add to course seemed to succeed, but ' +
-                                'we received an error trying to retrieve ' +
-                                "the user's course details.",
-                        };
-                    })
-                    .finally(function(){
-                        $scope.clearSearchResults();
-                        $scope.searchInProgress = false;
-                    });
-            };
-
-            $http.post(url, user)
-                .success(handlePostSuccess)
-                .error(function(data, status, headers, config, statusText) {
-                    $scope.handleAjaxError(data, status, headers, config, statusText);
-
-                    if (data.detail &&
-                            (data.detail.indexOf('Canvas API error details') != -1)) {
-                        // partial success, where we enrolled in the coursemanager
-                        // db, but got an error trying to enroll in canvas
-                        $scope.partialFailureData = {
-                            searchTerm: searchTerm,
-                            text: data.detail
-                        };
-                        handlePostSuccess();
-                    }
-                    else {
-                        $scope.clearMessages();
-                        $scope.addWarning = {
-                            type: 'addFailed',
-                            searchTerm: searchTerm,
-                        };
-                        $scope.clearSearchResults();
-                        $scope.searchInProgress = false;
-                    }
-                });
-        };
-        $scope.clearSearchResults = function() {
-            $scope.searchResults = [];
-        };
-        $scope.closeAlert = function(source) {
-            $scope[source] = null;
-            $scope.partialFailureData = null;
-        };
-        $scope.compareRoles = function(a, b) {
-            /*
-             * we want to sort roles by a combination of two fields.
-             * - active = (0 | 1)
-             * - prime_role_indicator = ('Y' | 'N' | '')
-             *
-             * we're sorting descending by active, then descending by
-             * prime_role_indicator, where 'Y' > 'N' > ''.
-             */
-            if (a.active == b.active) {
-                if (b.prime_role_indicator > a.prime_role_indicator) {
-                    return 1;
-                }
-                else if (b.prime_role_indicator < a.prime_role_indicator) {
-                    return -1;
-                }
-                else {
-                    return 0;
-                }
-            }
-            else {
-                return b.active - a.active;
-            }
-        };
-        $scope.confirmRemove = function(membership) {
-            // creates a new remove user confirmation modal, and
-            // stashes this membership object on the modal's child scope.
-
-            // this is a temp fix to change the display text of the role "Teaching Fellow" to "TA"
-            // a more perm solution is being discussed, but will invlove talking to the schools.
-            if (membership && membership.role &&
-                    membership.role.role_name == "Teaching Fellow") {
-                membership.role.role_name = "TA";
-            }
-
-            $scope.confirmRemoveModalInstance = $uibModal.open({
-                controller: function($scope, membership) {
-                    $scope.membership = membership;
-                },
-                resolve: {
-                    membership: function() {
-                        return membership;
-                    }
-                },
-                // allows template to refer to parent scope's getProfileFullName
-                scope: $scope,
-                templateUrl: 'partials/remove-course-membership-confirmation.html',
-            });
-
-            // if they confirm, then do the work
-            $scope.confirmRemoveModalInstance.result
-                .then($scope.removeMembership)
-                .finally(function() {
-                    $scope.confirmRemoveModalInstance = null;
-                });
-        };
-        $scope.disableAddUserButton = function(){
-            if ($scope.searchInProgress) {
-                return true;
-            }
-            else if ($scope.searchResults.length > 0) {
-                return (!$scope.selectedResult.id);
-            }
-            else if ($scope.searchTerm.length > 0) {
-                return false;
-            }
-            else {
-                return true;
-            }
-        };
-        $scope.filterSearchResults = function(searchResults){
-            var filteredResults = Array();
-            var resultsDict = {};
-
-            // create a dict of the id's as keys and the
-            // role records as values
-            for (i = 0; i < searchResults.length; i++) {
-                var role = searchResults[i];
-                if (resultsDict[role.univ_id] != undefined) {
-                    resultsDict[role.univ_id].push(role);
-                } else {
-                    resultsDict[role.univ_id] = [role];
-                }
-            }
-            // for each id sort the role list
-            // and fetch the top record
-            for (id in resultsDict) {
-                var roleList = resultsDict[id];
-                roleList.sort($scope.compareRoles);
-                filteredResults.push(roleList[0]);
-            }
-            // return the filtered list
-            return filteredResults;
-        };
-        $scope.getProfileFullName = function(profile) {
-            if (profile) {
-                return profile.name_last + ', ' + profile.name_first;
-            } else {
-                return '';
-            }
-        };
-        $scope.getProfileRoleTypeCd = function (profile) {
-            if (profile) {
-                return profile.role_type_cd;
-            } else {
-                return '';
-            }
-        };
-        $scope.handleAjaxError = function(data, status, headers, config, statusText) {
+        dc.handleAjaxError = function (data, status, headers, config, statusText) {
             $log.error('Error attempting to ' + config.method + ' ' + config.url +
-                       ': ' + status + ' ' + statusText + ': ' + JSON.stringify(data));
+                ': ' + status + ' ' + statusText + ': ' + JSON.stringify(data));
         };
-        $scope.handleLookupResults = function(results) {
-            var peopleResult = results[0];
-            var memberResult = results[1];
 
-            // this is a temp fix to change the display text of the role "Teaching Fellow" to "TA"
-            // a more perm solution is being discussed, but will invlove talking to the schools.
-            if (memberResult.data.results.length > 0 &&
-                    memberResult.data.results[0].role &&
-                    memberResult.data.results[0].role.role_name == "Teaching Fellow") {
-                memberResult.data.results[0].role.role_name = "TA";
-            }
+        dc.setCourseInstance = function (id) {
 
-            // TODO - implement and use generalized logic that will follow any
-            //        "next" links in the rest api response.  note that the api
-            //        proxy doesn't rewrite the next urls.
-            for (result in results) {
-                if (result.next) {
-                    $log.warning('Received multiple pages of results from '
-                                 + result.config.url + ', only using one.');
-                }
-            }
-
-            // if the user is already in the course, show their current enrollment
-            if (memberResult.data.results.length > 0) {
-                // just pick the first one to find the name
-                var profile = memberResult.data.results[0].profile;
-                $scope.clearMessages();
-                $scope.addWarning = {
-                    type: 'alreadyInCourse',
-                    fullName: $scope.getProfileFullName(profile),
-                    memberships: memberResult.data.results,
-                    searchTerm: memberResult.config.searchTerm,
-                };
-                $scope.searchInProgress = false;
-            }
-            else {
-                var filteredResults = $scope.filterSearchResults(
-                                          peopleResult.data.results);
-                if (filteredResults.length == 0) {
-                    // didn't find any people for the search term
-                    $scope.clearMessages();
-                    $scope.addWarning = {
-                        type: 'notFound',
-                        searchTerm: peopleResult.config.searchTerm,
-                    };
-                    $scope.searchInProgress = false;
-                }
-                else if (filteredResults.length == 1) {
-                    $scope.addUserToCourse(peopleResult.config.searchTerm,
-                                           {user_id: filteredResults[0].univ_id,
-                                            role_id: $scope.selectedRole.roleId});
-                }
-                else {
-                    $scope.searchResults = filteredResults;
-                    $scope.searchInProgress = false;
-                }
-            }
-        };
-        $scope.isUnivID = function(searchTerm) {
-            var re = /^[A-Za-z0-9]{8}$/;
-            return re.test(searchTerm);
-        };
-        $scope.lookup = function(searchTerm) {
-            var peopleParams = {page_size: 100};
-            var memberParams = {page_size: 100};
-
-            if ($scope.isUnivID(searchTerm)) {
-                peopleParams.univ_id = searchTerm;
-                memberParams.user_id = searchTerm;
-            } else {
-                peopleParams.email_address = searchTerm;
-                memberParams['profile.email_address'] = searchTerm;
-            }
-
-            // first the general people lookup
-            var peopleURL = djangoUrl.reverse('icommons_rest_api_proxy',
-                                              ['api/course/v2/people/']);
-            var peoplePromise = $http.get(peopleURL, {params: peopleParams,
-                                                      searchTerm: searchTerm})
-                                     .error($scope.handleAjaxError);
-
-            // then the course membership lookup
-            var memberURL = djangoUrl.reverse('icommons_rest_api_proxy',
-                                              ['api/course/v2/course_instances/'
-                                               + $scope.courseInstanceId
-                                               + '/people/']);
-            var memberPromise = $http.get(memberURL, {params: memberParams,
-                                                      searchTerm: searchTerm})
-                                     .error($scope.handleAjaxError);
-
-            // wait until they're both done, handle the combined results
-            $q.all([peoplePromise, memberPromise])
-                .then($scope.handleLookupResults);
-        };
-        $scope.removeMembership = function(membership) {
-            // the call stack to get here is a little weird.  we register
-            // this as the success callback on a promise hung off the
-            // $uibModal instance.
-            var courseMemberURL = djangoUrl.reverse(
-                                      'icommons_rest_api_proxy',
-                                      ['api/course/v2/course_instances/' +
-                                       $scope.courseInstanceId +
-                                       '/people/' + membership.user_id]);
-            var config = {
-                data: {
-                    role_id: membership.role.role_id,
-                    user_id: membership.user_id,
-                },
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-            };
-            $http.delete(courseMemberURL, config)
-                .success(function(data, status, headers, config, statusText) {
-                    var success = membership; // TODO - copy to avoid stomping the original?
-                    success.searchTerm = $scope.getProfileFullName(membership.profile)
-                        || membership.user_id;
-                    success.action = 'removed from';
-                    $scope.clearMessages();
-                    $scope.success = success;
-                    $scope.dtInstance.reloadData()
+            var url = djangoUrl.reverse(
+                'icommons_rest_api_proxy',
+                ['api/course/v2/course_instances/' + id + '/']);
+            $http.get(url)
+                .success(function (data, status, headers, config, statusText) {
+                    //check if the right data was obtained before storing it
+                    if (data.course_instance_id == id) {
+                        courseInstances.instances[data.course_instance_id] = data;
+                        $scope.courseInstance = dc.getFormattedCourseInstance(data)
+                    } else {
+                        $log.error(' CourseInstance record mismatch for id :'
+                            + id + ',  fetched record for :' + data.id);
+                    }
                 })
-                .error(function(data, status, headers, config, statusText) {
-                    $scope.handleAjaxError(data, status, headers, config, statusText);
-
-                    var failure = membership; // TODO - copy to avoid stomping the original?
-                    var reloadData = false; // for some partial failures we need to reload
-                    switch(status) {
-                        case 404:
-                            switch (data.detail) {
-                                case 'User not found.':
-                                    failure.type = 'noSuchUser';
-                                    reloadData = true;
-                                    break;
-                                case 'Course instance not found.':
-                                    failure.type = 'noSuchCourse';
-                                    break;
-                                default:
-                                    failure.type = 'unexpected404';
-                                    break;
-                            }
-                            break;
-
-                        case 500:
-                            if (data.detail == 'User could not be removed from Canvas.') {
-                                failure.type = 'canvasError';
-                                reloadData = true;
-                            }
-                            else {
-                                failure.type = 'serverError';
-                            }
-                            break;
-
-                        default:
-                            failure.type = 'unknown';
-                            break;
-                    }
-                    $scope.clearMessages();
-                    $scope.removeFailure = failure;
-                    if (reloadData) {
-                        $scope.dtInstance.reloadData();
-                    }
-                });
-        };
-        $scope.renderId = function(data, type, full, meta) {
-            if (full.profile) {
-                return '<badge ng-cloak role="'
-                    + $scope.getProfileRoleTypeCd(full.profile)
-                    + '"></badge> ' + full.user_id;
-            } else {
-                return '<badge ng-cloak role=""></badge> ' + full.user_id;
-            }
-        };
-        $scope.renderName = function(data, type, full, meta) {
-            return $scope.getProfileFullName(full.profile) || full.user_id;
-        };
-        // hotfix added to address TA role name
-        // will be addressed with a database change as soon as
-        // devops determines viability of change
-        $scope.renderRole = function(data, type, full, meta) {
-            return /^Teaching Fellow$/.test(data) ? 'TA' : data;
-        };
-        $scope.renderRemove = function(data, type, full, meta) {
-            // TODO - maybe make this a directive?  the isolate scope
-            //        in a directive complicates things.  anything has
-            //        to be better than this mess, though.
-            var registrarFed = /^.*feed$/.test(full.source);
-            var iconClass = registrarFed ? 'fa-trash-disabled' : '';
-            var icon = '<i class="fa fa-trash-o ' + iconClass + '"></i>';
-            var linkOpen = '';
-            if (!registrarFed) {
-                linkOpen = '<a href="" ng-click="confirmRemove(' +
-                           'dtInstance.DataTable.data()[' + meta.row + '])" ' +
-                           'data-sisid="' + full.user_id + '">';
-            }
-            var linkClose = registrarFed ? '' : '</a>';
-            return '<div class="text-center">' +
-                       linkOpen + icon + linkClose + '</div>';
-        }
-        $scope.renderSource = function(data, type, full, meta) {
-            return /^.*feed$/.test(data) ? 'Registrar Added' : 'Manually Added';
-        };
-        $scope.selectRole = function(role) {
-            $scope.selectedRole = role;
-        };
-        $scope.setCourseInstance = function(id) {
-            console.log(courseInstances);
-            //var ci = courseInstances.instances[id];
-            //if (angular.isDefined(ci)) {
-            //    $scope.courseInstance = $scope.getFormattedCourseInstance(ci)
-            //}
-            //else {
-                var url = djangoUrl.reverse(
-                              'icommons_rest_api_proxy',
-                              ['api/course/v2/course_instances/' + id + '/']);
-                $http.get(url)
-                    .success(function(data, status, headers, config, statusText) {
-                        //check if the right data was obtained before storing it
-                        if (data.course_instance_id == id){
-                            courseInstances.instances[data.course_instance_id] = data;
-                            $scope.courseInstance = $scope.getFormattedCourseInstance(data)
-                        }else{
-                            $log.error(' CourseInstance record mismatch for id :'
-                                + id +',  fetched record for :' +data.id);
-                        }
-                    })
-                    .error($scope.handleAjaxError);
-            //}
+                .error($scope.handleAjaxError);
         };
 
-        $scope.getFormattedCourseInstance = function(ci) {
+        dc.stripQuotes = function(str){
+            return str.trim().replace(new RegExp("^\"|\"$", "g"), "");
+        };
+
+        dc.getFormattedCourseInstance = function (ci) {
             // This is a helper function that formats the CourseInstance metadata
             // and is combination of existing logic in
             // Searchcontroller.courseInstanceToTable and Searchcontroller cell
             // render functions.
 
-            console.log(ci);
             courseInstance = {};
             if (ci) {
-                courseInstance['title']= ci.title;
-
+                courseInstance['title'] = dc.stripQuotes(ci.title);
                 courseInstance['school'] = ci.course ?
-                        ci.course.school_id.toUpperCase() : '';
-
+                    ci.course.school_id.toUpperCase() : '';
                 courseInstance['term'] = ci.term ? ci.term.display_name : '';
                 courseInstance['year'] = ci.term ? ci.term.academic_year : '';
                 courseInstance['cid'] = ci.course_instance_id;
-
                 courseInstance['registrar_code_display'] = ci.course ?
-                        ci.course.registrar_code_display +
-                        ' (' + ci.course.course_id + ')'.trim() : '';
-
-                courseInstance['description'] = ci.description;
-                courseInstance['short_title'] = ci.short_title;
+                ci.course.registrar_code_display +
+                ' (' + ci.course.course_id + ')'.trim() : '';
+                courseInstance['description'] = dc.stripQuotes(ci.description);
+                courseInstance['short_title'] = dc.stripQuotes(ci.short_title);
                 courseInstance['sub_title'] = ci.sub_title;
                 courseInstance['meeting_time'] = ci.meeting_time;
                 courseInstance['location'] = ci.location;
                 courseInstance['instructors_display'] = ci.instructors_display;
                 courseInstance['course_instance_id'] = ci.course_instance_id;
-
-                courseInstance['notes'] = ci.notes;
+                courseInstance['notes'] = dc.stripQuotes(ci.notes);
 
                 if (ci.secondary_xlist_instances &&
                     ci.secondary_xlist_instances.length > 0) {
-                        courseInstance['xlist_status'] = 'Primary';
+                    courseInstance['xlist_status'] = 'Primary';
                 } else if (ci.primary_xlist_instances &&
                     ci.primary_xlist_instances.length > 0) {
-                        courseInstance['xlist_status'] = 'Secondary';
+                    courseInstance['xlist_status'] = 'Secondary';
                 } else {
-                        courseInstance['xlist_status'] = 'N/A';
+                    courseInstance['xlist_status'] = 'N/A';
                 }
                 courseInstance['sites'] = ci.sites;
-
-                //var sites = ci.sites || [];
-                //var siteIds =[]
-                //sites.forEach(function (site) {
-                //    site.site_id = site.external_id;
-                //    if (site.site_id.indexOf('http') === 0) {
-                //        site.site_id = site.site_id.substr(site.site_id.lastIndexOf('/')+1);
-                //    }
-                //    siteIds.push(site.site_id)
-                //});
-                //courseInstance['sites']= siteIds.length>0 ? siteIds.join(', ') : 'N/A';
             }
             return courseInstance;
         };
 
-        $scope.clearMessages = function(){
-            $scope.addPartialFailure = null;
-            $scope.removeFailure = null;
-            $scope.addWarning = null;
-            $scope.success = null;
-        };
+        dc.courseInstanceId = $routeParams.courseInstanceId;
 
-        // now actually init the controller
-        $scope.addPartialFailure = null;
-        $scope.partialFailureData = null;
-        $scope.addWarning = null;
-        $scope.confirmRemoveModalInstance = null;
-        $scope.courseInstanceId = $routeParams.courseInstanceId;
-        $scope.removeFailure = null;
+        dc.setCourseInstance($routeParams.courseInstanceId);
 
-        $scope.roles = [
-            // NOTE - these may need to be updated based on the db values
-            {roleId: 0, roleName: 'Student'},
-            {roleId: 10, roleName: 'Guest'},
-            {roleId: 14, roleName: 'Shopper'},
-            {roleId: 9, roleName: 'Teacher'},
-            {roleId: 1, roleName: 'Course Head'},
-            {roleId: 2, roleName: 'Faculty'},
-            {roleId: 12, roleName: 'Teaching Staff'},
-            {roleId: 5, roleName: 'TA'},
-            {roleId: 11, roleName: 'Course Support Staff'},
-            {roleId: 7, roleName: 'Designer'},
-            {roleId: 15, roleName: 'Observer'},
-        ];
-        $scope.searchInProgress = false;
-        $scope.searchResults = [];
-        $scope.searchTerm = '';
-        $scope.selectedResult = {id: undefined};
-        $scope.selectedRole = $scope.roles[0];
-        $scope.setCourseInstance($routeParams.courseInstanceId);
-        $scope.success = null;
-
-        // configure the datatable
-        $scope.dtInstance = null;
-        $scope.dtOptions = {
-            ajax: function(data, callback, settings) {
-                var url = djangoUrl.reverse('icommons_rest_api_proxy',
-                                            ['api/course/v2/course_instances/'
-                                             + $scope.courseInstanceId + '/people/']);
-                var queryParams = {
-                    offset: data.start,
-                    limit: data.length,
-                    '-source': 'xreg_map', // exclude xreg people
-                    ordering: (data.order[0].dir === 'desc' ? '-' : '')
-                              + $scope.sortKeyByColumnId[data.order[0].column],
-                };
-
-                $.ajax({
-                    url: url,
-                    method: 'GET',
-                    data: queryParams,
-                    dataSrc: 'data',
-                    dataType: 'json',
-                    success: function(data, textStatus, jqXHR) {
-                        callback({
-                            recordsTotal: data.count,
-                            recordsFiltered: data.count,
-                            data: data.results,
-                        });
-                    },
-                    error: function(data, textStatus, errorThrown) {
-                        $log.error('Error getting data from ' + url + ': '
-                                   + textStatus + ', ' + errorThrown);
-                        callback({
-                            recordsTotal: 0,
-                            recordsFiltered: 0,
-                            data: [],
-                        });
-                    },
-                });
-            },
-            createdRow: function( row, data, dataIndex ) {
-                // to use angular directives within the rendered datatable,
-                // we have to compile those elements ourselves.  joy.
-                $compile(angular.element(row).contents())($scope);
-            },
-            language: {
-                emptyTable: 'There are no people to display.',
-                info: 'Showing _START_ to _END_ of _TOTAL_ people',
-                infoEmpty: 'Showing 0 to 0 of 0 people',
-                paginate: {
-                    next: '',
-                    previous: '',
-                },
-            },
-            lengthMenu: [10, 25, 50, 100],
-            // yes, this is a deprecated param.  yes, it's still required.
-            // see https://datatables.net/forums/discussion/27287/using-an-ajax-custom-get-function-don-t-forget-to-set-sajaxdataprop
-            sAjaxDataProp: 'data',
-            searching: false,
-            serverSide: true,
-        };
-
-        // see hotfix note above for renderRole
-        $scope.dtColumns = [
-            {
-                data: '',
-                render: $scope.renderName,
-                title: 'Name',
-            },
-            {
-                data: '',
-                render: $scope.renderId,
-                title: 'ID',
-            },
-            {
-                data: 'role.role_name',
-                render: $scope.renderRole,
-                title: 'Role'
-            },
-            {
-                data: 'source',
-                render: $scope.renderSource,
-                title: 'Source',
-            },
-            {
-                data: '',
-                orderable: false,
-                render: $scope.renderRemove,
-                title: 'Remove',
-            },
-        ];
     }
 })();

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -1,0 +1,650 @@
+// TODO - split out add/remove into separate controllers?
+
+(function() {
+    var app = angular.module('CourseInfo');
+    app.controller('DetailsController', DetailsController);
+
+    function DetailsController($scope, $routeParams, courseInstances, $compile,
+                              djangoUrl, $http, $q, $log, $uibModal) {
+        // set up constants
+        $scope.sortKeyByColumnId = {
+            0: 'name',
+            1: 'user_id',
+            2: 'role__role_name',
+            3: 'source_manual_registrar',
+        };
+
+        // set up functions we'll be calling later
+        $scope.addUser = function(searchTerm) {
+            $scope.searchInProgress = true;
+            if ($scope.searchResults.length === 0) {
+                $scope.lookup(searchTerm);
+            }
+            else if ($scope.searchResults.length === 1) {
+                $log.error('Add user button pressed while we have a single search result');
+            }
+            else { // $scope.searchResults.length > 1
+                if ($scope.selectedResult.id) {
+                    $scope.addUserToCourse(searchTerm,
+                                           {user_id: $scope.selectedResult.id,
+                                            role_id: $scope.selectedRole.roleId});
+                }
+                else {
+                    $scope.lookup(searchTerm);
+                }
+            }
+        };
+        $scope.addUserToCourse = function(searchTerm, user){
+            var url = djangoUrl.reverse('icommons_rest_api_proxy',
+                                        ['api/course/v2/course_instances/'
+                                         + $scope.courseInstanceId + '/people/']);
+            $scope.clearMessages();
+            $scope.partialFailureData = null;
+
+            // called on actual post success, and on error-but-partial-success
+            var handlePostSuccess = function() {
+                $http.get(url, {params: {user_id: user.user_id}})
+                    .success(function(data, status, headers, config, statusText) {
+
+                        // this is a temp fix to change the display text of the role "Teaching Fellow" to "TA"
+                        // a more perm solution is being discussed, but will invlove talking to the schools.
+                        if ( data.results[0].role.role_name == "Teaching Fellow") {
+                            data.results[0].role.role_name = "TA";
+                        }
+
+                        data.results[0].searchTerm = searchTerm;
+                        data.results[0].action = 'added to';
+                        $scope.clearMessages();
+                        // if there was a partial error, specifically if there was
+                        // an error adding the user to the Canvas course (we caught
+                        // a Canvas API error). The user has been added to the
+                        // coursemanager db, but could not be added to Canvas.
+                        // In this case it's possible that the user will be addded
+                        // during the next Canvas sync. We let the user know about
+                        // the partial failure and that it may correct itself.
+                        if($scope.partialFailureData){
+                            data.results[0].partialFailureData = $scope.partialFailureData
+                        }
+
+                        $scope.success = data.results[0];
+                        $scope.dtInstance.reloadData();
+                    })
+                    .error(function(data, status, headers, config, statusText) {
+                        // log it, then display a warning
+                        $scope.handleAjaxError(data, status, headers, config,
+                                statusText);
+                        $scope.clearMessages();
+                        $scope.addPartialFailure = {
+                            searchTerm: searchTerm,
+                            text: 'Add to course seemed to succeed, but ' +
+                                'we received an error trying to retrieve ' +
+                                "the user's course details.",
+                        };
+                    })
+                    .finally(function(){
+                        $scope.clearSearchResults();
+                        $scope.searchInProgress = false;
+                    });
+            };
+
+            $http.post(url, user)
+                .success(handlePostSuccess)
+                .error(function(data, status, headers, config, statusText) {
+                    $scope.handleAjaxError(data, status, headers, config, statusText);
+
+                    if (data.detail &&
+                            (data.detail.indexOf('Canvas API error details') != -1)) {
+                        // partial success, where we enrolled in the coursemanager
+                        // db, but got an error trying to enroll in canvas
+                        $scope.partialFailureData = {
+                            searchTerm: searchTerm,
+                            text: data.detail
+                        };
+                        handlePostSuccess();
+                    }
+                    else {
+                        $scope.clearMessages();
+                        $scope.addWarning = {
+                            type: 'addFailed',
+                            searchTerm: searchTerm,
+                        };
+                        $scope.clearSearchResults();
+                        $scope.searchInProgress = false;
+                    }
+                });
+        };
+        $scope.clearSearchResults = function() {
+            $scope.searchResults = [];
+        };
+        $scope.closeAlert = function(source) {
+            $scope[source] = null;
+            $scope.partialFailureData = null;
+        };
+        $scope.compareRoles = function(a, b) {
+            /*
+             * we want to sort roles by a combination of two fields.
+             * - active = (0 | 1)
+             * - prime_role_indicator = ('Y' | 'N' | '')
+             *
+             * we're sorting descending by active, then descending by
+             * prime_role_indicator, where 'Y' > 'N' > ''.
+             */
+            if (a.active == b.active) {
+                if (b.prime_role_indicator > a.prime_role_indicator) {
+                    return 1;
+                }
+                else if (b.prime_role_indicator < a.prime_role_indicator) {
+                    return -1;
+                }
+                else {
+                    return 0;
+                }
+            }
+            else {
+                return b.active - a.active;
+            }
+        };
+        $scope.confirmRemove = function(membership) {
+            // creates a new remove user confirmation modal, and
+            // stashes this membership object on the modal's child scope.
+
+            // this is a temp fix to change the display text of the role "Teaching Fellow" to "TA"
+            // a more perm solution is being discussed, but will invlove talking to the schools.
+            if (membership && membership.role &&
+                    membership.role.role_name == "Teaching Fellow") {
+                membership.role.role_name = "TA";
+            }
+
+            $scope.confirmRemoveModalInstance = $uibModal.open({
+                controller: function($scope, membership) {
+                    $scope.membership = membership;
+                },
+                resolve: {
+                    membership: function() {
+                        return membership;
+                    }
+                },
+                // allows template to refer to parent scope's getProfileFullName
+                scope: $scope,
+                templateUrl: 'partials/remove-course-membership-confirmation.html',
+            });
+
+            // if they confirm, then do the work
+            $scope.confirmRemoveModalInstance.result
+                .then($scope.removeMembership)
+                .finally(function() {
+                    $scope.confirmRemoveModalInstance = null;
+                });
+        };
+        $scope.disableAddUserButton = function(){
+            if ($scope.searchInProgress) {
+                return true;
+            }
+            else if ($scope.searchResults.length > 0) {
+                return (!$scope.selectedResult.id);
+            }
+            else if ($scope.searchTerm.length > 0) {
+                return false;
+            }
+            else {
+                return true;
+            }
+        };
+        $scope.filterSearchResults = function(searchResults){
+            var filteredResults = Array();
+            var resultsDict = {};
+
+            // create a dict of the id's as keys and the
+            // role records as values
+            for (i = 0; i < searchResults.length; i++) {
+                var role = searchResults[i];
+                if (resultsDict[role.univ_id] != undefined) {
+                    resultsDict[role.univ_id].push(role);
+                } else {
+                    resultsDict[role.univ_id] = [role];
+                }
+            }
+            // for each id sort the role list
+            // and fetch the top record
+            for (id in resultsDict) {
+                var roleList = resultsDict[id];
+                roleList.sort($scope.compareRoles);
+                filteredResults.push(roleList[0]);
+            }
+            // return the filtered list
+            return filteredResults;
+        };
+        $scope.getProfileFullName = function(profile) {
+            if (profile) {
+                return profile.name_last + ', ' + profile.name_first;
+            } else {
+                return '';
+            }
+        };
+        $scope.getProfileRoleTypeCd = function (profile) {
+            if (profile) {
+                return profile.role_type_cd;
+            } else {
+                return '';
+            }
+        };
+        $scope.handleAjaxError = function(data, status, headers, config, statusText) {
+            $log.error('Error attempting to ' + config.method + ' ' + config.url +
+                       ': ' + status + ' ' + statusText + ': ' + JSON.stringify(data));
+        };
+        $scope.handleLookupResults = function(results) {
+            var peopleResult = results[0];
+            var memberResult = results[1];
+
+            // this is a temp fix to change the display text of the role "Teaching Fellow" to "TA"
+            // a more perm solution is being discussed, but will invlove talking to the schools.
+            if (memberResult.data.results.length > 0 &&
+                    memberResult.data.results[0].role &&
+                    memberResult.data.results[0].role.role_name == "Teaching Fellow") {
+                memberResult.data.results[0].role.role_name = "TA";
+            }
+
+            // TODO - implement and use generalized logic that will follow any
+            //        "next" links in the rest api response.  note that the api
+            //        proxy doesn't rewrite the next urls.
+            for (result in results) {
+                if (result.next) {
+                    $log.warning('Received multiple pages of results from '
+                                 + result.config.url + ', only using one.');
+                }
+            }
+
+            // if the user is already in the course, show their current enrollment
+            if (memberResult.data.results.length > 0) {
+                // just pick the first one to find the name
+                var profile = memberResult.data.results[0].profile;
+                $scope.clearMessages();
+                $scope.addWarning = {
+                    type: 'alreadyInCourse',
+                    fullName: $scope.getProfileFullName(profile),
+                    memberships: memberResult.data.results,
+                    searchTerm: memberResult.config.searchTerm,
+                };
+                $scope.searchInProgress = false;
+            }
+            else {
+                var filteredResults = $scope.filterSearchResults(
+                                          peopleResult.data.results);
+                if (filteredResults.length == 0) {
+                    // didn't find any people for the search term
+                    $scope.clearMessages();
+                    $scope.addWarning = {
+                        type: 'notFound',
+                        searchTerm: peopleResult.config.searchTerm,
+                    };
+                    $scope.searchInProgress = false;
+                }
+                else if (filteredResults.length == 1) {
+                    $scope.addUserToCourse(peopleResult.config.searchTerm,
+                                           {user_id: filteredResults[0].univ_id,
+                                            role_id: $scope.selectedRole.roleId});
+                }
+                else {
+                    $scope.searchResults = filteredResults;
+                    $scope.searchInProgress = false;
+                }
+            }
+        };
+        $scope.isUnivID = function(searchTerm) {
+            var re = /^[A-Za-z0-9]{8}$/;
+            return re.test(searchTerm);
+        };
+        $scope.lookup = function(searchTerm) {
+            var peopleParams = {page_size: 100};
+            var memberParams = {page_size: 100};
+
+            if ($scope.isUnivID(searchTerm)) {
+                peopleParams.univ_id = searchTerm;
+                memberParams.user_id = searchTerm;
+            } else {
+                peopleParams.email_address = searchTerm;
+                memberParams['profile.email_address'] = searchTerm;
+            }
+
+            // first the general people lookup
+            var peopleURL = djangoUrl.reverse('icommons_rest_api_proxy',
+                                              ['api/course/v2/people/']);
+            var peoplePromise = $http.get(peopleURL, {params: peopleParams,
+                                                      searchTerm: searchTerm})
+                                     .error($scope.handleAjaxError);
+
+            // then the course membership lookup
+            var memberURL = djangoUrl.reverse('icommons_rest_api_proxy',
+                                              ['api/course/v2/course_instances/'
+                                               + $scope.courseInstanceId
+                                               + '/people/']);
+            var memberPromise = $http.get(memberURL, {params: memberParams,
+                                                      searchTerm: searchTerm})
+                                     .error($scope.handleAjaxError);
+
+            // wait until they're both done, handle the combined results
+            $q.all([peoplePromise, memberPromise])
+                .then($scope.handleLookupResults);
+        };
+        $scope.removeMembership = function(membership) {
+            // the call stack to get here is a little weird.  we register
+            // this as the success callback on a promise hung off the
+            // $uibModal instance.
+            var courseMemberURL = djangoUrl.reverse(
+                                      'icommons_rest_api_proxy',
+                                      ['api/course/v2/course_instances/' +
+                                       $scope.courseInstanceId +
+                                       '/people/' + membership.user_id]);
+            var config = {
+                data: {
+                    role_id: membership.role.role_id,
+                    user_id: membership.user_id,
+                },
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            };
+            $http.delete(courseMemberURL, config)
+                .success(function(data, status, headers, config, statusText) {
+                    var success = membership; // TODO - copy to avoid stomping the original?
+                    success.searchTerm = $scope.getProfileFullName(membership.profile)
+                        || membership.user_id;
+                    success.action = 'removed from';
+                    $scope.clearMessages();
+                    $scope.success = success;
+                    $scope.dtInstance.reloadData()
+                })
+                .error(function(data, status, headers, config, statusText) {
+                    $scope.handleAjaxError(data, status, headers, config, statusText);
+
+                    var failure = membership; // TODO - copy to avoid stomping the original?
+                    var reloadData = false; // for some partial failures we need to reload
+                    switch(status) {
+                        case 404:
+                            switch (data.detail) {
+                                case 'User not found.':
+                                    failure.type = 'noSuchUser';
+                                    reloadData = true;
+                                    break;
+                                case 'Course instance not found.':
+                                    failure.type = 'noSuchCourse';
+                                    break;
+                                default:
+                                    failure.type = 'unexpected404';
+                                    break;
+                            }
+                            break;
+
+                        case 500:
+                            if (data.detail == 'User could not be removed from Canvas.') {
+                                failure.type = 'canvasError';
+                                reloadData = true;
+                            }
+                            else {
+                                failure.type = 'serverError';
+                            }
+                            break;
+
+                        default:
+                            failure.type = 'unknown';
+                            break;
+                    }
+                    $scope.clearMessages();
+                    $scope.removeFailure = failure;
+                    if (reloadData) {
+                        $scope.dtInstance.reloadData();
+                    }
+                });
+        };
+        $scope.renderId = function(data, type, full, meta) {
+            if (full.profile) {
+                return '<badge ng-cloak role="'
+                    + $scope.getProfileRoleTypeCd(full.profile)
+                    + '"></badge> ' + full.user_id;
+            } else {
+                return '<badge ng-cloak role=""></badge> ' + full.user_id;
+            }
+        };
+        $scope.renderName = function(data, type, full, meta) {
+            return $scope.getProfileFullName(full.profile) || full.user_id;
+        };
+        // hotfix added to address TA role name
+        // will be addressed with a database change as soon as
+        // devops determines viability of change
+        $scope.renderRole = function(data, type, full, meta) {
+            return /^Teaching Fellow$/.test(data) ? 'TA' : data;
+        };
+        $scope.renderRemove = function(data, type, full, meta) {
+            // TODO - maybe make this a directive?  the isolate scope
+            //        in a directive complicates things.  anything has
+            //        to be better than this mess, though.
+            var registrarFed = /^.*feed$/.test(full.source);
+            var iconClass = registrarFed ? 'fa-trash-disabled' : '';
+            var icon = '<i class="fa fa-trash-o ' + iconClass + '"></i>';
+            var linkOpen = '';
+            if (!registrarFed) {
+                linkOpen = '<a href="" ng-click="confirmRemove(' +
+                           'dtInstance.DataTable.data()[' + meta.row + '])" ' +
+                           'data-sisid="' + full.user_id + '">';
+            }
+            var linkClose = registrarFed ? '' : '</a>';
+            return '<div class="text-center">' +
+                       linkOpen + icon + linkClose + '</div>';
+        }
+        $scope.renderSource = function(data, type, full, meta) {
+            return /^.*feed$/.test(data) ? 'Registrar Added' : 'Manually Added';
+        };
+        $scope.selectRole = function(role) {
+            $scope.selectedRole = role;
+        };
+        $scope.setCourseInstance = function(id) {
+            console.log(courseInstances);
+            //var ci = courseInstances.instances[id];
+            //if (angular.isDefined(ci)) {
+            //    $scope.courseInstance = $scope.getFormattedCourseInstance(ci)
+            //}
+            //else {
+                var url = djangoUrl.reverse(
+                              'icommons_rest_api_proxy',
+                              ['api/course/v2/course_instances/' + id + '/']);
+                $http.get(url)
+                    .success(function(data, status, headers, config, statusText) {
+                        //check if the right data was obtained before storing it
+                        if (data.course_instance_id == id){
+                            courseInstances.instances[data.course_instance_id] = data;
+                            $scope.courseInstance = $scope.getFormattedCourseInstance(data)
+                        }else{
+                            $log.error(' CourseInstance record mismatch for id :'
+                                + id +',  fetched record for :' +data.id);
+                        }
+                    })
+                    .error($scope.handleAjaxError);
+            //}
+        };
+
+        $scope.getFormattedCourseInstance = function(ci) {
+            // This is a helper function that formats the CourseInstance metadata
+            // and is combination of existing logic in
+            // Searchcontroller.courseInstanceToTable and Searchcontroller cell
+            // render functions.
+
+            console.log(ci);
+            courseInstance = {};
+            if (ci) {
+                courseInstance['title']= ci.title;
+
+                courseInstance['school'] = ci.course ?
+                        ci.course.school_id.toUpperCase() : '';
+
+                courseInstance['term'] = ci.term ? ci.term.display_name : '';
+                courseInstance['year'] = ci.term ? ci.term.academic_year : '';
+                courseInstance['cid'] = ci.course_instance_id;
+
+                courseInstance['registrar_code_display'] = ci.course ?
+                        ci.course.registrar_code_display +
+                        ' (' + ci.course.course_id + ')'.trim() : '';
+
+                courseInstance['description'] = ci.description;
+                courseInstance['short_title'] = ci.short_title;
+                courseInstance['sub_title'] = ci.sub_title;
+                courseInstance['meeting_time'] = ci.meeting_time;
+                courseInstance['location'] = ci.location;
+                courseInstance['instructors_display'] = ci.instructors_display;
+                courseInstance['course_instance_id'] = ci.course_instance_id;
+
+                courseInstance['notes'] = ci.notes;
+
+                if (ci.secondary_xlist_instances &&
+                    ci.secondary_xlist_instances.length > 0) {
+                        courseInstance['xlist_status'] = 'Primary';
+                } else if (ci.primary_xlist_instances &&
+                    ci.primary_xlist_instances.length > 0) {
+                        courseInstance['xlist_status'] = 'Secondary';
+                } else {
+                        courseInstance['xlist_status'] = 'N/A';
+                }
+                courseInstance['sites'] = ci.sites;
+
+                //var sites = ci.sites || [];
+                //var siteIds =[]
+                //sites.forEach(function (site) {
+                //    site.site_id = site.external_id;
+                //    if (site.site_id.indexOf('http') === 0) {
+                //        site.site_id = site.site_id.substr(site.site_id.lastIndexOf('/')+1);
+                //    }
+                //    siteIds.push(site.site_id)
+                //});
+                //courseInstance['sites']= siteIds.length>0 ? siteIds.join(', ') : 'N/A';
+            }
+            return courseInstance;
+        };
+
+        $scope.clearMessages = function(){
+            $scope.addPartialFailure = null;
+            $scope.removeFailure = null;
+            $scope.addWarning = null;
+            $scope.success = null;
+        };
+
+        // now actually init the controller
+        $scope.addPartialFailure = null;
+        $scope.partialFailureData = null;
+        $scope.addWarning = null;
+        $scope.confirmRemoveModalInstance = null;
+        $scope.courseInstanceId = $routeParams.courseInstanceId;
+        $scope.removeFailure = null;
+
+        $scope.roles = [
+            // NOTE - these may need to be updated based on the db values
+            {roleId: 0, roleName: 'Student'},
+            {roleId: 10, roleName: 'Guest'},
+            {roleId: 14, roleName: 'Shopper'},
+            {roleId: 9, roleName: 'Teacher'},
+            {roleId: 1, roleName: 'Course Head'},
+            {roleId: 2, roleName: 'Faculty'},
+            {roleId: 12, roleName: 'Teaching Staff'},
+            {roleId: 5, roleName: 'TA'},
+            {roleId: 11, roleName: 'Course Support Staff'},
+            {roleId: 7, roleName: 'Designer'},
+            {roleId: 15, roleName: 'Observer'},
+        ];
+        $scope.searchInProgress = false;
+        $scope.searchResults = [];
+        $scope.searchTerm = '';
+        $scope.selectedResult = {id: undefined};
+        $scope.selectedRole = $scope.roles[0];
+        $scope.setCourseInstance($routeParams.courseInstanceId);
+        $scope.success = null;
+
+        // configure the datatable
+        $scope.dtInstance = null;
+        $scope.dtOptions = {
+            ajax: function(data, callback, settings) {
+                var url = djangoUrl.reverse('icommons_rest_api_proxy',
+                                            ['api/course/v2/course_instances/'
+                                             + $scope.courseInstanceId + '/people/']);
+                var queryParams = {
+                    offset: data.start,
+                    limit: data.length,
+                    '-source': 'xreg_map', // exclude xreg people
+                    ordering: (data.order[0].dir === 'desc' ? '-' : '')
+                              + $scope.sortKeyByColumnId[data.order[0].column],
+                };
+
+                $.ajax({
+                    url: url,
+                    method: 'GET',
+                    data: queryParams,
+                    dataSrc: 'data',
+                    dataType: 'json',
+                    success: function(data, textStatus, jqXHR) {
+                        callback({
+                            recordsTotal: data.count,
+                            recordsFiltered: data.count,
+                            data: data.results,
+                        });
+                    },
+                    error: function(data, textStatus, errorThrown) {
+                        $log.error('Error getting data from ' + url + ': '
+                                   + textStatus + ', ' + errorThrown);
+                        callback({
+                            recordsTotal: 0,
+                            recordsFiltered: 0,
+                            data: [],
+                        });
+                    },
+                });
+            },
+            createdRow: function( row, data, dataIndex ) {
+                // to use angular directives within the rendered datatable,
+                // we have to compile those elements ourselves.  joy.
+                $compile(angular.element(row).contents())($scope);
+            },
+            language: {
+                emptyTable: 'There are no people to display.',
+                info: 'Showing _START_ to _END_ of _TOTAL_ people',
+                infoEmpty: 'Showing 0 to 0 of 0 people',
+                paginate: {
+                    next: '',
+                    previous: '',
+                },
+            },
+            lengthMenu: [10, 25, 50, 100],
+            // yes, this is a deprecated param.  yes, it's still required.
+            // see https://datatables.net/forums/discussion/27287/using-an-ajax-custom-get-function-don-t-forget-to-set-sajaxdataprop
+            sAjaxDataProp: 'data',
+            searching: false,
+            serverSide: true,
+        };
+
+        // see hotfix note above for renderRole
+        $scope.dtColumns = [
+            {
+                data: '',
+                render: $scope.renderName,
+                title: 'Name',
+            },
+            {
+                data: '',
+                render: $scope.renderId,
+                title: 'ID',
+            },
+            {
+                data: 'role.role_name',
+                render: $scope.renderRole,
+                title: 'Role'
+            },
+            {
+                data: 'source',
+                render: $scope.renderSource,
+                title: 'Source',
+            },
+            {
+                data: '',
+                orderable: false,
+                render: $scope.renderRemove,
+                title: 'Remove',
+            },
+        ];
+    }
+})();

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -17,12 +17,12 @@
 
         dc.handleLookupResults = function(results) {
             var courseResult = results[0];
-            var peopleResult = results[1];
+            var membersResult = results[1];
 
             //check if the right data was obtained before storing it
             if (courseResult.data.course_instance_id == dc.courseInstanceId) {
                 courseInstances.instances[courseResult.data.course_instance_id] = courseResult.data;
-                dc.courseInstance = dc.getFormattedCourseInstance(courseResult.data, peopleResult.data)
+                dc.courseInstance = dc.getFormattedCourseInstance(courseResult.data, membersResult.data)
             } else {
                 $log.error(' CourseInstance record mismatch for id :'
                     + dc.courseInstanceId + ',  fetched record for :' + courseResult.data.id);
@@ -35,31 +35,30 @@
                 'icommons_rest_api_proxy',
                 ['api/course/v2/course_instances/' + id + '/']);
 
-            var people_url = djangoUrl.reverse(
+            var members_url = djangoUrl.reverse(
                 'icommons_rest_api_proxy',
                 ['api/course/v2/course_instances/'
                 + id + '/people/']);
 
             var coursePromise = $http.get(course_url)
-                .error($scope.handleAjaxError);
+                .error(dc.handleAjaxError);
 
-            var peoplePromise = $http.get(people_url)
-                .error($scope.handleAjaxError);
+            var membersPromise = $http.get(members_url)
+                .error(dc.handleAjaxError);
 
-            $q.all([coursePromise, peoplePromise])
+            $q.all([coursePromise, membersPromise])
                 .then(dc.handleLookupResults);
         };
 
         dc.stripQuotes = function(str){
-            return str ? str.trim().replace(new RegExp("^\"|\"$", "g"), "") : undefined;
+            return str ? str.trim().replace(new RegExp("^\"|\"$", "g"), "") : '';
         };
 
-        dc.getFormattedCourseInstance = function (ci, people) {
+        dc.getFormattedCourseInstance = function (ci, members) {
             // This is a helper function that formats the CourseInstance metadata
             // and is combination of existing logic in
             // Searchcontroller.courseInstanceToTable and Searchcontroller cell
             // render functions.
-
             courseInstance = {};
             if (ci) {
                 courseInstance['title'] = dc.stripQuotes(ci.title);
@@ -67,21 +66,21 @@
                     ci.course.school_id.toUpperCase() : '';
                 courseInstance['term'] = ci.term ? ci.term.display_name : '';
                 courseInstance['year'] = ci.term ? ci.term.academic_year : '';
-                courseInstance['departments'] = ci.course.departments;
-                courseInstance['course_groups'] = ci.course.course_groups;
+                courseInstance['departments'] = ci.course.departments ? ci.course.departments : [];
+                courseInstance['course_groups'] = ci.course.course_groups ? ci.course.course_groups : [];
                 courseInstance['cid'] = ci.course_instance_id;
                 courseInstance['registrar_code_display'] = ci.course ?
                 ci.course.registrar_code_display +
                 ' (' + ci.course.course_id + ')'.trim() : '';
                 courseInstance['description'] = dc.stripQuotes(ci.description);
                 courseInstance['short_title'] = dc.stripQuotes(ci.short_title);
-                courseInstance['sub_title'] = ci.sub_title;
-                courseInstance['meeting_time'] = ci.meeting_time;
+                courseInstance['sub_title'] = ci.sub_title ? ci.sub_title : '';
+                courseInstance['meeting_time'] = ci.meeting_time ? ci.meeting_time : '';
                 courseInstance['location'] = ci.location;
-                courseInstance['instructors_display'] = ci.instructors_display;
+                courseInstance['instructors_display'] = ci.instructors_display ? ci.instructors_display : '';
                 courseInstance['course_instance_id'] = ci.course_instance_id;
                 courseInstance['notes'] = dc.stripQuotes(ci.notes);
-                courseInstance['conclude_date'] = ci.conclude_date;
+                courseInstance['conclude_date'] = ci.conclude_date ? ci.conclude_date : '';
 
                 if (ci.secondary_xlist_instances &&
                     ci.secondary_xlist_instances.length > 0) {
@@ -93,11 +92,10 @@
                     courseInstance['xlist_status'] = 'N/A';
                 }
 
-                courseInstance['sites'] = ci.sites;
+                courseInstance['sites'] = ci.sites ? ci.sites : [];
             }
-            if(people){
-                courseInstance['members'] = people.count;
-            }
+            courseInstance['members'] = members.count ? members.count : 0;
+
             return courseInstance;
         };
 

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -1,4 +1,6 @@
-// TODO - split out add/remove into separate controllers?
+
+// TODO - this is pretty much a copy of the people controller with some mods.
+// TODO - this still needs a lot of clean up, we don't need everything in here
 
 (function() {
     var app = angular.module('CourseInfo');

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -52,6 +52,7 @@
                 courseInstance['term'] = ci.term ? ci.term.display_name : '';
                 courseInstance['year'] = ci.term ? ci.term.academic_year : '';
                 courseInstance['departments'] = ci.course.departments;
+                courseInstance['course_groups'] = ci.course.course_groups;
                 courseInstance['cid'] = ci.course_instance_id;
                 courseInstance['registrar_code_display'] = ci.course ?
                 ci.course.registrar_code_display +

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -25,7 +25,7 @@
                     //check if the right data was obtained before storing it
                     if (data.course_instance_id == id) {
                         courseInstances.instances[data.course_instance_id] = data;
-                        $scope.courseInstance = dc.getFormattedCourseInstance(data)
+                        dc.courseInstance = dc.getFormattedCourseInstance(data)
                     } else {
                         $log.error(' CourseInstance record mismatch for id :'
                             + id + ',  fetched record for :' + data.id);
@@ -35,7 +35,7 @@
         };
 
         dc.stripQuotes = function(str){
-            return str.trim().replace(new RegExp("^\"|\"$", "g"), "");
+            return str ? str.trim().replace(new RegExp("^\"|\"$", "g"), "") : undefined;
         };
 
         dc.getFormattedCourseInstance = function (ci) {
@@ -51,6 +51,7 @@
                     ci.course.school_id.toUpperCase() : '';
                 courseInstance['term'] = ci.term ? ci.term.display_name : '';
                 courseInstance['year'] = ci.term ? ci.term.academic_year : '';
+                courseInstance['departments'] = ci.course.departments;
                 courseInstance['cid'] = ci.course_instance_id;
                 courseInstance['registrar_code_display'] = ci.course ?
                 ci.course.registrar_code_display +
@@ -63,6 +64,7 @@
                 courseInstance['instructors_display'] = ci.instructors_display;
                 courseInstance['course_instance_id'] = ci.course_instance_id;
                 courseInstance['notes'] = dc.stripQuotes(ci.notes);
+                courseInstance['conclude_date'] = ci.conclude_date;
 
                 if (ci.secondary_xlist_instances &&
                     ci.secondary_xlist_instances.length > 0) {
@@ -73,6 +75,7 @@
                 } else {
                     courseInstance['xlist_status'] = 'N/A';
                 }
+
                 courseInstance['sites'] = ci.sites;
             }
             return courseInstance;

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -51,6 +51,9 @@
         };
 
         dc.stripQuotes = function(str){
+            // soem fields are coming over with quotes around them and those quotes
+            // are being displayed in the html.
+            // This strips off double quotes from the begining and ending of fields
             return str ? str.trim().replace(new RegExp("^\"|\"$", "g"), "") : '';
         };
 

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -74,7 +74,7 @@
                 ' (' + ci.course.course_id + ')'.trim() : '';
                 courseInstance['description'] = dc.stripQuotes(ci.description);
                 courseInstance['short_title'] = dc.stripQuotes(ci.short_title);
-                courseInstance['sub_title'] = ci.sub_title ? ci.sub_title : '';
+                courseInstance['sub_title'] = ci.sub_title ? dc.stripQuotes(ci.sub_title) : '';
                 courseInstance['meeting_time'] = ci.meeting_time ? ci.meeting_time : '';
                 courseInstance['location'] = ci.location;
                 courseInstance['instructors_display'] = ci.instructors_display ? ci.instructors_display : '';

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -472,7 +472,7 @@
                         ci.course.school_id.toUpperCase() : '';
                 courseInstance['term'] = ci.term ? ci.term.display_name : '';
                 courseInstance['year'] = ci.term ? ci.term.academic_year : '';
-                courseInstance['cid'] = ci.course_instance_id;
+                courseInstance['course_instance_id'] = ci.course_instance_id;
                 courseInstance['registrar_code_display'] = ci.course ?
                         ci.course.registrar_code_display +
                         ' (' + ci.course.course_id + ')'.trim() : '';

--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -234,7 +234,7 @@
                         {
                             data: null,
                             render: function(data, type, row, meta) {
-                                var url = '#/people/' + row.cid;
+                                var url = '#/details/' + row.cid;
                                 return '<a href="' + url + '">' + row.description + '</a>';
                             },
                         },

--- a/course_info/templates/course_info/index.html
+++ b/course_info/templates/course_info/index.html
@@ -56,6 +56,7 @@
     <script src="{% static 'course_info/js/app.js' %}"></script>
     <script src="{% static 'course_info/js/controllers/SearchController.js' %}"></script>
     <script src="{% static 'course_info/js/controllers/PeopleController.js' %}"></script>
+    <script src="{% static 'course_info/js/controllers/DetailsController.js' %}"></script>
     <script src="{% static 'course_info/js/services/CourseInstancesService.js' %}"></script>
     <script src="{% static 'course_info/js/directives/BadgeDirective.js' %}"></script>
   </body>

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -21,7 +21,7 @@
                     <div class="col-md-2">
                         <strong>Course Code: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.registrar_code_display }}</div>
+                    <div class="col-md-10">{{dc.courseInstance.registrar_code_display }}</div>
                 </div>
             </li>
 
@@ -30,9 +30,9 @@
                     <div class="col-md-2">
                         <strong>Cross Listing: </strong>
                     </div>
-                    <div class="col-md-10" ng-switch on="courseInstance.xlist_status">
+                    <div class="col-md-10" ng-switch on="dc.courseInstance.xlist_status">
                         <span ng-switch-when="Primary" class="label label-info">Primary</span>
-                        <span ng-switch-when="Secondary" class="label label-info">Secondary {{courseInstance.xlist_status}}</span>
+                        <span ng-switch-when="Secondary" class="label label-info">Secondary</span>
                         <span ng-switch-default class="label label-info">N/A</span>
                     </div>
                 </div>
@@ -43,7 +43,7 @@
                     <div class="col-md-2">
                         <strong>Term: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.term}}</div>
+                    <div class="col-md-10">{{dc.courseInstance.term}}</div>
                 </div>
             </li>
 
@@ -52,7 +52,7 @@
                     <div class="col-md-2">
                         <strong>SIS/Course Instance ID: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.course_instance_id}}</div>
+                    <div class="col-md-10">{{dc.courseInstance.course_instance_id}}</div>
                 </div>
             </li>
 
@@ -61,7 +61,7 @@
                     <div class="col-md-2">
                         <strong>Course Title: </strong>
                     </div>
-                    <div class="col-md-10" ng-bind-html="courseInstance.title"></div>
+                    <div class="col-md-10" ng-bind-html="dc.courseInstance.title"></div>
                 </div>
             </li>
 
@@ -70,7 +70,7 @@
                     <div class="col-md-2">
                         <strong>Short Title: </strong>
                     </div>
-                    <div class="col-md-10" ng-bind-html="courseInstance.short_title"></div>
+                    <div class="col-md-10" ng-bind-html="dc.courseInstance.short_title"></div>
                 </div>
             </li>
 
@@ -79,7 +79,7 @@
                     <div class="col-md-2">
                         <strong>Subtitle: </strong>
                     </div>
-                    <div class="col-md-10" ng-bind-html="courseInstance.sub_title"></div>
+                    <div class="col-md-10" ng-bind-html="dc.courseInstance.sub_title"></div>
                 </div>
             </li>
 
@@ -88,7 +88,7 @@
                     <div class="col-md-2">
                         <strong>Description: </strong>
                     </div>
-                    <div class="col-md-10" ng-bind-html="courseInstance.description"></div>
+                    <div class="col-md-10" ng-bind-html="dc.courseInstance.description"></div>
                 </div>
             </li>
 
@@ -97,7 +97,7 @@
                     <div class="col-md-2">
                         <strong>Notes: </strong>
                     </div>
-                    <div class="col-md-10" ng-bind-html="courseInstance.notes"></div>
+                    <div class="col-md-10" ng-bind-html="dc.courseInstance.notes"></div>
                 </div>
             </li>
 
@@ -106,7 +106,7 @@
                     <div class="col-md-2">
                         <strong>Instructors (display): </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.instructors_display}}</div>
+                    <div class="col-md-10">{{dc.courseInstance.instructors_display}}</div>
                 </div>
             </li>
 
@@ -115,7 +115,7 @@
                     <div class="col-md-2">
                         <strong>People: </strong>
                     </div>
-                    <div class="col-md-10"><a href="#/people/{{courseInstance.cid}}">people</a></div>
+                    <div class="col-md-10"><a href="#/people/{{dc.courseInstance.cid}}">people</a></div>
                 </div>
             </li>
 
@@ -124,7 +124,7 @@
                     <div class="col-md-2">
                         <strong>Location: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.location}}</div>
+                    <div class="col-md-10">{{dc.courseInstance.location}}</div>
                 </div>
             </li>
 
@@ -133,7 +133,7 @@
                     <div class="col-md-2">
                         <strong>Meeting Time: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.meeting_time}}</div>
+                    <div class="col-md-10">{{dc.courseInstance.meeting_time}}</div>
                 </div>
             </li>
 
@@ -142,16 +142,28 @@
                     <div class="col-md-2">
                         <strong>Departments: </strong>
                     </div>
-                    <div class="col-md-10" ng-repeat="dept in departments">{{dept.name}}</div>
+                    <div class="col-md-10" ng-repeat="dept in dc.courseInstance.departments">
+                         <div class="list-group" ng-if="dc.courseInstance.departments.length > 0">
+                            <div class="list-group-item list-group-sub-item" ng-repeat="dept in dc.courseInstance.departments">
+                                {{dept.name}}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </li>
 
             <li class="list-group-item">
                 <div class="row">
                     <div class="col-md-2">
-                        <strong>Course Group: </strong>
+                        <strong>Course Groups: </strong>
                     </div>
-                    <div class="col-md-10">todo</div>
+                    <div class="col-md-10">
+                        <div class="list-group">
+                            <div class="list-group-item list-group-sub-item" ng-repeat="group in dc.courseInstance.course_groups">
+                                {{group.name}}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </li>
 
@@ -162,13 +174,9 @@
                     </div>
                     <div class="col-md-10">
                         <div class="list-group">
-                            <div class="list-group-item list-group-sub-item" ng-repeat="site in courseInstance.sites">
-
-                                <div class="label label-primary col-md-1">Official</div>
-
-                                <!-- TO DO - honor the Official/Unofficial status of the course -->
-                                <!--<div class="label label-default col-md-1">Unofficial</div>-->
-
+                            <div class="list-group-item list-group-sub-item" ng-repeat="site in dc.courseInstance.sites">
+                                <div class="label label-primary col-md-1" ng-if="site.map_type == 'official'">Official</div>
+                                <div class="label label-primary col-md-1" ng-if="site.map_type == 'unofficial'">Unofficial</div>
                                 <div class="col-md-11"><a href="{{site.course_site_url}}"
                                                           target="_blank">{{site.course_site_url}}</a>
                                 </div>

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -115,7 +115,15 @@
                     <div class="col-md-2">
                         <strong>People: </strong>
                     </div>
-                    <div class="col-md-10"><a href="#/people/{{dc.courseInstance.cid}}">people</a></div>
+                    <div class="col-md-10">
+                        <a href="#/people/{{dc.courseInstance.cid}}">
+                            <ng-pluralize count="dc.courseInstance.members"
+                                          when="{'0': 'There are no people in the course.',
+                                'one': 'There is one person in the course.',
+                                'other': 'There are {} people in the course.'}">
+                            </ng-pluralize>
+                        </a>
+                    </div>
                 </div>
             </li>
 

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -1,0 +1,205 @@
+{% verbatim %}
+
+<nav>
+    <h3 class="breadcrumbs">
+        {% endverbatim %}
+        <a href="{% url 'dashboard_account' %}">Admin Console</a>
+        &gt; <a href="#/">Find Course Info</a>
+        {% verbatim %}
+        <small><i class="fa fa-chevron-right"></i></small>
+        People in {{courseInstance.title}}
+    </h3>
+</nav>
+
+<main class="float=left col=60">
+    <div class="container-fluid">
+
+        <ul class="list-group">
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Course Code: </strong>
+                    </div>
+                    <div class="col-md-10">{{courseInstance.registrar_code_display }}</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Cross Listing: </strong>
+                    </div>
+                    <div class="col-md-10">
+                        <span ng-show="courseInstance.xlist_status == 'Primary'" class="label label-info">Primary</span>
+                        <span ng-show="courseInstance.xlist_status == 'Secondary'" class="label label-info">Secondary</span>
+                    </div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Term: </strong>
+                    </div>
+                    <div class="col-md-10">{{courseInstance.term}}</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>SIS/Course Instance ID: </strong>
+                    </div>
+                    <div class="col-md-10">{{courseInstance.course_instance_id}}</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Course Title: </strong>
+                    </div>
+                    <div class="col-md-10">{{courseInstance.title}}</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Short Title: </strong>
+                    </div>
+                    <div class="col-md-10">{{courseInstance.short_title}}</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Subtitle: </strong>
+                    </div>
+                    <div class="col-md-10">{{courseInstance.sub_title}}</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Description: </strong>
+                    </div>
+                    <div class="col-md-10">{{courseInstance.description}}</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Notes: </strong>
+                    </div>
+                    <div class="col-md-10">
+                        {{courseInstance.notes}}
+                    </div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Instructors (display): </strong>
+                    </div>
+                    <div class="col-md-10">{{courseInstance.instructors_display}}</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>People: </strong>
+                    </div>
+                    <div class="col-md-10"><a href="#/people/{{courseInstance.cid}}">people</a></div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Location: </strong>
+                    </div>
+                    <div class="col-md-10">{{courseInstance.location}}</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Meeting Time: </strong>
+                    </div>
+                    <div class="col-md-10">{{courseInstance.meeting_time}}</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Department: </strong>
+                    </div>
+                    <div class="col-md-10">Romance Languages and Literatures</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Course Group: </strong>
+                    </div>
+                    <div class="col-md-10">Portuguese</div>
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Associated Official and Unofficial Site(s): </strong>
+                    </div>
+                    <div class="col-md-10">
+                        <div class="list-group">
+                            <div class="list-group-item list-group-sub-item" ng-repeat="site in courseInstance.sites">
+
+                                <div class="label label-primary col-md-1">Official</div>
+
+                                <div class="col-md-11"><a href="{{site.course_site_url}}"
+                                                          target="_blank">{{site.course_site_url}}</a>
+                                </div>
+                            </div>
+                            <!--<div class="list-group-item list-group-sub-item">-->
+                                <!--<div class="label label-default col-md-1">Unofficial</div>-->
+                                <!--<div class="col-md-11"><a href="http://isites.harvard.edu/icb/icb.do?keyword=k96235"-->
+                                                          <!--target="_blank">http://isites.harvard.edu/icb/icb.do?keyword=k96235</a>-->
+                                <!--</div>-->
+                            <!--</div>-->
+                            <!--<div class="list-group-item list-group-sub-item">-->
+                                <!--<div class="label label-default col-md-1">Unofficial</div>-->
+                                <!--<div class="col-md-11"><a href="https://wordpress.org/showcase/harvard-gazette-online/"-->
+                                                          <!--target="_blank">https://wordpress.org/showcase/harvard-gazette-online/</a>-->
+                                <!--</div>-->
+                            <!--</div>-->
+                        </div>
+                    </div>
+
+                </div>
+            </li>
+
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-md-2">
+                        <strong>Conclusion Date: </strong>
+                    </div>
+                    <div class="col-md-10">&nbsp;</div>
+                </div>
+            </li>
+
+        </ul>
+    </div>
+</main>
+
+{% endverbatim %}

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -140,9 +140,9 @@
             <li class="list-group-item">
                 <div class="row">
                     <div class="col-md-2">
-                        <strong>Department: </strong>
+                        <strong>Departments: </strong>
                     </div>
-                    <div class="col-md-10">Romance Languages and Literatures</div>
+                    <div class="col-md-10" ng-repeat="dept in departments">{{dept.name}}</div>
                 </div>
             </li>
 
@@ -184,7 +184,7 @@
                     <div class="col-md-2">
                         <strong>Conclusion Date: </strong>
                     </div>
-                    <div class="col-md-10">&nbsp;</div>
+                    <div class="col-md-10">{{courseInstance.conclude_date}}</div>
                 </div>
             </li>
 

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -116,7 +116,7 @@
                         <strong>People: </strong>
                     </div>
                     <div class="col-md-10">
-                        <a href="#/people/{{dc.courseInstance.cid}}">
+                        <a href="#/people/{{dc.courseInstance.course_instance_id}}">
                             <ng-pluralize count="dc.courseInstance.members"
                                           when="{'0': 'There are no people in the course.',
                                 'one': 'There is one person in the course.',

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -11,7 +11,7 @@
     </h3>
 </nav>
 
-<main class="float=left col=60">
+<main class="float-left col-60">
     <div class="container-fluid">
 
         <ul class="list-group">
@@ -183,8 +183,10 @@
                     <div class="col-md-10">
                         <div class="list-group">
                             <div class="list-group-item list-group-sub-item" ng-repeat="site in dc.courseInstance.sites">
-                                <div class="label label-primary col-md-1" ng-if="site.map_type == 'official'">Official</div>
-                                <div class="label label-primary col-md-1" ng-if="site.map_type == 'unofficial'">Unofficial</div>
+                                <div ng-switch on="site.map_type">
+                                    <div class="label label-primary col-md-1" ng-switch-when="official">Official</div>
+                                    <div class="label label-primary col-md-1" ng-switch-when="unofficial">Unofficial</div>
+                                </div>
                                 <div class="col-md-11"><a href="{{site.course_site_url}}"
                                                           target="_blank">{{site.course_site_url}}</a>
                                 </div>

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -7,7 +7,7 @@
         &gt; <a href="#/">Find Course Info</a>
         {% verbatim %}
         <small><i class="fa fa-chevron-right"></i></small>
-        People in {{courseInstance.title}}
+        Details for {{courseInstance.title}}
     </h3>
 </nav>
 
@@ -30,9 +30,10 @@
                     <div class="col-md-2">
                         <strong>Cross Listing: </strong>
                     </div>
-                    <div class="col-md-10">
-                        <span ng-show="courseInstance.xlist_status == 'Primary'" class="label label-info">Primary</span>
-                        <span ng-show="courseInstance.xlist_status == 'Secondary'" class="label label-info">Secondary</span>
+                    <div class="col-md-10" ng-switch on="courseInstance.xlist_status">
+                        <span ng-switch-when="Primary" class="label label-info">Primary</span>
+                        <span ng-switch-when="Secondary" class="label label-info">Secondary {{courseInstance.xlist_status}}</span>
+                        <span ng-switch-default class="label label-info">N/A</span>
                     </div>
                 </div>
             </li>
@@ -60,7 +61,7 @@
                     <div class="col-md-2">
                         <strong>Course Title: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.title}}</div>
+                    <div class="col-md-10" ng-bind-html="courseInstance.title"></div>
                 </div>
             </li>
 
@@ -69,7 +70,7 @@
                     <div class="col-md-2">
                         <strong>Short Title: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.short_title}}</div>
+                    <div class="col-md-10" ng-bind-html="courseInstance.short_title"></div>
                 </div>
             </li>
 
@@ -78,7 +79,7 @@
                     <div class="col-md-2">
                         <strong>Subtitle: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.sub_title}}</div>
+                    <div class="col-md-10" ng-bind-html="courseInstance.sub_title"></div>
                 </div>
             </li>
 
@@ -87,7 +88,7 @@
                     <div class="col-md-2">
                         <strong>Description: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.description}}</div>
+                    <div class="col-md-10" ng-bind-html="courseInstance.description"></div>
                 </div>
             </li>
 
@@ -96,9 +97,7 @@
                     <div class="col-md-2">
                         <strong>Notes: </strong>
                     </div>
-                    <div class="col-md-10">
-                        {{courseInstance.notes}}
-                    </div>
+                    <div class="col-md-10" ng-bind-html="courseInstance.notes"></div>
                 </div>
             </li>
 
@@ -152,7 +151,7 @@
                     <div class="col-md-2">
                         <strong>Course Group: </strong>
                     </div>
-                    <div class="col-md-10">Portuguese</div>
+                    <div class="col-md-10">todo</div>
                 </div>
             </li>
 
@@ -167,22 +166,13 @@
 
                                 <div class="label label-primary col-md-1">Official</div>
 
+                                <!-- TO DO - honor the Official/Unofficial status of the course -->
+                                <!--<div class="label label-default col-md-1">Unofficial</div>-->
+
                                 <div class="col-md-11"><a href="{{site.course_site_url}}"
                                                           target="_blank">{{site.course_site_url}}</a>
                                 </div>
                             </div>
-                            <!--<div class="list-group-item list-group-sub-item">-->
-                                <!--<div class="label label-default col-md-1">Unofficial</div>-->
-                                <!--<div class="col-md-11"><a href="http://isites.harvard.edu/icb/icb.do?keyword=k96235"-->
-                                                          <!--target="_blank">http://isites.harvard.edu/icb/icb.do?keyword=k96235</a>-->
-                                <!--</div>-->
-                            <!--</div>-->
-                            <!--<div class="list-group-item list-group-sub-item">-->
-                                <!--<div class="label label-default col-md-1">Unofficial</div>-->
-                                <!--<div class="col-md-11"><a href="https://wordpress.org/showcase/harvard-gazette-online/"-->
-                                                          <!--target="_blank">https://wordpress.org/showcase/harvard-gazette-online/</a>-->
-                                <!--</div>-->
-                            <!--</div>-->
                         </div>
                     </div>
 

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -31,7 +31,7 @@
               <td class="sorting" tabindex="0">{{courseInstance.year}}</td>
               <td class="sorting" tabindex="0">{{courseInstance.sites}}</td>
               <td class="sorting" tabindex="0">{{courseInstance.registrar_code_display }}</td>
-              <td class="sorting" tabindex="0">{{courseInstance.cid}}</td>
+              <td class="sorting" tabindex="0">{{courseInstance.course_instance_id}}</td>
               <td class="sorting" tabindex="0">{{courseInstance.xlist_status}}</td>
             </tr>
           </tbody>

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -4,8 +4,10 @@
   <h3 class="breadcrumbs">
     {% endverbatim %}
     <a href="{% url 'dashboard_account' %}">Admin Console</a>
-    &gt; <a href="#/">Find Course Info</a>
     {% verbatim %}
+    &gt; <a href="#/">Find Course Info</a>
+    &gt; <a href="#/details/{{courseInstance.cid}}">Details</a>
+
     <small><i class="fa fa-chevron-right"></i></small>
     People in {{courseInstance.title}}
   </h3>

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -14,7 +14,7 @@
 </nav>
 
 
-<main class="float=left col=60">
+<main class="float-left col-60">
 <div class="container-fluid">
 
   <div class="col-md-12">

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -59,7 +59,7 @@ describe('Unit testing DetailsController', function () {
 
     describe('setup', function () {
         beforeEach(function () {
-            controller = $controller('DetailsController', {$scope: scope});
+            dc = $controller('DetailsController', {$scope: scope});
         });
 
         afterEach(function () {
@@ -88,6 +88,10 @@ describe('Unit testing DetailsController', function () {
                 course: {
                     school_id: 'abc',
                     registrar_code_display: '2222'
+                },
+                term: {
+                    display_name: 'Summer 2015',
+                    academic_year: '2015',
                 }
             };
             members = {
@@ -105,7 +109,7 @@ describe('Unit testing DetailsController', function () {
             expect(dc.courseInstance['members']).toEqual(100);
         });
 
-        it('should work when CourseInstance returns invalid id', function () {
+        it('should log an error when CourseInstance returns an invalid id', function () {
             controller = $controller('DetailsController', {$scope: scope});
             ci.course_instance_id = 12345;
             spyOn($log, 'error');
@@ -113,35 +117,6 @@ describe('Unit testing DetailsController', function () {
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify(members));
             $httpBackend.flush(2);
             expect($log.error).toHaveBeenCalled();
-        });
-    });
-
-    describe('stripQuotes', function () {
-        var ci;
-        var members;
-        beforeEach(function () {
-            // if we want to pull the instance id from $routeParams, this has
-            // to be in a beforeEach(), can't be in a describe().
-            ci = {
-                course_instance_id: $routeParams.courseInstanceId,
-                title: '"Test Title"',
-                course: {
-                    school_id: 'abc',
-                    registrar_code_display: '2222'
-                }
-            };
-            members = {
-                count: 100
-            };
-        });
-
-        it('should strip the quotes from the string', function () {
-            controller = $controller('DetailsController', {$scope: scope});
-            result = dc.stripQuotes(ci.title);
-            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
-            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify(members));
-            $httpBackend.flush(2);
-            expect('Test Title').toEqual(result);
         });
     });
 
@@ -154,7 +129,7 @@ describe('Unit testing DetailsController', function () {
                 title: 'Test Title',
                 short_title: 'Test',
                 sub_title: 'Jasime is your friend',
-                description: '"<p>hello</p>"',
+                description: '<p>hello</p>',
                 sites: [
                     {
                         external_id: 'https://x.y.z/888',
@@ -204,7 +179,7 @@ describe('Unit testing DetailsController', function () {
             courseInstances.instances[ci.course_instance_id] = ci;
             dc = $controller('DetailsController', {$scope: scope});
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
-            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({}));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify(members));
             $httpBackend.flush(2);
             expect(dc.courseInstance['title']).toEqual(ci.title);
             expect(dc.courseInstance['short_title']).toEqual(ci.short_title);
@@ -215,23 +190,25 @@ describe('Unit testing DetailsController', function () {
             expect(dc.courseInstance['course_groups']).toEqual(ci.course.course_groups);
             expect(dc.courseInstance['departments']).toEqual(ci.course.departments);
             expect(dc.courseInstance['year']).toEqual(ci.term.academic_year);
-            expect(dc.courseInstance['cid']).toEqual(ci.course_instance_id);
+            expect(dc.courseInstance['course_instance_id']).toEqual(ci.course_instance_id);
             expect(dc.courseInstance['registrar_code_display']).toEqual(
                 ci.course.registrar_code_display + ' (' + ci.course.course_id + ')');
             expect(dc.courseInstance['sites']).toEqual(ci.sites);
             expect(dc.courseInstance['xlist_status']).toEqual('N/A');
             expect(dc.courseInstance['description']).toEqual('<p>hello</p>');
             // members.count is not defined it should equal 0
-            expect(dc.courseInstance['members']).toEqual(0);
+            expect(dc.courseInstance['members']).toEqual(100);
 
         });
 
         it('should deal with an empty ci', function () {
             dc = $controller('DetailsController', {$scope: scope});
+            spyOn($log, 'error');
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({}));
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({}));
             $httpBackend.flush(2);
             expect(dc.courseInstance).toEqual(undefined);
+            expect($log.error).toHaveBeenCalled();
         });
     });
 });

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -226,7 +226,7 @@ describe('Unit testing DetailsController', function () {
 
         });
 
-        it('should deal with no ci', function () {
+        it('should deal with an empty ci', function () {
             dc = $controller('DetailsController', {$scope: scope});
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({}));
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({}));

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -1,0 +1,131 @@
+describe('Unit testing DetailsController', function() {
+    var $controller, $rootScope, $routeParams, courseInstances, $compile, djangoUrl,
+        $httpBackend, $window, $log, $uibModal, $sce;
+
+    var controller, scope;
+    var courseInstanceId = 1234567890;
+    var courseInstanceURL =
+        '/angular/reverse/?djng_url_name=icommons_rest_api_proxy&djng_url_args' +
+        '=api%2Fcourse%2Fv2%2Fcourse_instances%2F' + courseInstanceId + '%2F';
+
+    // set up the test environment
+    beforeEach(function () {
+        module('CourseInfo');
+        inject(function (_$controller_, _$rootScope_, _$routeParams_, _courseInstances_,
+                         _$compile_, _djangoUrl_, _$httpBackend_, _$window_, _$log_,
+                         _$uibModal_, _$sce_) {
+            $controller = _$controller_;
+            $rootScope = _$rootScope_;
+            $routeParams = _$routeParams_;
+            courseInstances = _courseInstances_;
+            $compile = _$compile_;
+            djangoUrl = _djangoUrl_;
+            $httpBackend = _$httpBackend_;
+            $window = _$window_;
+            $log = _$log_;
+            $uibModal = _$uibModal_;
+            $sce = _$sce_;
+
+            // this comes from django_auth_lti, just stub it out so that the $httpBackend
+            // sanity checks in afterEach() don't fail
+            $window.globals = {
+                append_resource_link_id: function (url) {
+                    return url;
+                }
+            };
+        });
+        scope = $rootScope.$new();
+        $routeParams.courseInstanceId = courseInstanceId;
+    });
+
+    afterEach(function () {
+        // sanity checks to make sure no http calls are still pending
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+        // DI sanity check
+    it('should inject the providers we requested', function() {
+        [$controller, $rootScope, $routeParams, courseInstances, $compile,
+         djangoUrl, $httpBackend, $window, $log, $sce].forEach(function(thing) {
+            expect(thing).not.toBeUndefined();
+            expect(thing).not.toBeNull();
+        });
+    });
+
+    describe('setup', function() {
+        beforeEach(function() {
+            controller = $controller('DetailsController', {$scope: scope });
+        });
+
+        afterEach(function() {
+            // handle the course instance get from setTitle, so we can always
+            // assert at the end of a test that there's no pending http calls.
+            $httpBackend.expectGET(courseInstanceURL).respond(200, '');
+            $httpBackend.flush(1);
+        });
+
+        it('should set the course instance id', function() {
+            expect(dc.courseInstanceId).toEqual($routeParams.courseInstanceId);
+        });
+
+    });
+
+    describe('setCourseInstance', function() {
+        var ci;
+        beforeEach(function() {
+            // if we want to pull the instance id from $routeParams, this has
+            // to be in a beforeEach(), can't be in a describe().
+            ci = {
+                course_instance_id: $routeParams.courseInstanceId,
+                title: 'Test Title',
+                course: {
+                    school_id: 'abc',
+                    registrar_code_display: '2222'
+                }
+            };
+        });
+
+        it('should work when CourseInstance is empty', function() {
+            controller = $controller('DetailsController', {$scope: scope});
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
+            $httpBackend.flush(1);
+            expect(dc.courseInstance['title']).toEqual(ci.title);
+            expect(dc.courseInstance['school']).toEqual(ci.course.school_id.toUpperCase());
+        });
+
+        it('should work when CourseInstance returns invalid id', function() {
+            controller = $controller('DetailsController', {$scope: scope});
+            ci.course_instance_id = 12345;
+            spyOn($log, 'error');
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
+            $httpBackend.flush(1);
+            expect($log.error).toHaveBeenCalled();
+        });
+    });
+
+    describe('stripQuotes', function(){
+        var ci;
+        beforeEach(function() {
+            // if we want to pull the instance id from $routeParams, this has
+            // to be in a beforeEach(), can't be in a describe().
+            ci = {
+                course_instance_id: $routeParams.courseInstanceId,
+                title: '"Test Title"',
+                course: {
+                    school_id: 'abc',
+                    registrar_code_display: '2222'
+                }
+            };
+        });
+
+        it('should strip the quotes from the string', function(){
+            controller = $controller('DetailsController', {$scope: scope});
+            result = dc.stripQuotes(ci.title);
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
+            $httpBackend.flush(1);
+            expect('Test Title').toEqual(result);
+        });
+    });
+
+});

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -1,4 +1,4 @@
-describe('Unit testing DetailsController', function() {
+describe('Unit testing DetailsController', function () {
     var $controller, $rootScope, $routeParams, courseInstances, $compile, djangoUrl,
         $httpBackend, $window, $log, $uibModal, $sce;
 
@@ -7,6 +7,10 @@ describe('Unit testing DetailsController', function() {
     var courseInstanceURL =
         '/angular/reverse/?djng_url_name=icommons_rest_api_proxy&djng_url_args' +
         '=api%2Fcourse%2Fv2%2Fcourse_instances%2F' + courseInstanceId + '%2F';
+
+    var peopleURL =
+        '/angular/reverse/?djng_url_name=icommons_rest_api_proxy&djng_url_args' +
+        '=api%2Fcourse%2Fv2%2Fcourse_instances%2F' + courseInstanceId + '%2Fpeople%2F';
 
     // set up the test environment
     beforeEach(function () {
@@ -44,36 +48,38 @@ describe('Unit testing DetailsController', function() {
         $httpBackend.verifyNoOutstandingRequest();
     });
 
-        // DI sanity check
-    it('should inject the providers we requested', function() {
+    // DI sanity check
+    it('should inject the providers we requested', function () {
         [$controller, $rootScope, $routeParams, courseInstances, $compile,
-         djangoUrl, $httpBackend, $window, $log, $sce].forEach(function(thing) {
+            djangoUrl, $httpBackend, $window, $log, $sce].forEach(function (thing) {
             expect(thing).not.toBeUndefined();
             expect(thing).not.toBeNull();
         });
     });
 
-    describe('setup', function() {
-        beforeEach(function() {
-            controller = $controller('DetailsController', {$scope: scope });
+    describe('setup', function () {
+        beforeEach(function () {
+            controller = $controller('DetailsController', {$scope: scope});
         });
 
-        afterEach(function() {
+        afterEach(function () {
             // handle the course instance get from setTitle, so we can always
             // assert at the end of a test that there's no pending http calls.
             $httpBackend.expectGET(courseInstanceURL).respond(200, '');
-            $httpBackend.flush(1);
+            $httpBackend.expectGET(peopleURL).respond(200, '');
+            $httpBackend.flush(2);
         });
 
-        it('should set the course instance id', function() {
+        it('should set the course instance id', function () {
             expect(dc.courseInstanceId).toEqual($routeParams.courseInstanceId);
         });
 
     });
 
-    describe('setCourseInstance', function() {
+    describe('setCourseInstance', function () {
         var ci;
-        beforeEach(function() {
+        var members;
+        beforeEach(function () {
             // if we want to pull the instance id from $routeParams, this has
             // to be in a beforeEach(), can't be in a describe().
             ci = {
@@ -84,29 +90,36 @@ describe('Unit testing DetailsController', function() {
                     registrar_code_display: '2222'
                 }
             };
+            members = {
+                count: 100
+            };
         });
 
-        it('should work when CourseInstance is empty', function() {
-            controller = $controller('DetailsController', {$scope: scope});
+        it('should work when CourseInstance is empty', function () {
+            var dc = $controller('DetailsController', {$scope: scope});
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
-            $httpBackend.flush(1);
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify(members));
+            $httpBackend.flush(2);
             expect(dc.courseInstance['title']).toEqual(ci.title);
             expect(dc.courseInstance['school']).toEqual(ci.course.school_id.toUpperCase());
+            expect(dc.courseInstance['members']).toEqual(100);
         });
 
-        it('should work when CourseInstance returns invalid id', function() {
+        it('should work when CourseInstance returns invalid id', function () {
             controller = $controller('DetailsController', {$scope: scope});
             ci.course_instance_id = 12345;
             spyOn($log, 'error');
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
-            $httpBackend.flush(1);
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify(members));
+            $httpBackend.flush(2);
             expect($log.error).toHaveBeenCalled();
         });
     });
 
-    describe('stripQuotes', function(){
+    describe('stripQuotes', function () {
         var ci;
-        beforeEach(function() {
+        var members;
+        beforeEach(function () {
             // if we want to pull the instance id from $routeParams, this has
             // to be in a beforeEach(), can't be in a describe().
             ci = {
@@ -117,15 +130,108 @@ describe('Unit testing DetailsController', function() {
                     registrar_code_display: '2222'
                 }
             };
+            members = {
+                count: 100
+            };
         });
 
-        it('should strip the quotes from the string', function(){
+        it('should strip the quotes from the string', function () {
             controller = $controller('DetailsController', {$scope: scope});
             result = dc.stripQuotes(ci.title);
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
-            $httpBackend.flush(1);
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify(members));
+            $httpBackend.flush(2);
             expect('Test Title').toEqual(result);
         });
     });
 
+    describe('getFormattedCourseInstance', function () {
+        var ci;
+        var members;
+        beforeEach(function () {
+            ci = {
+                course_instance_id: $routeParams.courseInstanceId,
+                title: 'Test Title',
+                short_title: 'Test',
+                sub_title: 'Jasime is your friend',
+                description: '"<p>hello</p>"',
+                sites: [
+                    {
+                        external_id: 'https://x.y.z/888',
+                        site_id: '888',
+                        map_type: 'official'
+                    },
+                     {
+                        external_id: 'https://x.y.z/999',
+                        site_id: '999',
+                        map_type: 'unofficial'
+                    }
+                ],
+                course: {
+                    school_id: 'abc',
+                    registrar_code_display: '2222',
+                    course_id: '789',
+                    course_groups: [
+                        {
+                            name: 'group one',
+                            id: 1
+                        },
+                        {
+                            name: 'group two',
+                            id: 2
+                        }
+                    ],
+                    departments : [
+                        {
+                            name: 'dept1',
+                            id: 1
+                        }
+                    ]
+                },
+                term: {
+                    display_name: 'Summer 2015',
+                    academic_year: '2015',
+                },
+                primary_xlist_instances: [],
+            };
+
+            members = {
+                count: 100
+            };
+        });
+
+        it('format the course instance data for the UI ', function () {
+            courseInstances.instances[ci.course_instance_id] = ci;
+            dc = $controller('DetailsController', {$scope: scope});
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({}));
+            $httpBackend.flush(2);
+            expect(dc.courseInstance['title']).toEqual(ci.title);
+            expect(dc.courseInstance['short_title']).toEqual(ci.short_title);
+            expect(dc.courseInstance['sub_title']).toEqual(ci.sub_title);
+            expect(dc.courseInstance['school']).toEqual
+            (ci.course.school_id.toUpperCase());
+            expect(dc.courseInstance['term']).toEqual(ci.term.display_name);
+            expect(dc.courseInstance['course_groups']).toEqual(ci.course.course_groups);
+            expect(dc.courseInstance['departments']).toEqual(ci.course.departments);
+            expect(dc.courseInstance['year']).toEqual(ci.term.academic_year);
+            expect(dc.courseInstance['cid']).toEqual(ci.course_instance_id);
+            expect(dc.courseInstance['registrar_code_display']).toEqual(
+                ci.course.registrar_code_display + ' (' + ci.course.course_id + ')');
+            expect(dc.courseInstance['sites']).toEqual(ci.sites);
+            expect(dc.courseInstance['xlist_status']).toEqual('N/A');
+            expect(dc.courseInstance['description']).toEqual('<p>hello</p>');
+            // members.count is not defined it should equal 0
+            expect(dc.courseInstance['members']).toEqual(0);
+
+        });
+
+        it('should deal with no ci', function () {
+            dc = $controller('DetailsController', {$scope: scope});
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({}));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({}));
+            $httpBackend.flush(2);
+            expect(dc.courseInstance).toEqual(undefined);
+        });
+    });
 });

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -194,7 +194,7 @@ describe('Unit testing PeopleController', function() {
                     (ci.course.school_id.toUpperCase());
             expect(scope.courseInstance['term']).toEqual(ci.term.display_name);
             expect(scope.courseInstance['year']).toEqual(ci.term.academic_year);
-            expect(scope.courseInstance['cid']).toEqual(ci.course_instance_id);
+            expect(scope.courseInstance['course_instance_id']).toEqual(ci.course_instance_id);
             expect(scope.courseInstance['registrar_code_display']).toEqual(
                     ci.course.registrar_code_display+' ('+ci.course.course_id+')');
             expect(scope.courseInstance['sites']).toEqual('888');


### PR DESCRIPTION
This PR adds a new page called "course details" to the course info tool. Once a user selects a course they get a view of course information. This view is not editable, that is another story. This view has as a field a link to the previously existing people page that shows a list of all the people in the course. 

There is a new html partial, a new controller, and new Jasmine tests. 
