### PR TITLE
Sprint 44 TLT-2376 Revert to using datatables default styling

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -9,7 +9,7 @@ django-proxy==1.0.2
 django-redis-cache==1.5.3
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.19#egg=django-icommons-common==1.10.19
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.1#egg=django-icommons-ui==1.1
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.1.1#egg=django-icommons-ui==1.1.1
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.1#egg=canvas-python-sdk==0.8.1
 hiredis==0.2.0
 ims_lti_py==0.6

--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -151,11 +151,10 @@
             $scope.initializeDatatable = function() {
                 $scope.dataTable = $('#courseInfoDT').DataTable({
                     serverSide: true,
-                    deferLoading: true,
                     ajax: function(data, callback, settings) {
-                        $scope.$apply(function(){
+                        $timeout(function(){
                             $scope.searchInProgress = true;
-                        });
+                        }, 0);
                         $scope.enableColumnSorting(false);
                         //filter the sites flagged to be excluded(get only ones
                         // with exclude_from_isites set to 0)

--- a/course_info/templates/course_info/index.html
+++ b/course_info/templates/course_info/index.html
@@ -13,12 +13,12 @@
     <link rel="stylesheet" type="text/css"
                            href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}"
                            media="screen"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.11/datatables.min.css' %}" media="screen"/>
+    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.11/media/css/jquery.dataTables.min.css' %}" media="screen"/>
     <link rel="stylesheet" type="text/css" href="{% static 'course_info/css/index.css' %}">
 
     {% if debug %}
     <script src="{% static 'jquery-2.2.2/jquery-2.2.2.js' %}"></script>
-    <script src="{% static 'datatables-1.10.11/datatables.js' %}"></script>
+    <script src="{% static 'datatables-1.10.11/media/js/jquery.dataTables.js' %}"></script>
     <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular-route.js' %}"></script>
@@ -28,7 +28,7 @@
     <script src="{% static 'angular-datatables-0.5.3/dist/angular-datatables.js' %}"></script>
     {% else %}
     <script src="{% static 'jquery-2.2.2/jquery-2.2.2.min.js' %}"></script>
-    <script src="{% static 'datatables-1.10.11/datatables.min.js' %}"></script>
+    <script src="{% static 'datatables-1.10.11/media/js/jquery.dataTables.min.js' %}"></script>
     <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.min.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular.min.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular-route.min.js' %}"></script>

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -20,7 +20,7 @@
   <div class="col-md-12">
       <div id="courseInfoDT_wrapper" class="dataTables_wrapper form-inline no-footer">
         <table id="courseInfoDT"
-               class="display dataTable course-info-table table table-striped table-condensed"
+               class="display dataTable course-info-table"
                role="grid" aria-describedby="courseInfoDT_info"
                cellspacing="0">
           <tbody>

--- a/course_info/templates/course_info/partials/search.html
+++ b/course_info/templates/course_info/partials/search.html
@@ -105,9 +105,7 @@
 
   <p class="panel">
     <div ng-cloak ng-show="showDataTable">
-      <table id="courseInfoDT"
-             class="table table-striped table-condensed dataTable display"
-             cellspacing="0" width="100%">
+      <table id="courseInfoDT" class="display" cellspacing="0" width="100%">
         <thead>
           <th class="sorting" tabindex="0">School&nbsp;&nbsp;</th>
           <th class="sorting" tabindex="0">Course Details&nbsp;&nbsp;</th>


### PR DESCRIPTION
(depends on https://github.com/Harvard-University-iCommons/django-icommons-ui/pull/79)

So, it turns out the column width issue (sizing them based on the headers, not the data) wasn't due to the styling library, it was because datatables changed the semantics of what it expected for the `deferLoading` option.  That must have been causing some internal error that DT swallowed, which resulted in the bad widths.  Removing it exposed a separate bug, that we were calling `$scope.$apply()` from within our ajax callback, and that might be happening when angular is already in a digest cycle.  Applying the standard "wrap it in `$timeout(..., 0)` instead" fix resolved the issue, and got us back to a sane column width.

We could probably go back and *reapply* the bootstrap styling, but a) I'm tired of messing with this for no real reason, b) a quick straw poll shows people prefer the default stying, and c) this means there should be no user-visible changes from our library upgrades.