### PR TITLE
Sprint 44 TLT-2376 Library updates

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -9,7 +9,7 @@ django-proxy==1.0.2
 django-redis-cache==1.5.3
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.19#egg=django-icommons-common==1.10.19
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.13#egg=django-icommons-ui==0.9.13
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.1#egg=django-icommons-ui==1.1
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.1#egg=canvas-python-sdk==0.8.1
 hiredis==0.2.0
 ims_lti_py==0.6

--- a/canvas_account_admin_tools/templates/canvas_account_admin_tools/base.html
+++ b/canvas_account_admin_tools/templates/canvas_account_admin_tools/base.html
@@ -8,8 +8,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Admin Tasks</title>
 
-        <link href="{% static 'bootstrap-3.3.4/css/bootstrap.min.css' %}" rel="stylesheet">
-        <link href="{% static 'font-awesome-4.2.0/css/font-awesome.min.css' %}" rel="stylesheet">
+        <link href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}" rel="stylesheet">
+        <link href="{% static 'font-awesome-4.5.0/css/font-awesome.min.css' %}" rel="stylesheet">
         {% block stylesheets %}{% endblock stylesheets %}
     </head>
     <body>
@@ -17,8 +17,8 @@
             {% block content %}{% endblock content %}
         </div>
 
-        <script src="{% static 'jquery-1.10.2/jquery-1.10.2.min.js' %}"></script>
-        <script src="{% static 'bootstrap-3.3.4/js/bootstrap.min.js' %}"></script>
+        <script src="{% static 'jquery-2.2.2/jquery-2.2.2.min.js' %}"></script>
+        <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.min.js' %}"></script>
         {% block javascript %}{% endblock javascript %}
     </body>
 </html>

--- a/course_info/templates/course_info/index.html
+++ b/course_info/templates/course_info/index.html
@@ -9,38 +9,34 @@
           content="width=device-width, initial-scale=1, user-scalable=no">
     <link href="{% static 'favicon.ico' %}" rel="icon" type="image/x-icon">
     <link rel="stylesheet" type="text/css"
-                           href="{% static 'font-awesome-4.2.0/css/font-awesome.min.css' %}">
+                           href="{% static 'font-awesome-4.5.0/css/font-awesome.min.css' %}">
     <link rel="stylesheet" type="text/css"
-                           href="{% static 'bootstrap-3.3.4/css/bootstrap.min.css' %}"
+                           href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}"
                            media="screen"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.7/media/css/jquery.dataTables.min.css' %}" media="screen"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-bootstrap3/BS3/assets/css/datatables.css' %}" media="screen"/>
+    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.11/datatables.min.css' %}" media="screen"/>
     <link rel="stylesheet" type="text/css" href="{% static 'course_info/css/index.css' %}">
 
     {% if debug %}
-    <script src="{% static 'jquery-1.10.2/jquery-1.10.2.js' %}"></script>
-    <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.js' %}"></script>
-    <script src="{% static 'underscore-1.8.2/underscore.js' %}"></script>
-    <script src="{% static 'bootstrap-3.3.4/js/bootstrap.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular-route.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular-sanitize.js' %}"></script>
-    <script src="{% static 'angular-ui-bootstrap-0.14.3/ui-bootstrap-tpls-0.14.3.js' %}"></script>
+    <script src="{% static 'jquery-2.2.2/jquery-2.2.2.js' %}"></script>
+    <script src="{% static 'datatables-1.10.11/datatables.js' %}"></script>
+    <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular-route.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular-sanitize.js' %}"></script>
+    <script src="{% static 'angular-ui-bootstrap-1.2.5/ui-bootstrap-tpls-1.2.5.js' %}"></script>
     <script src="{% static 'djangular/js/django-angular.js' %}"></script>
-    <script src="{% static 'angular-datatables-0.5.1/angular-datatables.js' %}"></script>
+    <script src="{% static 'angular-datatables-0.5.3/dist/angular-datatables.js' %}"></script>
     {% else %}
-    <script src="{% static 'jquery-1.10.2/jquery-1.10.2.min.js' %}"></script>
-    <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.min.js' %}"></script>
-    <script src="{% static 'underscore-1.8.2/underscore.min.js' %}"></script>
-    <script src="{% static 'bootstrap-3.3.4/js/bootstrap.min.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular.min.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular-route.min.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular-sanitize.min.js' %}"></script>
-    <script src="{% static 'angular-ui-bootstrap-0.14.3/ui-bootstrap-tpls-0.14.3.min.js' %}"></script>
+    <script src="{% static 'jquery-2.2.2/jquery-2.2.2.min.js' %}"></script>
+    <script src="{% static 'datatables-1.10.11/datatables.min.js' %}"></script>
+    <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.min.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular.min.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular-route.min.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular-sanitize.min.js' %}"></script>
+    <script src="{% static 'angular-ui-bootstrap-1.2.5/ui-bootstrap-tpls-1.2.5.min.js' %}"></script>
     <script src="{% static 'djangular/js/django-angular.min.js' %}"></script>
-    <script src="{% static 'angular-datatables-0.5.1/angular-datatables.min.js' %}"></script>
+    <script src="{% static 'angular-datatables-0.5.3/dist/angular-datatables.min.js' %}"></script>
     {% endif %}
-    <script src="{% static 'datatables-bootstrap3/BS3/assets/js/datatables.js' %}"></script>
     {# fixes safari autocomplete issue #}
     {# (see https://github.com/angular/angular.js/issues/1460) #}
     <script src="{% static 'course_info/js/polyfills/autofill-event.js' %}"></script>

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -19,8 +19,8 @@
 
   <div class="col-md-12">
       <div id="courseInfoDT_wrapper" class="dataTables_wrapper form-inline no-footer">
-        <!-- UI comment - inline style for a table border until table-box makes it to Bootrsap 4 -->
-        <table id="courseInfoDT" class="display dataTable course-info-table"
+        <table id="courseInfoDT"
+               class="display dataTable course-info-table table table-striped table-condensed"
                role="grid" aria-describedby="courseInfoDT_info"
                cellspacing="0">
           <tbody>

--- a/course_info/templates/course_info/partials/search.html
+++ b/course_info/templates/course_info/partials/search.html
@@ -105,7 +105,9 @@
 
   <p class="panel">
     <div ng-cloak ng-show="showDataTable">
-      <table id="courseInfoDT" class="display" cellspacing="0" width="100%">
+      <table id="courseInfoDT"
+             class="table table-striped table-condensed dataTable display"
+             cellspacing="0" width="100%">
         <thead>
           <th class="sorting" tabindex="0">School&nbsp;&nbsp;</th>
           <th class="sorting" tabindex="0">Course Details&nbsp;&nbsp;</th>

--- a/cross_list_courses/templates/cross_list_courses/index.html
+++ b/cross_list_courses/templates/cross_list_courses/index.html
@@ -9,36 +9,32 @@
           content="width=device-width, initial-scale=1, user-scalable=no">
     <link href="/static/favicon.ico" rel="icon" type="image/x-icon">
     <link rel="stylesheet" type="text/css"
-          href="{% static 'font-awesome-4.2.0/css/font-awesome.min.css' %}">
+          href="{% static 'font-awesome-4.5.0/css/font-awesome.min.css' %}">
     <link rel="stylesheet" type="text/css"
-          href="{% static 'bootstrap-3.3.4/css/bootstrap.min.css' %}"
+          href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}"
           media="screen"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.7/media/css/jquery.dataTables.min.css' %}" media="screen"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-bootstrap3/BS3/assets/css/datatables.css' %}" media="screen"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'cross_list_courses/css/index.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.11/datatables.min.css' %}" media="screen"/>
 
     {% if debug %}
-    <script src="{% static 'jquery-1.10.2/jquery-1.10.2.js' %}"></script>
-    <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.js' %}"></script>
-    <script src="{% static 'underscore-1.8.2/underscore.js' %}"></script>
-    <script src="{% static 'bootstrap-3.3.4/js/bootstrap.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular-route.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular-sanitize.js' %}"></script>
-    <script src="{% static 'angular-ui-bootstrap-0.14.3/ui-bootstrap-tpls-0.14.3.js' %}"></script>
+    <script src="{% static 'jquery-2.2.2/jquery-2.2.2.js' %}"></script>
+    <script src="{% static 'datatables-1.10.11/datatables.js' %}"></script>
+    <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular-route.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular-sanitize.js' %}"></script>
+    <script src="{% static 'angular-ui-bootstrap-1.2.5/ui-bootstrap-tpls-1.2.5.js' %}"></script>
     <script src="{% static 'djangular/js/django-angular.js' %}"></script>
-    <script src="{% static 'angular-datatables-0.5.1/angular-datatables.js' %}"></script>
+    <script src="{% static 'angular-datatables-0.5.3/dist/angular-datatables.js' %}"></script>
     {% else %}
-    <script src="{% static 'jquery-1.10.2/jquery-1.10.2.min.js' %}"></script>
-    <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.min.js' %}"></script>
-    <script src="{% static 'underscore-1.8.2/underscore.min.js' %}"></script>
-    <script src="{% static 'bootstrap-3.3.4/js/bootstrap.min.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular.min.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular-route.min.js' %}"></script>
-    <script src="{% static 'angular-1.3.9/angular-sanitize.min.js' %}"></script>
-    <script src="{% static 'angular-ui-bootstrap-0.14.3/ui-bootstrap-tpls-0.14.3.min.js' %}"></script>
+    <script src="{% static 'jquery-2.2.2/jquery-2.2.2.min.js' %}"></script>
+    <script src="{% static 'datatables-1.10.11/datatables.min.js' %}"></script>
+    <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.min.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular.min.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular-route.min.js' %}"></script>
+    <script src="{% static 'angular-1.5.2/angular-sanitize.min.js' %}"></script>
+    <script src="{% static 'angular-ui-bootstrap-1.2.5/ui-bootstrap-tpls-1.2.5.min.js' %}"></script>
     <script src="{% static 'djangular/js/django-angular.min.js' %}"></script>
-    <script src="{% static 'angular-datatables-0.5.1/angular-datatables.min.js' %}"></script>
+    <script src="{% static 'angular-datatables-0.5.3/dist/angular-datatables.min.js' %}"></script>
     {% endif %}
   
     {% include 'django_auth_lti/resource_link_id.html' %}


### PR DESCRIPTION
I'm not actually entirely sure that we had been using the bootstrap styling for datatables in `course_info` before, since our `<table>` tags were missing the bootstrap table-styling classes.  But we're using them now.

Depends on https://github.com/Harvard-University-iCommons/django-icommons-ui/pull/77.