### PR TITLE
tlt-2376: edit course details - fixes course members count 

### DIFF
--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -89,6 +89,10 @@
             var members_url = djangoUrl.reverse(dc.apiProxy,
                 [dc.apiBase + id + '/people/']);
 
+            var membersQueryConfig = {
+                params: { '-source': 'xreg_map' }  // exclude xreg people
+            };
+
             $http.get(course_url)
                 .then(dc.handleCourseInstanceResponse,
                     function cleanUpFailedCourseDetailsGet(response) {
@@ -97,7 +101,7 @@
                             response.statusText);
                 });
 
-            $http.get(members_url)
+            $http.get(members_url, membersQueryConfig)
                 .then(dc.handlePeopleResponse,
                     function cleanUpFailedCourseMembersGet(response) {
                         dc.handleAjaxErrorResponse(response);


### PR DESCRIPTION
(fixes bug TLT-2532)
- the course people tool/page excludes source=xreg course member records; this fix updates the count in the edit course people link to also exclude xreg records