### PR TITLE
Sprint 44: TLT-2376 - edit course details

### DIFF
--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -9,7 +9,6 @@
   margin-top: 1em;
 }
 
-
 #directoryLink {
     margin-bottom: 1em;
 }

--- a/course_info/static/course_info/js/app.js
+++ b/course_info/static/course_info/js/app.js
@@ -35,6 +35,7 @@
             .when('/details/:courseInstanceId', {
                 templateUrl: 'partials/details.html',
                 controller: 'DetailsController as dc',
+                //dependencies: ['directives/editable_field']
             })
             .when('/people/:courseInstanceId', {
                 templateUrl: 'partials/people.html',

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -144,7 +144,10 @@
 
             // todo: refactor and collapse, no longer need all these functions since they are single-line
             $http.patch(url, postData)
-                .then($log, dc.handleAjaxError)
+                .then(function finalizeCourseDetailsPatch(response) {
+                    // update Reset button
+                    $.extend(dc.courseInstance, postData);
+                }, dc.handleAjaxError)
                 .finally( function courseDetailsUpdateNoLongerInProgress() {
                     dc.courseDetailsUpdateInProgress = false;
                 });

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -34,8 +34,14 @@
         };
 
         dc.isCourseInstanceEditable = function(courseRegistrarCode) {
+            // TLT-2376: sandbox and ILE courses are editable, and are
+            // identified by their course (registrar) code
             return (courseRegistrarCode.startsWith('ILE-') ||
                     courseRegistrarCode.startsWith('SB-'));
+        };
+
+        dc.isDefined = function(obj) {
+            return (typeof obj === 'undefined');
         };
 
         dc.handleCourseInstanceResponse = function(response) {
@@ -46,8 +52,8 @@
                 // overwrite the members attribute of dc.courseInstance
                 $.extend(dc.courseInstance,
                     dc.getFormattedCourseInstance(response.data));
-                // todo: comment
-                // using 354962 for ILE testing
+                // TLT-2376: only sandbox and ILE courses are currently editable
+                // todo: remove this comment--using 354962 for ILE testing
                 var rc = response.data.course.registrar_code;
                 dc.editable = dc.isCourseInstanceEditable(rc);
                 dc.resetForm();
@@ -156,7 +162,6 @@
                 postData[field] = dc.formDisplayData[field];
             });
 
-            // todo: refactor and collapse, no longer need all these functions since they are single-line
             $http.patch(url, postData)
                 .then(function finalizeCourseDetailsPatch(response) {
                     // update Reset button
@@ -177,6 +182,7 @@
                 editable: '=', // can be < in angular 1.5
                 field: '@',
                 formValue: '=',
+                isLoading: '&',
                 label: '@',
                 modelValue: '=',
             },
@@ -185,10 +191,13 @@
   <div class="form-group"> \
     <label for="input-course-{{field}}" class="col-md-2"> \
       {{label}} \
+      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span> \
     </label> \
     <div class="col-md-10"> \
-      <input type="text" class="form-control" id="input-course-{{field}}" ng-show="editable" ng-model="formValue"/> \
-      <span ng-hide="editable">{{modelValue}}</span> \
+      <div ng-hide="isLoading()"> \
+        <input type="text" class="form-control" id="input-course-{{field}}" ng-show="editable" ng-model="formValue"/> \
+        <span ng-hide="editable">{{modelValue}}</span> \
+      </div> \
     </div> \
   </div> \
 </li> \
@@ -201,6 +210,7 @@
             //templateUrl: 'directives/field_label_wrapper.html'
             scope: {
                 field: '@',
+                isLoading: '&',
                 label: '@',
             },
             transclude: true,
@@ -209,8 +219,10 @@
   <div class="form-group"> \
     <label for="input-course-{{field}}" class="col-md-2"> \
       {{label}} \
+      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span> \
     </label> \
-    <div class="col-md-10" ng-transclude> \
+    <div class="col-md-10"> \
+      <div ng-hide="isLoading()" ng-transclude></div> \
     </div> \
   </div> \
 </li> \

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -9,7 +9,6 @@
                                djangoUrl, $http, $q, $log, $uibModal, $sce) {
 
         var dc = this;
-        var remove_quotes_regex = new RegExp("^\"|\"$", "g");
         dc.courseDetailsUpdateInProgress = false;
         dc.editable = false;
 
@@ -58,13 +57,6 @@
             $q.all([coursePromise, membersPromise])
                 .then(dc.handleLookupResults);
         };
-
-        //dc.stripQuotes = function(str){
-        //    // soem fields are coming over with quotes around them and those quotes
-        //    // are being displayed in the html.
-        //    // This strips off double quotes from the begining and ending of fields
-        //    return str ? str.trim().replace(remove_quotes_regex, "") : '';
-        //};
 
         dc.getFormattedCourseInstance = function (ci, members) {
             // This is a helper function that formats the CourseInstance metadata

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -10,6 +10,7 @@
         var dc = this;
         dc.alerts = {form: {}, global: {}};
         dc.apiBase = 'api/course/v2/course_instances/';
+        dc.apiProxy = 'icommons_rest_api_proxy';
         dc.courseDetailsUpdateInProgress = false;
         dc.courseInstanceId = $routeParams.courseInstanceId;
         dc.courseInstance = {};
@@ -60,7 +61,6 @@
                 $.extend(dc.courseInstance,
                     dc.getFormattedCourseInstance(response.data));
                 // TLT-2376: only sandbox and ILE courses are currently editable
-                // todo: remove this comment--using 354962 for ILE testing
                 var rc = response.data.course.registrar_code;
                 dc.editable = dc.isCourseInstanceEditable(rc);
                 dc.resetForm();
@@ -78,11 +78,11 @@
 
         dc.fetchCourseInstanceDetails = function (id) {
 
-            var course_url = djangoUrl.reverse(
-                'icommons_rest_api_proxy', [dc.apiBase + id + '/']);
+            var course_url = djangoUrl.reverse(dc.apiProxy,
+                [dc.apiBase + id + '/']);
 
-            var members_url = djangoUrl.reverse(
-                'icommons_rest_api_proxy', [dc.apiBase + id + '/people/']);
+            var members_url = djangoUrl.reverse(dc.apiProxy,
+                [dc.apiBase + id + '/people/']);
 
             $http.get(course_url)
                 .then(dc.handleCourseInstanceResponse,
@@ -106,10 +106,8 @@
         };
 
         dc.getFormattedCourseInstance = function (ciData) {
-            // This is a helper function that formats the CourseInstance metadata
-            // and is combination of existing logic in
-            // Searchcontroller.courseInstanceToTable and Searchcontroller cell
-            // render functions.
+            // This is a helper function that formats the raw CourseInstance
+            // API response data for display in the UI
             var ci = ciData;  // shorten for brevity, preferable to `with()`
             var courseInstance = {};
             if (ci) {
@@ -152,7 +150,6 @@
             return courseInstance;
         };
 
-        // todo - fix pristine?
         dc.resetForm = function() {
             dc.formDisplayData = angular.copy(dc.courseInstance);
         };
@@ -175,12 +172,12 @@
             }
         };
 
-        // todo: data validation
         dc.submitCourseDetailsForm = function() {
             dc.courseDetailsUpdateInProgress = true;
             var postData = {};
-            var url = djangoUrl.reverse('icommons_rest_api_proxy',
+            var url = djangoUrl.reverse(dc.apiProxy,
                 [dc.apiBase + dc.courseInstanceId + '/']);
+            // we could also get these from editable properties on the DOM
             var fields = [
                 'description',
                 'instructors_display',

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -221,11 +221,13 @@
         return {
             //templateUrl: 'directives/editable_field.html'
             scope: {
-                editable: '=', // can be < in angular 1.5
+                editable: '=', // can be < in angular 1.5;
+                               // if not provided, defaults to null/false
                 field: '@',
                 formValue: '=',
                 isLoading: '&',
                 label: '@',
+                maxlength: '@',
                 modelValue: '=',
             },
             template: ' \
@@ -237,7 +239,7 @@
     </label> \
     <div class="col-md-10"> \
       <div ng-hide="isLoading()"> \
-        <input type="text" class="form-control" id="input-course-{{field}}" ng-show="editable" ng-model="formValue"/> \
+        <input type="text" class="form-control" id="input-course-{{field}}" name="input-course-{{field}}" ng-show="editable" ng-model="formValue" maxlength="{{maxlength}}"/> \
         <span ng-hide="editable">{{modelValue}}</span> \
       </div> \
     </div> \

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -52,6 +52,7 @@
                 courseInstance['term'] = ci.term ? ci.term.display_name : '';
                 courseInstance['year'] = ci.term ? ci.term.academic_year : '';
                 courseInstance['departments'] = ci.course.departments;
+                courseInstance['course_groups'] = ci.course.course_groups;
                 courseInstance['cid'] = ci.course_instance_id;
                 courseInstance['registrar_code_display'] = ci.course ?
                 ci.course.registrar_code_display +

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -1,43 +1,69 @@
-// TODO - this is pretty much a copy of the people controller with some mods.
-// TODO - this still needs a lot of clean up, we don't need everything in here
-
 (function () {
     var app = angular.module('CourseInfo');
     app.controller('DetailsController', DetailsController);
+    app.directive('huEditableField', editableFieldDirective);
+    app.directive('huFieldLabelWrapper', fieldLabelWrapperDirective);
 
     function DetailsController($scope, $routeParams, courseInstances, $compile,
                                djangoUrl, $http, $q, $log, $uibModal, $sce) {
 
         var dc = this;
         dc.courseDetailsUpdateInProgress = false;
+        dc.courseInstanceId = $routeParams.courseInstanceId;
+        dc.courseInstance = {};
+        dc.courseInstances = courseInstances;
         dc.editable = false;
+
+        dc.init = function() {
+            var instances = courseInstances.instances;
+            if (instances && instances[dc.courseInstanceId]) {
+                dc.courseInstance = dc.getFormattedCourseInstance(
+                    instances[dc.courseInstanceId]);
+            }
+            dc.fetchCourseInstanceDetails(dc.courseInstanceId);
+        };
+
+        dc.handleAjaxErrorResponse = function(r) {
+            dc.handleAjaxError(
+                r.data, r.status, r.headers, r.config, r.statusText);
+        };
 
         dc.handleAjaxError = function (data, status, headers, config, statusText) {
             $log.error('Error attempting to ' + config.method + ' ' + config.url +
                 ': ' + status + ' ' + statusText + ': ' + JSON.stringify(data));
         };
 
-        dc.handleLookupResults = function(results) {
-            var courseResult = results[0];
-            var membersResult = results[1];
+        dc.isCourseInstanceEditable = function(courseRegistrarCode) {
+            return (courseRegistrarCode.startsWith('ILE-') ||
+                    courseRegistrarCode.startsWith('SB-'));
+        };
 
+        dc.handleCourseInstanceResponse = function(response) {
             //check if the right data was obtained before storing it
-            if (courseResult.data.course_instance_id == dc.courseInstanceId) {
-                courseInstances.instances[courseResult.data.course_instance_id] = courseResult.data;
-                dc.courseInstance = dc.getFormattedCourseInstance(courseResult.data, membersResult.data);
+            if (response.data.course_instance_id == dc.courseInstanceId) {
+                courseInstances.instances[response.data.course_instance_id] = response.data;
+                // if people/members are fetched first, we don't want to
+                // overwrite the members attribute of dc.courseInstance
+                $.extend(dc.courseInstance,
+                    dc.getFormattedCourseInstance(response.data));
                 // todo: comment
                 // using 354962 for ILE testing
-                var rc = courseResult.data.course.registrar_code;
-                dc.editable = (rc.startsWith('ILE-')
-                               || rc.startsWith('SB-'));
+                var rc = response.data.course.registrar_code;
+                dc.editable = dc.isCourseInstanceEditable(rc);
                 dc.resetForm();
             } else {
                 $log.error(' CourseInstance record mismatch for id :'
-                    + dc.courseInstanceId + ',  fetched record for :' + courseResult.data.id);
+                    + dc.courseInstanceId + ',  fetched record for :'
+                    + response.data.id);
             }
         };
 
-        dc.setCourseInstance = function (id) {
+        dc.handlePeopleResponse = function(response) {
+            if (!dc.hasOwnProperty('courseInstance')) { }
+            dc.courseInstance['members'] = response.data.count;
+        };
+
+        dc.fetchCourseInstanceDetails = function (id) {
 
             var course_url = djangoUrl.reverse(
                 'icommons_rest_api_proxy',
@@ -48,22 +74,23 @@
                 ['api/course/v2/course_instances/'
                 + id + '/people/']);
 
-            var coursePromise = $http.get(course_url)
-                .error(dc.handleAjaxError);
+            $http.get(course_url)
+                .then(dc.handleCourseInstanceResponse,
+                    dc.handleAjaxErrorResponse);
 
-            var membersPromise = $http.get(members_url)
-                .error(dc.handleAjaxError);
+            $http.get(members_url)
+                .then(dc.handlePeopleResponse,
+                    dc.handleAjaxErrorResponse);
 
-            $q.all([coursePromise, membersPromise])
-                .then(dc.handleLookupResults);
         };
 
-        dc.getFormattedCourseInstance = function (ci, members) {
+        dc.getFormattedCourseInstance = function (ciData) {
             // This is a helper function that formats the CourseInstance metadata
             // and is combination of existing logic in
             // Searchcontroller.courseInstanceToTable and Searchcontroller cell
             // render functions.
-            courseInstance = {};
+            var ci = ciData;  // shorten for brevity, preferable to `with()`
+            var courseInstance = {};
             if (ci) {
                 courseInstance['title'] = ci.title;
                 courseInstance['school'] = ci.course.school_id.toUpperCase();
@@ -98,14 +125,9 @@
 
                 courseInstance['sites'] = ci.sites;
             }
-            courseInstance['members'] = members.count;
 
             return courseInstance;
         };
-
-        dc.courseInstanceId = $routeParams.courseInstanceId;
-
-        dc.setCourseInstance($routeParams.courseInstanceId);
 
         // todo - fix pristine?
         dc.resetForm = function() {
@@ -143,6 +165,57 @@
                 .finally( function courseDetailsUpdateNoLongerInProgress() {
                     dc.courseDetailsUpdateInProgress = false;
                 });
+        };
+
+        dc.init();
+    }
+
+    function editableFieldDirective() {
+        return {
+            //templateUrl: 'directives/editable_field.html'
+            scope: {
+                editable: '=', // can be < in angular 1.5
+                field: '@',
+                formValue: '=',
+                label: '@',
+                modelValue: '=',
+            },
+            template: ' \
+<li class="list-group-item"> \
+  <div class="form-group"> \
+    <label for="input-course-{{field}}" class="col-md-2"> \
+      {{label}} \
+    </label> \
+    <div class="col-md-10"> \
+      <input type="text" class="form-control" id="input-course-{{field}}" ng-show="editable" ng-model="formValue"/> \
+      <span ng-hide="editable">{{modelValue}}</span> \
+    </div> \
+  </div> \
+</li> \
+'
         }
     }
+
+    function fieldLabelWrapperDirective() {
+        return {
+            //templateUrl: 'directives/field_label_wrapper.html'
+            scope: {
+                field: '@',
+                label: '@',
+            },
+            transclude: true,
+            template: ' \
+<li class="list-group-item"> \
+  <div class="form-group"> \
+    <label for="input-course-{{field}}" class="col-md-2"> \
+      {{label}} \
+    </label> \
+    <div class="col-md-10" ng-transclude> \
+    </div> \
+  </div> \
+</li> \
+'
+        }
+    }
+
 })();

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -122,9 +122,11 @@
                 courseInstance['departments'] = ci.course.departments;
                 courseInstance['course_groups'] = ci.course.course_groups;
 
-                var registrar_code = ci.course.registrar_code_display ? ci.course.registrar_code_display : ci.course.registrar_code;
+                var registrarCode = ci.course.registrar_code_display
+                    ? ci.course.registrar_code_display
+                    : ci.course.registrar_code;
 
-                courseInstance['registrar_code_display'] = registrar_code + ' (' + ci.course.course_id + ')'.trim();
+                courseInstance['registrar_code_display'] = registrarCode.trim();
 
                 courseInstance['description'] = ci.description;
                 courseInstance['short_title'] = ci.short_title;

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -1,14 +1,15 @@
 (function () {
-    var app = angular.module('CourseInfo');
-    app.controller('DetailsController', DetailsController);
-    app.directive('huEditableField', editableFieldDirective);
-    app.directive('huFieldLabelWrapper', fieldLabelWrapperDirective);
+    angular.module('CourseInfo')
+        .controller('DetailsController', DetailsController)
+        .directive('huEditableInput', editableInputDirective)
+        .directive('huFieldLabelWrapper', fieldLabelWrapperDirective);
 
     function DetailsController($scope, $routeParams, courseInstances, $compile,
                                djangoUrl, $http, $q, $log, $uibModal, $sce) {
 
         var dc = this;
         dc.alerts = {form: {}, global: {}};
+        dc.apiBase = 'api/course/v2/course_instances/';
         dc.courseDetailsUpdateInProgress = false;
         dc.courseInstanceId = $routeParams.courseInstanceId;
         dc.courseInstance = {};
@@ -78,13 +79,10 @@
         dc.fetchCourseInstanceDetails = function (id) {
 
             var course_url = djangoUrl.reverse(
-                'icommons_rest_api_proxy',
-                ['api/course/v2/course_instances/' + id + '/']);
+                'icommons_rest_api_proxy', [dc.apiBase + id + '/']);
 
             var members_url = djangoUrl.reverse(
-                'icommons_rest_api_proxy',
-                ['api/course/v2/course_instances/'
-                + id + '/people/']);
+                'icommons_rest_api_proxy', [dc.apiBase + id + '/people/']);
 
             $http.get(course_url)
                 .then(dc.handleCourseInstanceResponse,
@@ -182,8 +180,7 @@
             dc.courseDetailsUpdateInProgress = true;
             var postData = {};
             var url = djangoUrl.reverse('icommons_rest_api_proxy',
-                ['api/course/v2/course_instances/'
-                + dc.courseInstanceId + '/']);
+                [dc.apiBase + dc.courseInstanceId + '/']);
             var fields = [
                 'description',
                 'instructors_display',
@@ -219,9 +216,8 @@
         dc.init();
     }
 
-    function editableFieldDirective() {
+    function editableInputDirective() {
         return {
-            //templateUrl: 'directives/editable_field.html'
             scope: {
                 editable: '=', // can be < in angular 1.5;
                                // if not provided, defaults to null/false
@@ -230,18 +226,20 @@
                 isLoading: '&',
                 label: '@',
                 maxlength: '@',
-                modelValue: '=',
+                modelValue: '='
             },
             template: ' \
 <li class="list-group-item"> \
   <div class="form-group"> \
     <label for="input-course-{{field}}" class="col-md-2"> \
       {{label}} \
-      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span> \
     </label> \
     <div class="col-md-10"> \
+      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span> \
       <div ng-hide="isLoading()"> \
-        <input type="text" class="form-control" id="input-course-{{field}}" name="input-course-{{field}}" ng-show="editable" ng-model="formValue" maxlength="{{maxlength}}"/> \
+        <input type="text" class="form-control" id="input-course-{{field}}" \
+               name="input-course-{{field}}" ng-show="editable" \
+               ng-model="formValue" maxlength="{{maxlength}}"/> \
         <span ng-hide="editable">{{modelValue}}</span> \
       </div> \
     </div> \
@@ -257,7 +255,7 @@
             scope: {
                 field: '@',
                 isLoading: '&',
-                label: '@',
+                label: '@'
             },
             transclude: true,
             template: ' \
@@ -265,9 +263,9 @@
   <div class="form-group"> \
     <label for="input-course-{{field}}" class="col-md-2"> \
       {{label}} \
-      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span> \
     </label> \
     <div class="col-md-10"> \
+      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span> \
       <div ng-hide="isLoading()" ng-transclude></div> \
     </div> \
   </div> \

--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -57,7 +57,8 @@
                                 text: tc.term_name + ' <span class="caret"></span>',
                             };
                         }));
-                    if (response.data.next !== '') {
+                    if (response.data.next && response.data.next !== '') {
+                        // API returns next=null if there are no more pages
                         console.log('Warning: Some terms missing from dropdown!');
                     }
                 }, function errorCallback(response) {

--- a/course_info/static/course_info/js/polyfills/autofill-event.js
+++ b/course_info/static/course_info/js/polyfills/autofill-event.js
@@ -1,0 +1,145 @@
+/**
+ * Autofill event polyfill ##version:1.0.0##
+ * (c) 2014 Google, Inc.
+ * License: MIT
+ * https://raw.githubusercontent.com/tbosch/autofill-event/master/src/autofill-event.js
+ * (fetched 03.07.2016)
+ */
+(function(window) {
+  var $ = window.jQuery || window.angular.element;
+  var rootElement = window.document.documentElement,
+    $rootElement = $(rootElement);
+
+  addGlobalEventListener('change', markValue);
+  addValueChangeByJsListener(markValue);
+
+  $.prototype.checkAndTriggerAutoFillEvent = jqCheckAndTriggerAutoFillEvent;
+
+  // Need to use blur and not change event
+  // as Chrome does not fire change events in all cases an input is changed
+  // (e.g. when starting to type and then finish the input by auto filling a username)
+  addGlobalEventListener('blur', function(target) {
+    // setTimeout needed for Chrome as it fills other
+    // form fields a little later...
+    window.setTimeout(function() {
+      findParentForm(target).find('input').checkAndTriggerAutoFillEvent();
+    }, 20);
+  });
+
+  function DOMContentLoadedListener() {
+    // mark all values that are present when the DOM is ready.
+    // We don't need to trigger a change event here,
+    // as js libs start with those values already being set!
+    forEach(document.getElementsByTagName('input'), markValue);
+
+    // The timeout is needed for Chrome as it auto fills
+    // login forms some time after DOMContentLoaded!
+    window.setTimeout(function() {
+      $rootElement.find('input').checkAndTriggerAutoFillEvent();
+    }, 200);
+  }
+
+  // IE8 compatibility issue
+  if(!window.document.addEventListener){
+    window.document.attachEvent('DOMContentLoaded', DOMContentLoadedListener);
+  }else{
+    window.document.addEventListener('DOMContentLoaded', DOMContentLoadedListener, false);
+  }
+
+  return;
+
+  // ----------
+
+  function jqCheckAndTriggerAutoFillEvent() {
+    var i, el;
+    for (i=0; i<this.length; i++) {
+      el = this[i];
+      if (!valueMarked(el)) {
+        markValue(el);
+        triggerChangeEvent(el);
+      }
+    }
+  }
+
+  function valueMarked(el) {
+    if (! ("$$currentValue" in el) ) {
+      // First time we see an element we take it's value attribute
+      // as real value. This might have been filled in the backend,
+      // ...
+      // Note: it's important to not use the value property here!
+      el.$$currentValue = el.getAttribute('value');
+    }
+
+    var val = el.value,
+         $$currentValue = el.$$currentValue;
+    if (!val && !$$currentValue) {
+      return true;
+    }
+    return val === $$currentValue;
+  }
+
+  function markValue(el) {
+    el.$$currentValue = el.value;
+  }
+
+  function addValueChangeByJsListener(listener) {
+    var jq = window.jQuery || window.angular.element,
+        jqProto = jq.prototype;
+    var _val = jqProto.val;
+    jqProto.val = function(newValue) {
+      var res = _val.apply(this, arguments);
+      if (arguments.length > 0) {
+        forEach(this, function(el) {
+          listener(el, newValue);
+        });
+      }
+      return res;
+    };
+  }
+
+  function addGlobalEventListener(eventName, listener) {
+    // Use a capturing event listener so that
+    // we also get the event when it's stopped!
+    // Also, the blur event does not bubble.
+    if(!rootElement.addEventListener){
+      rootElement.attachEvent(eventName, onEvent);
+    }else{
+      rootElement.addEventListener(eventName, onEvent, true);
+    }
+
+    function onEvent(event) {
+      var target = event.target;
+      listener(target);
+    }
+  }
+
+  function findParentForm(el) {
+    while (el) {
+      if (el.nodeName === 'FORM') {
+        return $(el);
+      }
+      el = el.parentNode;
+    }
+    return $();
+  }
+
+  function forEach(arr, listener) {
+    if (arr.forEach) {
+      return arr.forEach(listener);
+    }
+    var i;
+    for (i=0; i<arr.length; i++) {
+      listener(arr[i]);
+    }
+  }
+
+  function triggerChangeEvent(element) {
+    var doc = window.document;
+    var event = doc.createEvent("HTMLEvents");
+    event.initEvent("change", true, true);
+    element.dispatchEvent(event);
+  }
+
+
+
+})(window);

--- a/course_info/templates/course_info/index.html
+++ b/course_info/templates/course_info/index.html
@@ -41,6 +41,9 @@
     <script src="{% static 'angular-datatables-0.5.1/angular-datatables.min.js' %}"></script>
     {% endif %}
     <script src="{% static 'datatables-bootstrap3/BS3/assets/js/datatables.js' %}"></script>
+    {# fixes safari autocomplete issue #}
+    {# (see https://github.com/angular/angular.js/issues/1460) #}
+    <script src="{% static 'course_info/js/polyfills/autofill-event.js' %}"></script>
     {% include 'django_auth_lti/resource_link_id.html' %}
     <script>
       window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';

--- a/course_info/templates/course_info/index.html
+++ b/course_info/templates/course_info/index.html
@@ -7,7 +7,7 @@
   <head>
     <meta name="viewport"
           content="width=device-width, initial-scale=1, user-scalable=no">
-    <link href="/static/favicon.ico" rel="icon" type="image/x-icon">
+    <link href="{% static 'favicon.ico' %}" rel="icon" type="image/x-icon">
     <link rel="stylesheet" type="text/css"
                            href="{% static 'font-awesome-4.2.0/css/font-awesome.min.css' %}">
     <link rel="stylesheet" type="text/css"

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -21,7 +21,7 @@
                     <div class="col-md-2">
                         <strong>Course Code: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.registrar_code_display }}</div>
+                    <div class="col-md-10">{{dc.courseInstance.registrar_code_display }}</div>
                 </div>
             </li>
 
@@ -30,9 +30,9 @@
                     <div class="col-md-2">
                         <strong>Cross Listing: </strong>
                     </div>
-                    <div class="col-md-10" ng-switch on="courseInstance.xlist_status">
+                    <div class="col-md-10" ng-switch on="dc.courseInstance.xlist_status">
                         <span ng-switch-when="Primary" class="label label-info">Primary</span>
-                        <span ng-switch-when="Secondary" class="label label-info">Secondary {{courseInstance.xlist_status}}</span>
+                        <span ng-switch-when="Secondary" class="label label-info">Secondary</span>
                         <span ng-switch-default class="label label-info">N/A</span>
                     </div>
                 </div>
@@ -43,7 +43,7 @@
                     <div class="col-md-2">
                         <strong>Term: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.term}}</div>
+                    <div class="col-md-10">{{dc.courseInstance.term}}</div>
                 </div>
             </li>
 
@@ -52,7 +52,7 @@
                     <div class="col-md-2">
                         <strong>SIS/Course Instance ID: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.course_instance_id}}</div>
+                    <div class="col-md-10">{{dc.courseInstance.course_instance_id}}</div>
                 </div>
             </li>
 
@@ -61,7 +61,7 @@
                     <div class="col-md-2">
                         <strong>Course Title: </strong>
                     </div>
-                    <div class="col-md-10" ng-bind-html="courseInstance.title"></div>
+                    <div class="col-md-10" ng-bind-html="dc.courseInstance.title"></div>
                 </div>
             </li>
 
@@ -70,7 +70,7 @@
                     <div class="col-md-2">
                         <strong>Short Title: </strong>
                     </div>
-                    <div class="col-md-10" ng-bind-html="courseInstance.short_title"></div>
+                    <div class="col-md-10" ng-bind-html="dc.courseInstance.short_title"></div>
                 </div>
             </li>
 
@@ -79,7 +79,7 @@
                     <div class="col-md-2">
                         <strong>Subtitle: </strong>
                     </div>
-                    <div class="col-md-10" ng-bind-html="courseInstance.sub_title"></div>
+                    <div class="col-md-10" ng-bind-html="dc.courseInstance.sub_title"></div>
                 </div>
             </li>
 
@@ -88,7 +88,7 @@
                     <div class="col-md-2">
                         <strong>Description: </strong>
                     </div>
-                    <div class="col-md-10" ng-bind-html="courseInstance.description"></div>
+                    <div class="col-md-10" ng-bind-html="dc.courseInstance.description"></div>
                 </div>
             </li>
 
@@ -97,7 +97,7 @@
                     <div class="col-md-2">
                         <strong>Notes: </strong>
                     </div>
-                    <div class="col-md-10" ng-bind-html="courseInstance.notes"></div>
+                    <div class="col-md-10" ng-bind-html="dc.courseInstance.notes"></div>
                 </div>
             </li>
 
@@ -106,7 +106,7 @@
                     <div class="col-md-2">
                         <strong>Instructors (display): </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.instructors_display}}</div>
+                    <div class="col-md-10">{{dc.courseInstance.instructors_display}}</div>
                 </div>
             </li>
 
@@ -115,7 +115,7 @@
                     <div class="col-md-2">
                         <strong>People: </strong>
                     </div>
-                    <div class="col-md-10"><a href="#/people/{{courseInstance.cid}}">people</a></div>
+                    <div class="col-md-10"><a href="#/people/{{dc.courseInstance.cid}}">people</a></div>
                 </div>
             </li>
 
@@ -124,7 +124,7 @@
                     <div class="col-md-2">
                         <strong>Location: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.location}}</div>
+                    <div class="col-md-10">{{dc.courseInstance.location}}</div>
                 </div>
             </li>
 
@@ -133,7 +133,7 @@
                     <div class="col-md-2">
                         <strong>Meeting Time: </strong>
                     </div>
-                    <div class="col-md-10">{{courseInstance.meeting_time}}</div>
+                    <div class="col-md-10">{{dc.courseInstance.meeting_time}}</div>
                 </div>
             </li>
 
@@ -142,16 +142,28 @@
                     <div class="col-md-2">
                         <strong>Departments: </strong>
                     </div>
-                    <div class="col-md-10" ng-repeat="dept in departments">{{dept.name}}</div>
+                    <div class="col-md-10" ng-repeat="dept in dc.courseInstance.departments">
+                         <div class="list-group" ng-if="dc.courseInstance.departments.length > 0">
+                            <div class="list-group-item list-group-sub-item" ng-repeat="dept in dc.courseInstance.departments">
+                                {{dept.name}}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </li>
 
             <li class="list-group-item">
                 <div class="row">
                     <div class="col-md-2">
-                        <strong>Course Group: </strong>
+                        <strong>Course Groups: </strong>
                     </div>
-                    <div class="col-md-10">todo</div>
+                    <div class="col-md-10">
+                        <div class="list-group">
+                            <div class="list-group-item list-group-sub-item" ng-repeat="group in dc.courseInstance.course_groups">
+                                {{group.name}}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </li>
 
@@ -162,13 +174,9 @@
                     </div>
                     <div class="col-md-10">
                         <div class="list-group">
-                            <div class="list-group-item list-group-sub-item" ng-repeat="site in courseInstance.sites">
-
-                                <div class="label label-primary col-md-1">Official</div>
-
-                                <!-- TO DO - honor the Official/Unofficial status of the course -->
-                                <!--<div class="label label-default col-md-1">Unofficial</div>-->
-
+                            <div class="list-group-item list-group-sub-item" ng-repeat="site in dc.courseInstance.sites">
+                                <div class="label label-primary col-md-1" ng-if="site.map_type == 'official'">Official</div>
+                                <div class="label label-primary col-md-1" ng-if="site.map_type == 'unofficial'">Unofficial</div>
                                 <div class="col-md-11"><a href="{{site.course_site_url}}"
                                                           target="_blank">{{site.course_site_url}}</a>
                                 </div>

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -54,10 +54,10 @@
       </div>
 
       <form name="dc.courseDetailsForm" class="form-horizontal" ng-if="dc.courseInstance.title" ng-submit="dc.submitCourseDetailsForm(this)">
-        <ul class="list-group">
-
+        <fieldset ng-disabled="dc.courseDetailsUpdateInProgress">
+          <ul class="list-group">
             <hu-editable-input
-                is-loading="dc.isDefined(dc.courseInstance.registrar_code_display)"
+                is-loading="dc.isUndefined(dc.courseInstance.registrar_code_display)"
                 form-value="dc.courseInstance.registrar_code_display"
                 model-value="dc.formDisplayData.registrar_code_display"
                 field="registrar_code_display"
@@ -65,26 +65,25 @@
 
             <hu-field-label-wrapper
               field="xlist_status"
-              is-loading="dc.isDefined(dc.courseInstance.xlist_status)"
+              is-loading="dc.isUndefined(dc.courseInstance.xlist_status)"
               label="Cross listing">
-                <div ng-switch on="dc.courseInstance.xlist_status">
-                  <span ng-switch-when="Primary" class="label label-info">
-                    Primary </span>
-                  <span ng-switch-when="Secondary" class="label label-info">
-                    Secondary </span>
-                  <span ng-switch-default class="label label-info">N/A</span>
+                <div ng-switch on="dc.courseInstance.xlist_status"
+                     class="label label-info">
+                  <span ng-switch-when="Primary"> Primary </span>
+                  <span ng-switch-when="Secondary"> Secondary </span>
+                  <span ng-switch-default> N/A </span>
                 </div>
             </hu-field-label-wrapper>
 
             <hu-editable-input
-                is-loading="dc.isDefined(dc.courseInstance.term)"
+                is-loading="dc.isUndefined(dc.courseInstance.term)"
                 form-value="dc.courseInstance.term"
                 model-value="dc.courseInstance.term"
                 field="term"
                 label="Term"></hu-editable-input>
 
             <hu-editable-input
-                is-loading="dc.isDefined(dc.courseInstance.course_instance_id)"
+                is-loading="dc.isUndefined(dc.courseInstance.course_instance_id)"
                 form-value="dc.courseInstance.course_instance_id"
                 model-value="dc.courseInstance.course_instance_id"
                 field="course_instance_id"
@@ -92,7 +91,7 @@
 
             <hu-editable-input
                 editable="dc.editable"
-                is-loading="dc.isDefined(dc.courseInstance.title)"
+                is-loading="dc.isUndefined(dc.courseInstance.title)"
                 form-value="dc.formDisplayData.title"
                 model-value="dc.courseInstance.title"
                 maxlength="500"
@@ -101,7 +100,7 @@
 
             <hu-editable-input
                 editable="dc.editable"
-                is-loading="dc.isDefined(dc.courseInstance.short_title)"
+                is-loading="dc.isUndefined(dc.courseInstance.short_title)"
                 form-value="dc.formDisplayData.short_title"
                 model-value="dc.courseInstance.short_title"
                 maxlength="200"
@@ -110,7 +109,7 @@
 
             <hu-editable-input
                 editable="dc.editable"
-                is-loading="dc.isDefined(dc.courseInstance.sub_title)"
+                is-loading="dc.isUndefined(dc.courseInstance.sub_title)"
                 form-value="dc.formDisplayData.sub_title"
                 model-value="dc.courseInstance.sub_title"
                 maxlength="500"
@@ -119,7 +118,7 @@
 
             <hu-editable-input
                 editable="dc.editable"
-                is-loading="dc.isDefined(dc.courseInstance.description)"
+                is-loading="dc.isUndefined(dc.courseInstance.description)"
                 form-value="dc.formDisplayData.description"
                 model-value="dc.courseInstance.description"
                 field="description"
@@ -127,7 +126,7 @@
 
             <hu-editable-input
                 editable="dc.editable"
-                is-loading="dc.isDefined(dc.courseInstance.notes)"
+                is-loading="dc.isUndefined(dc.courseInstance.notes)"
                 form-value="dc.formDisplayData.notes"
                 model-value="dc.courseInstance.notes"
                 maxlength="2000"
@@ -136,7 +135,7 @@
 
             <hu-editable-input
                 editable="dc.editable"
-                is-loading="dc.isDefined(dc.courseInstance.instructors_display)"
+                is-loading="dc.isUndefined(dc.courseInstance.instructors_display)"
                 form-value="dc.formDisplayData.instructors_display"
                 model-value="dc.courseInstance.instructors_display"
                 maxlength="4000"
@@ -144,7 +143,7 @@
                 label="Instructors (display)"></hu-editable-input>
 
             <hu-field-label-wrapper
-                is-loading="dc.isDefined(dc.courseInstance.members) && !dc.alertPresent('form', 'fetchMembersFailed')"
+                is-loading="dc.isUndefined(dc.courseInstance.members) && !dc.alertPresent('form', 'fetchMembersFailed')"
                 field="people"
                 label="People">
               <div class="alert alert-danger" role="alert"
@@ -175,7 +174,7 @@
 
             <hu-editable-input
                 editable="dc.editable"
-                is-loading="dc.isDefined(dc.courseInstance.location)"
+                is-loading="dc.isUndefined(dc.courseInstance.location)"
                 form-value="dc.formDisplayData.location"
                 model-value="dc.courseInstance.location"
                 maxlength="500"
@@ -184,7 +183,7 @@
 
             <hu-editable-input
                 editable="dc.editable"
-                is-loading="dc.isDefined(dc.courseInstance.meeting_time)"
+                is-loading="dc.isUndefined(dc.courseInstance.meeting_time)"
                 form-value="dc.formDisplayData.meeting_time"
                 model-value="dc.courseInstance.meeting_time"
                 maxlength="1000"
@@ -192,7 +191,7 @@
                 label="Meeting time"></hu-editable-input>
 
             <hu-field-label-wrapper
-                is-loading="dc.isDefined(dc.courseInstance.departments)"
+                is-loading="dc.isUndefined(dc.courseInstance.departments)"
                 field="departments"
                 label="Departments">
               <div class="row" ng-repeat="dept in dc.courseInstance.departments">
@@ -201,7 +200,7 @@
             </hu-field-label-wrapper>
 
             <hu-field-label-wrapper
-                is-loading="dc.isDefined(dc.courseInstance.course_groups)"
+                is-loading="dc.isUndefined(dc.courseInstance.course_groups)"
                 field="course_groups"
                 label="Course Groups">
               <div class="row" ng-repeat="group in dc.courseInstance.course_groups">
@@ -210,7 +209,7 @@
             </hu-field-label-wrapper>
 
             <hu-field-label-wrapper
-                is-loading="dc.isDefined(dc.courseInstance.sites)"
+                is-loading="dc.isUndefined(dc.courseInstance.sites)"
                 field="sites"
                 label="Associated Official and Unofficial Site(s)">
                 <div class="row" ng-repeat="site in dc.courseInstance.sites">
@@ -225,13 +224,14 @@
             </hu-field-label-wrapper>
 
             <hu-editable-input
-                is-loading="dc.isDefined(dc.courseInstance.conclude_date)"
+                is-loading="dc.isUndefined(dc.courseInstance.conclude_date)"
                 form-value="dc.formDisplayData.conclude_date"
                 model-value="dc.courseInstance.conclude_date"
                 field="conclude_date"
                 label="Conclusion Date"></hu-editable-input>
 
-        </ul>
+          </ul>
+        </fieldset>
 
         <div class="form-group" ng-show="dc.editable">
           <div class="col-md-12">

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -18,19 +18,19 @@
         <ul class="list-group">
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Course Code: </strong>
-                    </div>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                      Course Code
+                    </label>
                     <div class="col-md-10">{{dc.courseInstance.registrar_code_display }}</div>
                 </div>
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Cross Listing: </strong>
-                    </div>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                      Cross Listing
+                    </label>
                     <div class="col-md-10" ng-switch on="dc.courseInstance.xlist_status">
                         <span ng-switch-when="Primary" class="label label-info">Primary</span>
                         <span ng-switch-when="Secondary" class="label label-info">Secondary</span>
@@ -40,19 +40,19 @@
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Term: </strong>
-                    </div>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                      Term
+                    </label>
                     <div class="col-md-10">{{dc.courseInstance.term}}</div>
                 </div>
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>SIS/Course Instance ID: </strong>
-                    </div>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                      SIS/Course Instance ID
+                    </label>
                     <div class="col-md-10">{{dc.courseInstance.course_instance_id}}</div>
                 </div>
             </li>
@@ -70,55 +70,70 @@
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Short Title: </strong>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Short Title
+                    </label>
+                    <div class="col-md-10">
+                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.short_title" ng-show="dc.editable" />
+                      <span ng-bind-html="dc.courseInstance.short_title" ng-hide="dc.editable"></span>
                     </div>
-                    <div class="col-md-10" ng-bind-html="dc.courseInstance.short_title"></div>
                 </div>
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Subtitle: </strong>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Subtitle
+                    </label>
+                    <div class="col-md-10">
+                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.sub_title" ng-show="dc.editable" />
+                      <span ng-bind-html="dc.courseInstance.sub_title" ng-hide="dc.editable"></span>
                     </div>
-                    <div class="col-md-10" ng-bind-html="dc.courseInstance.sub_title"></div>
                 </div>
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Description: </strong>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Description
+                    </label>
+                    <div class="col-md-10">
+                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.description" ng-show="dc.editable" />
+                      <span ng-bind-html="dc.courseInstance.description" ng-hide="dc.editable"></span>
                     </div>
-                    <div class="col-md-10" ng-bind-html="dc.courseInstance.description"></div>
                 </div>
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Notes: </strong>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Notes
+                    </label>
+                    <div class="col-md-10">
+                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.notes" ng-show="dc.editable" />
+                      <span ng-bind-html="dc.courseInstance.notes" ng-hide="dc.editable"></span>
                     </div>
-                    <div class="col-md-10" ng-bind-html="dc.courseInstance.notes"></div>
                 </div>
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Instructors (display): </strong>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Instructors (display)
+                    </label>
+                    <div class="col-md-10">
+                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.instructors_display" ng-show="dc.editable" />
+                      <span ng-bind-html="dc.courseInstance.instructors_display" ng-hide="dc.editable"></span>
                     </div>
-                    <div class="col-md-10">{{dc.courseInstance.instructors_display}}</div>
                 </div>
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>People: </strong>
-                    </div>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        People
+                    </label>
                     <div class="col-md-10">
                         <a href="#/people/{{dc.courseInstance.course_instance_id}}">
                             <ng-pluralize count="dc.courseInstance.members"
@@ -132,28 +147,34 @@
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Location: </strong>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Location
+                    </label>
+                    <div class="col-md-10">
+                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.location" ng-show="dc.editable" />
+                      <span ng-bind-html="dc.courseInstance.location" ng-hide="dc.editable"></span>
                     </div>
-                    <div class="col-md-10">{{dc.courseInstance.location}}</div>
                 </div>
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Meeting Time: </strong>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Meeting Time
+                    </label>
+                    <div class="col-md-10">
+                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.meeting_time" ng-show="dc.editable" />
+                      <span ng-bind-html="dc.courseInstance.meeting_time" ng-hide="dc.editable"></span>
                     </div>
-                    <div class="col-md-10">{{dc.courseInstance.meeting_time}}</div>
                 </div>
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Departments: </strong>
-                    </div>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Departments
+                    </label>
                     <div class="col-md-10" ng-repeat="dept in dc.courseInstance.departments">
                          <div class="list-group" ng-if="dc.courseInstance.departments.length > 0">
                             <div class="list-group-item list-group-sub-item" ng-repeat="dept in dc.courseInstance.departments">
@@ -165,10 +186,10 @@
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Course Groups: </strong>
-                    </div>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Course Groups
+                    </label>
                     <div class="col-md-10">
                         <div class="list-group">
                             <div class="list-group-item list-group-sub-item" ng-repeat="group in dc.courseInstance.course_groups">
@@ -180,10 +201,10 @@
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Associated Official and Unofficial Site(s): </strong>
-                    </div>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Associated Official and Unofficial Site(s)
+                    </label>
                     <div class="col-md-10">
                         <div class="list-group">
                             <div class="list-group-item list-group-sub-item row" ng-repeat="site in dc.courseInstance.sites">
@@ -200,10 +221,10 @@
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Conclusion Date: </strong>
-                    </div>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Conclusion Date
+                    </label>
                     <div class="col-md-10">{{courseInstance.conclude_date}}</div>
                 </div>
             </li>

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -6,17 +6,19 @@
         <a href="{% url 'dashboard_account' %}">Admin Console</a>
         &gt; <a href="#/">Find Course Info</a>
         {% verbatim %}
-        <small><i class="fa fa-chevron-right"></i></small>
-        Details for {{dc.courseInstance.title}}
+        &gt;
+        <span ng-if="dc.courseInstance.title">Details for {{dc.courseInstance.title}}</span>
+        <span ng-if="!dc.courseInstance.title">Loading details for course instance {{dc.courseInstanceId}}... <i class="fa fa-refresh fa-spin"></i></span>
     </h3>
 </nav>
 
 <main>
-      <form name="courseDetailsForm" class="form-horizontal" ng-submit="dc.submitCourseDetailsForm()">
+      <form name="courseDetailsForm" class="form-horizontal" ng-if="dc.courseInstance.title" ng-submit="dc.submitCourseDetailsForm()">
         <ul class="list-group">
 
             <hu-editable-field
                 editable="false"
+                is-loading="dc.isDefined(dc.courseInstance.registrar_code_display)"
                 form-value="dc.courseInstance.registrar_code_display"
                 model-value="dc.formDisplayData.registrar_code_display"
                 field="registrar_code_display"
@@ -24,6 +26,7 @@
 
             <hu-field-label-wrapper
               field="xlist_status"
+              is-loading="dc.isDefined(dc.courseInstance.xlist_status)"
               label="Cross listing">
                 <div ng-switch on="dc.courseInstance.xlist_status">
                   <span ng-switch-when="Primary" class="label label-info">
@@ -36,6 +39,7 @@
 
             <hu-editable-field
                 editable="false"
+                is-loading="dc.isDefined(dc.courseInstance.term)"
                 form-value="dc.courseInstance.term"
                 model-value="dc.courseInstance.term"
                 field="term"
@@ -43,6 +47,7 @@
 
             <hu-editable-field
                 editable="false"
+                is-loading="dc.isDefined(dc.courseInstance.course_instance_id)"
                 form-value="dc.courseInstance.course_instance_id"
                 model-value="dc.courseInstance.course_instance_id"
                 field="course_instance_id"
@@ -50,6 +55,7 @@
 
             <hu-editable-field
                 editable="dc.editable"
+                is-loading="dc.isDefined(dc.courseInstance.title)"
                 form-value="dc.formDisplayData.title"
                 model-value="dc.courseInstance.title"
                 field="title"
@@ -57,6 +63,7 @@
 
             <hu-editable-field
                 editable="dc.editable"
+                is-loading="dc.isDefined(dc.courseInstance.short_title)"
                 form-value="dc.formDisplayData.short_title"
                 model-value="dc.courseInstance.short_title"
                 field="short_title"
@@ -64,6 +71,7 @@
 
             <hu-editable-field
                 editable="dc.editable"
+                is-loading="dc.isDefined(dc.courseInstance.sub_title)"
                 form-value="dc.formDisplayData.sub_title"
                 model-value="dc.courseInstance.sub_title"
                 field="sub_title"
@@ -71,6 +79,7 @@
 
             <hu-editable-field
                 editable="dc.editable"
+                is-loading="dc.isDefined(dc.courseInstance.description)"
                 form-value="dc.formDisplayData.description"
                 model-value="dc.courseInstance.description"
                 field="description"
@@ -78,6 +87,7 @@
 
             <hu-editable-field
                 editable="dc.editable"
+                is-loading="dc.isDefined(dc.courseInstance.notes)"
                 form-value="dc.formDisplayData.notes"
                 model-value="dc.courseInstance.notes"
                 field="notes"
@@ -85,12 +95,16 @@
 
             <hu-editable-field
                 editable="dc.editable"
+                is-loading="dc.isDefined(dc.courseInstance.instructors_display)"
                 form-value="dc.formDisplayData.instructors_display"
                 model-value="dc.courseInstance.instructors_display"
                 field="instructors_display"
                 label="Instructors (display)"></hu-editable-field>
 
-            <hu-field-label-wrapper field="people" label="People">
+            <hu-field-label-wrapper
+                is-loading="dc.isDefined(dc.courseInstance.members)"
+                field="people"
+                label="People">
               <a href="#/people/{{dc.courseInstance.course_instance_id}}">
                 <ng-pluralize count="dc.courseInstance.members"
                               when="{'0': 'There are no people in the course.',
@@ -102,6 +116,7 @@
 
             <hu-editable-field
                 editable="dc.editable"
+                is-loading="dc.isDefined(dc.courseInstance.location)"
                 form-value="dc.formDisplayData.location"
                 model-value="dc.courseInstance.location"
                 field="location"
@@ -109,26 +124,34 @@
 
             <hu-editable-field
                 editable="dc.editable"
+                is-loading="dc.isDefined(dc.courseInstance.meeting_time)"
                 form-value="dc.formDisplayData.meeting_time"
                 model-value="dc.courseInstance.meeting_time"
                 field="meeting_time"
                 label="Meeting time"></hu-editable-field>
 
-            <hu-field-label-wrapper field="departments" label="Departments">
+            <hu-field-label-wrapper
+                is-loading="dc.isDefined(dc.courseInstance.departments)"
+                field="departments"
+                label="Departments">
               <div class="row" ng-repeat="dept in dc.courseInstance.departments">
                 <div class="col-md-12"> {{dept.name}} </div>
               </div>
             </hu-field-label-wrapper>
 
-            <hu-field-label-wrapper field="course_groups" label="Course Groups">
+            <hu-field-label-wrapper
+                is-loading="dc.isDefined(dc.courseInstance.course_groups)"
+                field="course_groups"
+                label="Course Groups">
               <div class="row" ng-repeat="group in dc.courseInstance.course_groups">
                 <div class="col-md-12"> {{group.name}} </div>
               </div>
             </hu-field-label-wrapper>
 
             <hu-field-label-wrapper
-              field="sites"
-              label="Associated Official and Unofficial Site(s)">
+                is-loading="dc.isDefined(dc.courseInstance.sites)"
+                field="sites"
+                label="Associated Official and Unofficial Site(s)">
                 <div class="row" ng-repeat="site in dc.courseInstance.sites">
                   <div class="col-md-1">
                     <span class="label label-primary" ng-if="site.map_type == 'official'">Official</span>
@@ -141,7 +164,8 @@
             </hu-field-label-wrapper>
 
             <hu-editable-field
-                editable="dc.editable"
+                editable="false"
+                is-loading="dc.isDefined(dc.courseInstance.conclude_date)"
                 form-value="dc.formDisplayData.conclude_date"
                 model-value="dc.courseInstance.conclude_date"
                 field="conclude_date"

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -14,7 +14,7 @@
 <main class="float-left col-60">
     <div class="container-fluid">
 
-      <form name="courseDetailsForm" class="form-horizontal" ng-controller="DetailsController as dc" ng-submit="dc.submitCourseDetailsForm()">
+      <form name="courseDetailsForm" class="form-horizontal" ng-submit="dc.submitCourseDetailsForm()">
         <ul class="list-group">
 
             <li class="list-group-item">

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -53,11 +53,10 @@
         </div>
       </div>
 
-      <form name="courseDetailsForm" class="form-horizontal" ng-if="dc.courseInstance.title" ng-submit="dc.submitCourseDetailsForm(this)">
+      <form name="dc.courseDetailsForm" class="form-horizontal" ng-if="dc.courseInstance.title" ng-submit="dc.submitCourseDetailsForm(this)">
         <ul class="list-group">
 
             <hu-editable-field
-                editable="false"
                 is-loading="dc.isDefined(dc.courseInstance.registrar_code_display)"
                 form-value="dc.courseInstance.registrar_code_display"
                 model-value="dc.formDisplayData.registrar_code_display"
@@ -78,7 +77,6 @@
             </hu-field-label-wrapper>
 
             <hu-editable-field
-                editable="false"
                 is-loading="dc.isDefined(dc.courseInstance.term)"
                 form-value="dc.courseInstance.term"
                 model-value="dc.courseInstance.term"
@@ -86,7 +84,6 @@
                 label="Term"></hu-editable-field>
 
             <hu-editable-field
-                editable="false"
                 is-loading="dc.isDefined(dc.courseInstance.course_instance_id)"
                 form-value="dc.courseInstance.course_instance_id"
                 model-value="dc.courseInstance.course_instance_id"
@@ -98,6 +95,7 @@
                 is-loading="dc.isDefined(dc.courseInstance.title)"
                 form-value="dc.formDisplayData.title"
                 model-value="dc.courseInstance.title"
+                maxlength="500"
                 field="title"
                 label="Course Title"></hu-editable-field>
 
@@ -106,6 +104,7 @@
                 is-loading="dc.isDefined(dc.courseInstance.short_title)"
                 form-value="dc.formDisplayData.short_title"
                 model-value="dc.courseInstance.short_title"
+                maxlength="200"
                 field="short_title"
                 label="Short Title"></hu-editable-field>
 
@@ -114,6 +113,7 @@
                 is-loading="dc.isDefined(dc.courseInstance.sub_title)"
                 form-value="dc.formDisplayData.sub_title"
                 model-value="dc.courseInstance.sub_title"
+                maxlength="500"
                 field="sub_title"
                 label="Subtitle"></hu-editable-field>
 
@@ -130,6 +130,7 @@
                 is-loading="dc.isDefined(dc.courseInstance.notes)"
                 form-value="dc.formDisplayData.notes"
                 model-value="dc.courseInstance.notes"
+                maxlength="2000"
                 field="notes"
                 label="Notes"></hu-editable-field>
 
@@ -138,6 +139,7 @@
                 is-loading="dc.isDefined(dc.courseInstance.instructors_display)"
                 form-value="dc.formDisplayData.instructors_display"
                 model-value="dc.courseInstance.instructors_display"
+                maxlength="4000"
                 field="instructors_display"
                 label="Instructors (display)"></hu-editable-field>
 
@@ -175,6 +177,7 @@
                 is-loading="dc.isDefined(dc.courseInstance.location)"
                 form-value="dc.formDisplayData.location"
                 model-value="dc.courseInstance.location"
+                maxlength="500"
                 field="location"
                 label="Location"></hu-editable-field>
 
@@ -183,6 +186,7 @@
                 is-loading="dc.isDefined(dc.courseInstance.meeting_time)"
                 form-value="dc.formDisplayData.meeting_time"
                 model-value="dc.courseInstance.meeting_time"
+                maxlength="1000"
                 field="meeting_time"
                 label="Meeting time"></hu-editable-field>
 
@@ -220,7 +224,6 @@
             </hu-field-label-wrapper>
 
             <hu-editable-field
-                editable="false"
                 is-loading="dc.isDefined(dc.courseInstance.conclude_date)"
                 form-value="dc.formDisplayData.conclude_date"
                 model-value="dc.courseInstance.conclude_date"

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -7,227 +7,145 @@
         &gt; <a href="#/">Find Course Info</a>
         {% verbatim %}
         <small><i class="fa fa-chevron-right"></i></small>
-        Details for {{courseInstance.title}}
+        Details for {{dc.courseInstance.title}}
     </h3>
 </nav>
 
-<main class="float-left col-60">
-    <div class="container-fluid">
-
+<main>
       <form name="courseDetailsForm" class="form-horizontal" ng-submit="dc.submitCourseDetailsForm()">
         <ul class="list-group">
 
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                      Course Code
-                    </label>
-                    <div class="col-md-10">{{dc.courseInstance.registrar_code_display }}</div>
-                </div>
-            </li>
+            <hu-editable-field
+                editable="false"
+                form-value="dc.courseInstance.registrar_code_display"
+                model-value="dc.formDisplayData.registrar_code_display"
+                field="registrar_code_display"
+                label="Course Code"></hu-editable-field>
 
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                      Cross Listing
-                    </label>
-                    <div class="col-md-10" ng-switch on="dc.courseInstance.xlist_status">
-                        <span ng-switch-when="Primary" class="label label-info">Primary</span>
-                        <span ng-switch-when="Secondary" class="label label-info">Secondary</span>
-                        <span ng-switch-default class="label label-info">N/A</span>
-                    </div>
+            <hu-field-label-wrapper
+              field="xlist_status"
+              label="Cross listing">
+                <div ng-switch on="dc.courseInstance.xlist_status">
+                  <span ng-switch-when="Primary" class="label label-info">
+                    Primary </span>
+                  <span ng-switch-when="Secondary" class="label label-info">
+                    Secondary </span>
+                  <span ng-switch-default class="label label-info">N/A</span>
                 </div>
-            </li>
+            </hu-field-label-wrapper>
 
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                      Term
-                    </label>
-                    <div class="col-md-10">{{dc.courseInstance.term}}</div>
+            <hu-editable-field
+                editable="false"
+                form-value="dc.courseInstance.term"
+                model-value="dc.courseInstance.term"
+                field="term"
+                label="Term"></hu-editable-field>
+
+            <hu-editable-field
+                editable="false"
+                form-value="dc.courseInstance.course_instance_id"
+                model-value="dc.courseInstance.course_instance_id"
+                field="course_instance_id"
+                label="SIS/Course Instance ID"></hu-editable-field>
+
+            <hu-editable-field
+                editable="dc.editable"
+                form-value="dc.formDisplayData.title"
+                model-value="dc.courseInstance.title"
+                field="title"
+                label="Course Title"></hu-editable-field>
+
+            <hu-editable-field
+                editable="dc.editable"
+                form-value="dc.formDisplayData.short_title"
+                model-value="dc.courseInstance.short_title"
+                field="short_title"
+                label="Short Title"></hu-editable-field>
+
+            <hu-editable-field
+                editable="dc.editable"
+                form-value="dc.formDisplayData.sub_title"
+                model-value="dc.courseInstance.sub_title"
+                field="sub_title"
+                label="Subtitle"></hu-editable-field>
+
+            <hu-editable-field
+                editable="dc.editable"
+                form-value="dc.formDisplayData.description"
+                model-value="dc.courseInstance.description"
+                field="description"
+                label="Description"></hu-editable-field>
+
+            <hu-editable-field
+                editable="dc.editable"
+                form-value="dc.formDisplayData.notes"
+                model-value="dc.courseInstance.notes"
+                field="notes"
+                label="Notes"></hu-editable-field>
+
+            <hu-editable-field
+                editable="dc.editable"
+                form-value="dc.formDisplayData.instructors_display"
+                model-value="dc.courseInstance.instructors_display"
+                field="instructors_display"
+                label="Instructors (display)"></hu-editable-field>
+
+            <hu-field-label-wrapper field="people" label="People">
+              <a href="#/people/{{dc.courseInstance.course_instance_id}}">
+                <ng-pluralize count="dc.courseInstance.members"
+                              when="{'0': 'There are no people in the course.',
+                    'one': 'There is one person in the course.',
+                    'other': 'There are {} people in the course.'}">
+                </ng-pluralize>
+              </a>
+            </hu-field-label-wrapper>
+
+            <hu-editable-field
+                editable="dc.editable"
+                form-value="dc.formDisplayData.location"
+                model-value="dc.courseInstance.location"
+                field="location"
+                label="Location"></hu-editable-field>
+
+            <hu-editable-field
+                editable="dc.editable"
+                form-value="dc.formDisplayData.meeting_time"
+                model-value="dc.courseInstance.meeting_time"
+                field="meeting_time"
+                label="Meeting time"></hu-editable-field>
+
+            <hu-field-label-wrapper field="departments" label="Departments">
+              <div class="row" ng-repeat="dept in dc.courseInstance.departments">
+                <div class="col-md-12"> {{dept.name}} </div>
+              </div>
+            </hu-field-label-wrapper>
+
+            <hu-field-label-wrapper field="course_groups" label="Course Groups">
+              <div class="row" ng-repeat="group in dc.courseInstance.course_groups">
+                <div class="col-md-12"> {{group.name}} </div>
+              </div>
+            </hu-field-label-wrapper>
+
+            <hu-field-label-wrapper
+              field="sites"
+              label="Associated Official and Unofficial Site(s)">
+                <div class="row" ng-repeat="site in dc.courseInstance.sites">
+                  <div class="col-md-1">
+                    <span class="label label-primary" ng-if="site.map_type == 'official'">Official</span>
+                    <span class="label label-primary" ng-if="site.map_type == 'unofficial'">Unofficial</span>
+                  </div>
+                  <div class="col-md-11">
+                    <a href="{{site.course_site_url}}" target="_blank">{{site.course_site_url}}</a>
+                  </div>
                 </div>
-            </li>
+            </hu-field-label-wrapper>
 
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                      SIS/Course Instance ID
-                    </label>
-                    <div class="col-md-10">{{dc.courseInstance.course_instance_id}}</div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Course Title
-                    </label>
-                    <div class="col-md-10">
-                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.title" ng-show="dc.editable" />
-                      <span ng-bind-html="dc.courseInstance.title" ng-hide="dc.editable"></span>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Short Title
-                    </label>
-                    <div class="col-md-10">
-                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.short_title" ng-show="dc.editable" />
-                      <span ng-bind-html="dc.courseInstance.short_title" ng-hide="dc.editable"></span>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Subtitle
-                    </label>
-                    <div class="col-md-10">
-                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.sub_title" ng-show="dc.editable" />
-                      <span ng-bind-html="dc.courseInstance.sub_title" ng-hide="dc.editable"></span>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Description
-                    </label>
-                    <div class="col-md-10">
-                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.description" ng-show="dc.editable" />
-                      <span ng-bind-html="dc.courseInstance.description" ng-hide="dc.editable"></span>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Notes
-                    </label>
-                    <div class="col-md-10">
-                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.notes" ng-show="dc.editable" />
-                      <span ng-bind-html="dc.courseInstance.notes" ng-hide="dc.editable"></span>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Instructors (display)
-                    </label>
-                    <div class="col-md-10">
-                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.instructors_display" ng-show="dc.editable" />
-                      <span ng-bind-html="dc.courseInstance.instructors_display" ng-hide="dc.editable"></span>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        People
-                    </label>
-                    <div class="col-md-10">
-                        <a href="#/people/{{dc.courseInstance.course_instance_id}}">
-                            <ng-pluralize count="dc.courseInstance.members"
-                                          when="{'0': 'There are no people in the course.',
-                                'one': 'There is one person in the course.',
-                                'other': 'There are {} people in the course.'}">
-                            </ng-pluralize>
-                        </a>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Location
-                    </label>
-                    <div class="col-md-10">
-                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.location" ng-show="dc.editable" />
-                      <span ng-bind-html="dc.courseInstance.location" ng-hide="dc.editable"></span>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Meeting Time
-                    </label>
-                    <div class="col-md-10">
-                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.meeting_time" ng-show="dc.editable" />
-                      <span ng-bind-html="dc.courseInstance.meeting_time" ng-hide="dc.editable"></span>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Departments
-                    </label>
-                    <div class="col-md-10" ng-repeat="dept in dc.courseInstance.departments">
-                         <div class="list-group" ng-if="dc.courseInstance.departments.length > 0">
-                            <div class="list-group-item list-group-sub-item" ng-repeat="dept in dc.courseInstance.departments">
-                                {{dept.name}}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Course Groups
-                    </label>
-                    <div class="col-md-10">
-                        <div class="list-group">
-                            <div class="list-group-item list-group-sub-item" ng-repeat="group in dc.courseInstance.course_groups">
-                                {{group.name}}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Associated Official and Unofficial Site(s)
-                    </label>
-                    <div class="col-md-10">
-                        <div class="list-group">
-                            <div class="list-group-item list-group-sub-item row" ng-repeat="site in dc.courseInstance.sites">
-                                <div class="label label-primary col-md-1" ng-if="site.map_type == 'official'">Official</div>
-                                <div class="label label-primary col-md-1" ng-if="site.map_type == 'unofficial'">Unofficial</div>
-                                <div class="col-md-11"><a href="{{site.course_site_url}}"
-                                                          target="_blank">{{site.course_site_url}}</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-            </li>
-
-            <li class="list-group-item">
-                <div class="form-group">
-                    <label for="input-course-title" class="col-md-2 control-label">
-                        Conclusion Date
-                    </label>
-                    <div class="col-md-10">{{courseInstance.conclude_date}}</div>
-                </div>
-            </li>
+            <hu-editable-field
+                editable="dc.editable"
+                form-value="dc.formDisplayData.conclude_date"
+                model-value="dc.courseInstance.conclude_date"
+                field="conclude_date"
+                label="Conclusion Date"></hu-editable-field>
 
         </ul>
 
@@ -252,8 +170,8 @@
             </button>
           </div>
         </div>
+
       </form>
-    </div>
 </main>
 
 {% endverbatim %}

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -14,6 +14,7 @@
 <main class="float=left col=60">
     <div class="container-fluid">
 
+      <form name="courseDetailsForm" class="form-horizontal" ng-controller="DetailsController as dc" ng-submit="dc.submitCourseDetailsForm()">
         <ul class="list-group">
 
             <li class="list-group-item">
@@ -57,11 +58,14 @@
             </li>
 
             <li class="list-group-item">
-                <div class="row">
-                    <div class="col-md-2">
-                        <strong>Course Title: </strong>
+                <div class="form-group">
+                    <label for="input-course-title" class="col-md-2 control-label">
+                        Course Title
+                    </label>
+                    <div class="col-md-10">
+                      <input type="text" class="form-control" id="input-course-title" ng-model="dc.formDisplayData.title" ng-show="dc.editable" />
+                      <span ng-bind-html="dc.courseInstance.title" ng-hide="dc.editable"></span>
                     </div>
-                    <div class="col-md-10" ng-bind-html="dc.courseInstance.title"></div>
                 </div>
             </li>
 
@@ -197,6 +201,29 @@
             </li>
 
         </ul>
+
+        <div class="form-group" ng-show="dc.editable">
+          <div class="col-md-12">
+            <a type="link" class="btn btn-default"
+               ng-disabled="dc.courseDetailsUpdateInProgress || dc.courseInstance == null"
+               ng-click="dc.resetForm()">
+              Reset
+            </a>
+            <button id="course-details-form-submit" type="submit"
+                    class="btn btn-primary pull-right"
+                    ng-disabled="dc.courseDetailsUpdateInProgress || dc.courseInstance == null">
+              <span ng-switch="dc.courseDetailsUpdateInProgress">
+                <span ng-switch-when="false">
+                  Submit
+                </span>
+                <span ng-switch-when="true">
+                  <i class="fa fa-refresh fa-spin"></i> Updating Course...
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </form>
     </div>
 </main>
 

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -56,12 +56,12 @@
       <form name="dc.courseDetailsForm" class="form-horizontal" ng-if="dc.courseInstance.title" ng-submit="dc.submitCourseDetailsForm(this)">
         <ul class="list-group">
 
-            <hu-editable-field
+            <hu-editable-input
                 is-loading="dc.isDefined(dc.courseInstance.registrar_code_display)"
                 form-value="dc.courseInstance.registrar_code_display"
                 model-value="dc.formDisplayData.registrar_code_display"
                 field="registrar_code_display"
-                label="Course Code"></hu-editable-field>
+                label="Course Code"></hu-editable-input>
 
             <hu-field-label-wrapper
               field="xlist_status"
@@ -76,72 +76,72 @@
                 </div>
             </hu-field-label-wrapper>
 
-            <hu-editable-field
+            <hu-editable-input
                 is-loading="dc.isDefined(dc.courseInstance.term)"
                 form-value="dc.courseInstance.term"
                 model-value="dc.courseInstance.term"
                 field="term"
-                label="Term"></hu-editable-field>
+                label="Term"></hu-editable-input>
 
-            <hu-editable-field
+            <hu-editable-input
                 is-loading="dc.isDefined(dc.courseInstance.course_instance_id)"
                 form-value="dc.courseInstance.course_instance_id"
                 model-value="dc.courseInstance.course_instance_id"
                 field="course_instance_id"
-                label="SIS/Course Instance ID"></hu-editable-field>
+                label="SIS/Course Instance ID"></hu-editable-input>
 
-            <hu-editable-field
+            <hu-editable-input
                 editable="dc.editable"
                 is-loading="dc.isDefined(dc.courseInstance.title)"
                 form-value="dc.formDisplayData.title"
                 model-value="dc.courseInstance.title"
                 maxlength="500"
                 field="title"
-                label="Course Title"></hu-editable-field>
+                label="Course Title"></hu-editable-input>
 
-            <hu-editable-field
+            <hu-editable-input
                 editable="dc.editable"
                 is-loading="dc.isDefined(dc.courseInstance.short_title)"
                 form-value="dc.formDisplayData.short_title"
                 model-value="dc.courseInstance.short_title"
                 maxlength="200"
                 field="short_title"
-                label="Short Title"></hu-editable-field>
+                label="Short Title"></hu-editable-input>
 
-            <hu-editable-field
+            <hu-editable-input
                 editable="dc.editable"
                 is-loading="dc.isDefined(dc.courseInstance.sub_title)"
                 form-value="dc.formDisplayData.sub_title"
                 model-value="dc.courseInstance.sub_title"
                 maxlength="500"
                 field="sub_title"
-                label="Subtitle"></hu-editable-field>
+                label="Subtitle"></hu-editable-input>
 
-            <hu-editable-field
+            <hu-editable-input
                 editable="dc.editable"
                 is-loading="dc.isDefined(dc.courseInstance.description)"
                 form-value="dc.formDisplayData.description"
                 model-value="dc.courseInstance.description"
                 field="description"
-                label="Description"></hu-editable-field>
+                label="Description"></hu-editable-input>
 
-            <hu-editable-field
+            <hu-editable-input
                 editable="dc.editable"
                 is-loading="dc.isDefined(dc.courseInstance.notes)"
                 form-value="dc.formDisplayData.notes"
                 model-value="dc.courseInstance.notes"
                 maxlength="2000"
                 field="notes"
-                label="Notes"></hu-editable-field>
+                label="Notes"></hu-editable-input>
 
-            <hu-editable-field
+            <hu-editable-input
                 editable="dc.editable"
                 is-loading="dc.isDefined(dc.courseInstance.instructors_display)"
                 form-value="dc.formDisplayData.instructors_display"
                 model-value="dc.courseInstance.instructors_display"
                 maxlength="4000"
                 field="instructors_display"
-                label="Instructors (display)"></hu-editable-field>
+                label="Instructors (display)"></hu-editable-input>
 
             <hu-field-label-wrapper
                 is-loading="dc.isDefined(dc.courseInstance.members) && !dc.alertPresent('form', 'fetchMembersFailed')"
@@ -172,23 +172,23 @@
               </a>
             </hu-field-label-wrapper>
 
-            <hu-editable-field
+            <hu-editable-input
                 editable="dc.editable"
                 is-loading="dc.isDefined(dc.courseInstance.location)"
                 form-value="dc.formDisplayData.location"
                 model-value="dc.courseInstance.location"
                 maxlength="500"
                 field="location"
-                label="Location"></hu-editable-field>
+                label="Location"></hu-editable-input>
 
-            <hu-editable-field
+            <hu-editable-input
                 editable="dc.editable"
                 is-loading="dc.isDefined(dc.courseInstance.meeting_time)"
                 form-value="dc.formDisplayData.meeting_time"
                 model-value="dc.courseInstance.meeting_time"
                 maxlength="1000"
                 field="meeting_time"
-                label="Meeting time"></hu-editable-field>
+                label="Meeting time"></hu-editable-input>
 
             <hu-field-label-wrapper
                 is-loading="dc.isDefined(dc.courseInstance.departments)"
@@ -223,12 +223,12 @@
                 </div>
             </hu-field-label-wrapper>
 
-            <hu-editable-field
+            <hu-editable-input
                 is-loading="dc.isDefined(dc.courseInstance.conclude_date)"
                 form-value="dc.formDisplayData.conclude_date"
                 model-value="dc.courseInstance.conclude_date"
                 field="conclude_date"
-                label="Conclusion Date"></hu-editable-field>
+                label="Conclusion Date"></hu-editable-input>
 
         </ul>
 

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -13,7 +13,36 @@
 </nav>
 
 <main>
-      <form name="courseDetailsForm" class="form-horizontal" ng-if="dc.courseInstance.title" ng-submit="dc.submitCourseDetailsForm()">
+
+      <div id="alerts">
+        <div class="alert alert-success" role="alert"
+             id="alert-success-update-succeeded"
+             ng-if="dc.alerts.updateSucceeded && dc.alerts.updateSucceeded.show">
+          <p>
+            <i class="fa fa-check"></i>
+            Course instance updated.
+          </p>
+        </div>
+        <div class="alert alert-info" role="alert"
+             id="alert-info-form-reset"
+             ng-if="dc.alerts.formReset && dc.alerts.formReset.show">
+          <p>
+            <i class="fa fa-check"></i>
+            Course instance details reset.
+          </p>
+        </div>
+        <div class="alert alert-danger" role="alert"
+             id="alert-danger-update-failed"
+             ng-if="dc.alerts.updateFailed && dc.alerts.updateFailed.show">
+          <p>
+            <i class="fa fa-warning"></i>
+            The course instance could not be updated. Please try again.
+            Error details: {{ dc.alerts.updateFailed.details }}
+          </p>
+        </div>
+      </div>
+
+      <form name="courseDetailsForm" class="form-horizontal" ng-if="dc.courseInstance.title" ng-submit="dc.submitCourseDetailsForm(this)">
         <ul class="list-group">
 
             <hu-editable-field
@@ -177,7 +206,7 @@
           <div class="col-md-12">
             <a type="link" class="btn btn-default"
                ng-disabled="dc.courseDetailsUpdateInProgress || dc.courseInstance == null"
-               ng-click="dc.resetForm()">
+               ng-click="dc.resetFormFromUI()">
               Reset
             </a>
             <button id="course-details-form-submit" type="submit"

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -17,7 +17,7 @@
       <div id="alerts">
         <div class="alert alert-success" role="alert"
              id="alert-success-update-succeeded"
-             ng-if="dc.alerts.updateSucceeded && dc.alerts.updateSucceeded.show">
+             ng-if="dc.alertPresent('global', 'updateSucceeded')">
           <p>
             <i class="fa fa-check"></i>
             Course instance updated.
@@ -25,7 +25,7 @@
         </div>
         <div class="alert alert-info" role="alert"
              id="alert-info-form-reset"
-             ng-if="dc.alerts.formReset && dc.alerts.formReset.show">
+             ng-if="dc.alertPresent('global', 'formReset')">
           <p>
             <i class="fa fa-check"></i>
             Course instance details reset.
@@ -33,11 +33,22 @@
         </div>
         <div class="alert alert-danger" role="alert"
              id="alert-danger-update-failed"
-             ng-if="dc.alerts.updateFailed && dc.alerts.updateFailed.show">
+             ng-if="dc.alertPresent('global', 'updateFailed')">
           <p>
             <i class="fa fa-warning"></i>
             The course instance could not be updated. Please try again.
-            Error details: {{ dc.alerts.updateFailed.details }}
+            Error details: {{ dc.alerts.global.updateFailed.details }}
+          </p>
+        </div>
+        <div class="alert alert-danger" role="alert"
+             id="alert-danger-fetch-course-instance-failed"
+             ng-if="dc.alertPresent('global', 'fetchCourseInstanceFailed')">
+          <p>
+            <i class="fa fa-warning"></i>
+            The course instance details could not be fetched from the server.
+            Please try again.
+            Error details:
+            {{ dc.alerts.global.fetchCourseInstanceFailed.details }}
           </p>
         </div>
       </div>
@@ -131,9 +142,25 @@
                 label="Instructors (display)"></hu-editable-field>
 
             <hu-field-label-wrapper
-                is-loading="dc.isDefined(dc.courseInstance.members)"
+                is-loading="dc.isDefined(dc.courseInstance.members) && !dc.alertPresent('form', 'fetchMembersFailed')"
                 field="people"
                 label="People">
+              <div class="alert alert-danger" role="alert"
+                   id="alert-danger-fetch-course-members-failed"
+                   ng-if="dc.alertPresent('form', 'fetchMembersFailed')">
+                <p>
+                  <i class="fa fa-warning"></i>
+                  Error looking up course members.
+                  Error details: {{ dc.alerts.form.fetchMembersFailed.details }}
+                </p>
+                <p>
+                  <a href="#/people/{{dc.courseInstance.course_instance_id}}"
+                     class="alert-link">
+                    Go to course people page.
+                  </a>
+                </p>
+              </div>
+
               <a href="#/people/{{dc.courseInstance.course_instance_id}}">
                 <ng-pluralize count="dc.courseInstance.members"
                               when="{'0': 'There are no people in the course.',

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -57,7 +57,7 @@ describe('Unit testing DetailsController', function () {
         });
     });
 
-    describe('setup', function () {
+    describe('controller setup/initialization', function () {
         beforeEach(function () {
             dc = $controller('DetailsController', {$scope: scope});
         });
@@ -73,10 +73,13 @@ describe('Unit testing DetailsController', function () {
         it('should set the course instance id', function () {
             expect(dc.courseInstanceId).toEqual($routeParams.courseInstanceId);
         });
-
+        it('should populate the form immediately if course instance data is ' +
+            'available from the routeParams/previous screen, and then ' +
+            'continue to fetch course instance details to fill in missing ' +
+            'data');
     });
 
-    describe('setCourseInstance', function () {
+    describe('handleCourseInstanceResponse', function () {
         var ci;
         var members;
         beforeEach(function () {
@@ -99,7 +102,9 @@ describe('Unit testing DetailsController', function () {
             };
         });
 
-        it('should work when CourseInstance is empty', function () {
+        it('should fill in details from the course instance detail endpoint ' +
+            'when no course instance is provided by the ' +
+            'routeParams/previous screen', function () {
             var dc = $controller('DetailsController', {$scope: scope});
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify(members));
@@ -109,6 +114,9 @@ describe('Unit testing DetailsController', function () {
             expect(dc.courseInstance['members']).toEqual(100);
         });
 
+        it('should override details from the course instance info provided ' +
+            'by the routeParams/previous screen with refreshed/updated data ' +
+            'from the course instance detail endpoint ');
         it('should log an error when CourseInstance returns an invalid id', function () {
             controller = $controller('DetailsController', {$scope: scope});
             ci.course_instance_id = 12345;
@@ -136,7 +144,7 @@ describe('Unit testing DetailsController', function () {
                         site_id: '888',
                         map_type: 'official'
                     },
-                     {
+                    {
                         external_id: 'https://x.y.z/999',
                         site_id: '999',
                         map_type: 'unofficial'
@@ -156,7 +164,7 @@ describe('Unit testing DetailsController', function () {
                             id: 2
                         }
                     ],
-                    departments : [
+                    departments: [
                         {
                             name: 'dept1',
                             id: 1
@@ -175,7 +183,7 @@ describe('Unit testing DetailsController', function () {
             };
         });
 
-        it('format the course instance data for the UI ', function () {
+        it('should format the course instance data for the UI ', function () {
             courseInstances.instances[ci.course_instance_id] = ci;
             dc = $controller('DetailsController', {$scope: scope});
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
@@ -201,14 +209,52 @@ describe('Unit testing DetailsController', function () {
 
         });
 
-        it('should deal with an empty ci', function () {
-            dc = $controller('DetailsController', {$scope: scope});
-            spyOn($log, 'error');
-            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({}));
-            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({}));
-            $httpBackend.flush(2);
-            expect(dc.courseInstance).toEqual(undefined);
-            expect($log.error).toHaveBeenCalled();
-        });
     });
+        
+    describe('fetchCourseInstanceDetails', function() {
+        it('should handle both successful responses even if they arrive ' +
+            'separately');
+        it('should still handle the course instance data even if the ' +
+            'member data fetch fails');
+    });
+
+    describe('submitCourseDetailsForm', function() {
+        it('should call backend with only the editable form fields');
+        it('should show a message if successful and update the local ' +
+            'course instance data');
+        it('should show a message if unsuccessful and not update the ' +
+            'local course instance data');
+    });
+
+    describe('editableInputDirective', function() {
+        it('should substitute the right stuff for id, name, and label');
+        it('should show an input element if called with editable=true ' +
+            'and the value should be equal to the form\'s copy of the ' +
+            'model data');
+        it('should show regular non-editable text if called with ' +
+            'editable=false or no editable attribute and show the model ' +
+            'value, not the form copy of the model value');
+        it('should show only show the label and the loading indicator ' +
+            'while loading, and hide the loading indicator when no ' +
+            'longer loading');
+    });
+
+    describe('fieldLabelWrapperDirective', function() {
+        it('should call backend with only the editable form fields');
+        it('should show a message if successful and update the local ' +
+            'course instance data');
+        it('should show a message if unsuccessful and not update the ' +
+            'local course instance data');
+    });
+
+    describe('end-to-end tests - form interaction', function() {
+        it('should reset all data when form is reset and show reset ' +
+            'message');
+        it('should call backend on submit');
+        it('should show editable fields and form interaction buttons for ' +
+            'an editable course instance');
+        it('should show non-editable fields for a typical course ' +
+            'instance and no form interaction buttons');
+    });
+
 });


### PR DESCRIPTION
Pretty large change from TLT-1983. This PR adds editable fields to the course instance details page in the course_info tool according to TLT-2376 acceptance criteria.

It also:
- streamlines loading (uses existing course instance info if available, pulls extra from API asynchronously, and pulls course members asynchronously)
- provides loading indicators, failure indicators when data is unavailable from backend
- consolidates form fields into angular directives so that changes to field styling can be made in one place

Jasmine test stubs are included, but Jasmine tests can be worked on separately. Thanks!