### PR TITLE
Sprint 44 TLT-2376 Add deferLoading back in, fix paths for xlisting

### DIFF
--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -150,6 +150,7 @@
             var request = null;
             $scope.initializeDatatable = function() {
                 $scope.dataTable = $('#courseInfoDT').DataTable({
+                    deferLoading: 999, // number doesn't matter because table hidden
                     serverSide: true,
                     ajax: function(data, callback, settings) {
                         $timeout(function(){
@@ -200,7 +201,10 @@
                                     recordsFiltered: data.count,
                                     data: processedData
                                 });
-                                $scope.showDataTable = true;
+                                $timeout(function() {
+                                    $scope.dataTable.columns.adjust();
+                                    $scope.showDataTable = true;
+                                }, 0);
                             },
                             error: function(jqXHR, textStatus, errorThrown) {
                                 console.log(textStatus);

--- a/cross_list_courses/templates/cross_list_courses/index.html
+++ b/cross_list_courses/templates/cross_list_courses/index.html
@@ -13,11 +13,11 @@
     <link rel="stylesheet" type="text/css"
           href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}"
           media="screen"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.11/datatables.min.css' %}" media="screen"/>
+    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.11/media/css/jquery.dataTables.min.css' %}" media="screen"/>
 
     {% if debug %}
     <script src="{% static 'jquery-2.2.2/jquery-2.2.2.js' %}"></script>
-    <script src="{% static 'datatables-1.10.11/datatables.js' %}"></script>
+    <script src="{% static 'datatables-1.10.11/media/js/jquery.dataTables.js' %}"></script>
     <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular-route.js' %}"></script>
@@ -27,7 +27,7 @@
     <script src="{% static 'angular-datatables-0.5.3/dist/angular-datatables.js' %}"></script>
     {% else %}
     <script src="{% static 'jquery-2.2.2/jquery-2.2.2.min.js' %}"></script>
-    <script src="{% static 'datatables-1.10.11/datatables.min.js' %}"></script>
+    <script src="{% static 'datatables-1.10.11/media/js/jquery.dataTables.min.js' %}"></script>
     <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.min.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular.min.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular-route.min.js' %}"></script>


### PR DESCRIPTION
Somehow I missed the fact that with `deferLoading` missing, datatables would immediately load a page of data, before the user picked from the dropdowns and hit search.  Also, I forgot to check the crosslisting app.