### PR TITLE
Task/eparker71/tlt 2376/wip on jasmine tests

### DIFF
--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -126,7 +126,7 @@
                     ? ci.course.registrar_code_display
                     : ci.course.registrar_code;
 
-                courseInstance['registrar_code_display'] = registrarCode.trim();
+                courseInstance['registrar_code_display'] = registrarCode.trim() + ' (' + ci.course.course_id + ')';
 
                 courseInstance['description'] = ci.description;
                 courseInstance['short_title'] = ci.short_title;

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -130,7 +130,7 @@
                     ? ci.course.registrar_code_display
                     : ci.course.registrar_code;
 
-                courseInstance['registrar_code_display'] = registrarCode.trim() + ' (' + ci.course.course_id + ')';
+                courseInstance['registrar_code_display'] = registrarCode.trim();
 
                 courseInstance['description'] = ci.description;
                 courseInstance['short_title'] = ci.short_title;

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -513,15 +513,5 @@ describe('Unit testing DetailsController', function () {
         it('should show a message if unsuccessful and not update the ' +
             'local course instance data');
     });
-
-    describe('end-to-end tests - form interaction', function() {
-        it('should reset all data when form is reset and show reset ' +
-            'message');
-        it('should call backend on submit');
-        it('should show editable fields and form interaction buttons for ' +
-            'an editable course instance');
-        it('should show non-editable fields for a typical course ' +
-            'instance and no form interaction buttons');
-    });
-
+    
 });

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -451,8 +451,8 @@ describe('Unit testing DetailsController', function () {
         function getCompiledElement(){
             var element = angular.element('<hu-editable-input ' +
                     'editable="dc.editable"' +
-                    'is-loading="true"' +
-                    'form-value="tesValue"' +
+                    'is-loading="dc.isUndefined(dc.courseInstance.term)"' +
+                    'form-value="dc.courseInstance.term"' +
                     'model-value="testModelValue"' +
                     'maxlength="500"' +
                     'field="test-name"' +
@@ -465,7 +465,6 @@ describe('Unit testing DetailsController', function () {
 
         it('should substitute the right stuff for id, name, and label', function(){
             dc = $controller('DetailsController', {$scope: scope});
-            dc.editable = true;
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.flush(2);
@@ -479,7 +478,6 @@ describe('Unit testing DetailsController', function () {
             'and the value should be equal to the form\'s copy of the ' +
             'model data', function(){
             dc = $controller('DetailsController', {$scope: scope});
-            //dc.editable = true;
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.flush(2);
@@ -491,7 +489,6 @@ describe('Unit testing DetailsController', function () {
             'editable=false or no editable attribute and show the model ' +
             'value, not the form copy of the model value', function(){
             dc = $controller('DetailsController', {$scope: scope});
-            dc.editable = false;
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.flush(2);
@@ -499,10 +496,11 @@ describe('Unit testing DetailsController', function () {
             expect(liElement.find('input')).not.toBeVisible();
         });
 
-        it('should show only show the label and the loading indicator ' +
+        // skipping this test, can't seem to get it to work.
+        // we can revisit if needed.
+        xit('should only show the label and the loading indicator ' +
             'while loading, and hide the loading indicator when no ' +
             'longer loading', function(){
-
         });
     });
 
@@ -513,5 +511,5 @@ describe('Unit testing DetailsController', function () {
         it('should show a message if unsuccessful and not update the ' +
             'local course instance data');
     });
-    
+
 });

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -295,7 +295,83 @@ describe('Unit testing DetailsController', function () {
     });
 
     describe('submitCourseDetailsForm', function() {
-        it('should call backend with only the editable form fields');
+        var ci;
+        var members;
+        beforeEach(function () {
+            ci = {
+                course_instance_id: $routeParams.courseInstanceId,
+                title: 'Test Title',
+                short_title: 'Test',
+                sub_title: 'Jasime is your friend',
+                description: '<p>hello</p>',
+                sites: [
+                    {
+                        external_id: 'https://x.y.z/888',
+                        site_id: '888',
+                        map_type: 'official'
+                    },
+                    {
+                        external_id: 'https://x.y.z/999',
+                        site_id: '999',
+                        map_type: 'unofficial'
+                    }
+                ],
+                course: {
+                    school_id: 'abc',
+                    registrar_code: 'ILE-2222',
+                    registrar_code_display: '2222',
+                    course_id: '789',
+                    course_groups: [
+                        {
+                            name: 'group one',
+                            id: 1
+                        },
+                        {
+                            name: 'group two',
+                            id: 2
+                        }
+                    ],
+                    departments: [
+                        {
+                            name: 'dept1',
+                            id: 1
+                        }
+                    ]
+                },
+                term: {
+                    display_name: 'Summer 2015',
+                    academic_year: '2015',
+                },
+                primary_xlist_instances: [],
+            };
+
+            members = {
+                count: 100
+            };
+        });
+
+        it('should call backend with only the editable form fields', function(){
+            courseInstances.instances[ci.course_instance_id] = ci;
+            dc = $controller('DetailsController', {$scope: scope});
+            spyOn(dc, 'showNewGlobalAlert');
+            dc.formDisplayData = {
+                'description': 'this is a test',
+                'instructors_display': 'test teacher',
+                'location': 'test room',
+                'meeting_time': 'test oclock',
+                'notes': 'test notes',
+                'short_title': 'test short title',
+                'sub_title': 'test sub title',
+                'title': 'test title'
+            };
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.flush(2);
+            dc.submitCourseDetailsForm();
+            $httpBackend.expectPATCH(courseInstanceURL).respond(201, JSON.stringify({status: "success"}));
+            $httpBackend.flush(1);
+            expect(dc.showNewGlobalAlert).toHaveBeenCalled();
+        });
         it('should show a message if successful and update the local ' +
             'course instance data');
         it('should show a message if unsuccessful and not update the ' +

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -297,10 +297,21 @@ describe('Unit testing DetailsController', function () {
     describe('submitCourseDetailsForm', function() {
         var ci;
         var members;
+        var expectedPatchData = {
+                "description":"this is a test",
+                "instructors_display":"test teacher",
+                "location":"test room",
+                "meeting_time":"test oclock",
+                "notes":"test notes",
+                "short_title":"test short title",
+                "sub_title":"test sub title",
+                "title":"test title"
+            };
+
         beforeEach(function () {
             ci = {
                 course_instance_id: $routeParams.courseInstanceId,
-                title: 'Test Title',
+                title: 'Test Course Title',
                 short_title: 'Test',
                 sub_title: 'Jasime is your friend',
                 description: '<p>hello</p>',
@@ -364,18 +375,67 @@ describe('Unit testing DetailsController', function () {
                 'sub_title': 'test sub title',
                 'title': 'test title'
             };
+
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.flush(2);
             dc.submitCourseDetailsForm();
-            $httpBackend.expectPATCH(courseInstanceURL).respond(201, JSON.stringify({status: "success"}));
+            $httpBackend.expectPATCH(courseInstanceURL, expectedPatchData).respond(201, JSON.stringify({status: "success"}));
             $httpBackend.flush(1);
             expect(dc.showNewGlobalAlert).toHaveBeenCalled();
         });
+
         it('should show a message if successful and update the local ' +
-            'course instance data');
+            'course instance data', function(){
+            courseInstances.instances[ci.course_instance_id] = ci;
+            dc = $controller('DetailsController', {$scope: scope});
+            spyOn(dc, 'showNewGlobalAlert');
+            dc.formDisplayData = {
+                'description': 'this is a test',
+                'instructors_display': 'test teacher',
+                'location': 'test room',
+                'meeting_time': 'test oclock',
+                'notes': 'test notes',
+                'short_title': 'test short title',
+                'sub_title': 'test sub title',
+                'title': 'test title'
+            };
+
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.flush(2);
+            dc.submitCourseDetailsForm();
+            $httpBackend.expectPATCH(courseInstanceURL, expectedPatchData).respond(201, JSON.stringify({status: "success"}));
+            $httpBackend.flush(1);
+            expect(dc.showNewGlobalAlert).toHaveBeenCalled();
+            expect(dc.courseInstance['title']).toBe('test title');
+        });
+
         it('should show a message if unsuccessful and not update the ' +
-            'local course instance data');
+            'local course instance data', function(){
+            courseInstances.instances[ci.course_instance_id] = ci;
+            dc = $controller('DetailsController', {$scope: scope});
+            spyOn(dc, 'showNewGlobalAlert');
+            dc.formDisplayData = {
+                'description': 'this is a test',
+                'instructors_display': 'test teacher',
+                'location': 'test room',
+                'meeting_time': 'test oclock',
+                'notes': 'test notes',
+                'short_title': 'test short title',
+                'sub_title': 'test sub title',
+                'title': 'test title'
+            };
+
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.flush(2);
+            dc.submitCourseDetailsForm();
+            $httpBackend.expectPATCH(courseInstanceURL, expectedPatchData).respond(500);
+            $httpBackend.flush(1);
+            expect(dc.showNewGlobalAlert).toHaveBeenCalledWith('updateFailed', '');
+            expect(dc.courseInstance['title']).not.toBe('test title');
+        });
     });
 
     describe('editableInputDirective', function() {

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -10,7 +10,7 @@ describe('Unit testing DetailsController', function () {
 
     var peopleURL =
         '/angular/reverse/?djng_url_name=icommons_rest_api_proxy&djng_url_args' +
-        '=api%2Fcourse%2Fv2%2Fcourse_instances%2F' + courseInstanceId + '%2Fpeople%2F';
+        '=api%2Fcourse%2Fv2%2Fcourse_instances%2F' + courseInstanceId + '%2Fpeople%2F&-source=xreg_map';
 
     // set up the test environment
     beforeEach(function () {
@@ -202,7 +202,7 @@ describe('Unit testing DetailsController', function () {
             expect(dc.courseInstance['year']).toEqual(ci.term.academic_year);
             expect(dc.courseInstance['course_instance_id']).toEqual(ci.course_instance_id);
             expect(dc.courseInstance['registrar_code_display']).toEqual(
-                ci.course.registrar_code_display + ' (' + ci.course.course_id + ')');
+                ci.course.registrar_code_display);
             expect(dc.courseInstance['sites']).toEqual(ci.sites);
             expect(dc.courseInstance['xlist_status']).toEqual('N/A');
             expect(dc.courseInstance['description']).toEqual('<p>hello</p>');
@@ -439,16 +439,71 @@ describe('Unit testing DetailsController', function () {
     });
 
     describe('editableInputDirective', function() {
-        it('should substitute the right stuff for id, name, and label');
+        var compile, scope, directiveElem;
+        beforeEach(function () {
+             inject(function($compile, $rootScope){
+                compile = $compile;
+                scope = $rootScope.$new();
+              });
+              directiveElem = getCompiledElement();
+        });
+
+        function getCompiledElement(){
+            var element = angular.element('<hu-editable-input ' +
+                    'editable="dc.editable"' +
+                    'is-loading="true"' +
+                    'form-value="tesValue"' +
+                    'model-value="testModelValue"' +
+                    'maxlength="500"' +
+                    'field="test-name"' +
+                'label="test label">' +
+                '</hu-editable-input>');
+            var compiledElement = compile(element)(scope);
+            scope.$digest();
+            return compiledElement;
+        }
+
+        it('should substitute the right stuff for id, name, and label', function(){
+            dc = $controller('DetailsController', {$scope: scope});
+            dc.editable = true;
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.flush(2);
+            var liElement = directiveElem.find('li');
+            expect(liElement.find('label').text().trim()).toBe('test label');
+            expect(liElement.find('input').prop('id')).toBe('input-course-test-name');
+            expect(liElement.find('input').prop('maxlength')).toBe(500);
+        });
+
         it('should show an input element if called with editable=true ' +
             'and the value should be equal to the form\'s copy of the ' +
-            'model data');
+            'model data', function(){
+            dc = $controller('DetailsController', {$scope: scope});
+            //dc.editable = true;
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.flush(2);
+            var liElement = directiveElem.find('li');
+            expect(liElement.find('input').prop('id')).toBe('input-course-test-name');
+        });
+
         it('should show regular non-editable text if called with ' +
             'editable=false or no editable attribute and show the model ' +
-            'value, not the form copy of the model value');
+            'value, not the form copy of the model value', function(){
+            dc = $controller('DetailsController', {$scope: scope});
+            dc.editable = false;
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.flush(2);
+            var liElement = directiveElem.find('li');
+            expect(liElement.find('input')).not.toBeVisible();
+        });
+
         it('should show only show the label and the loading indicator ' +
             'while loading, and hide the loading indicator when no ' +
-            'longer loading');
+            'longer loading', function(){
+
+        });
     });
 
     describe('fieldLabelWrapperDirective', function() {

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -274,7 +274,6 @@ describe('Unit testing DetailsController', function () {
             'separately', function(){
             courseInstances.instances[ci.course_instance_id] = ci;
             dc = $controller('DetailsController', {$scope: scope});
-            spyOn(dc, 'handleCourseInstanceResponse');
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify(members));
             $httpBackend.flush(2);
@@ -382,7 +381,7 @@ describe('Unit testing DetailsController', function () {
             dc.submitCourseDetailsForm();
             $httpBackend.expectPATCH(courseInstanceURL, expectedPatchData).respond(201, JSON.stringify({status: "success"}));
             $httpBackend.flush(1);
-            expect(dc.showNewGlobalAlert).toHaveBeenCalled();
+            expect(dc.showNewGlobalAlert).toHaveBeenCalledWith('updateSucceeded');
         });
 
         it('should show a message if successful and update the local ' +
@@ -407,7 +406,7 @@ describe('Unit testing DetailsController', function () {
             dc.submitCourseDetailsForm();
             $httpBackend.expectPATCH(courseInstanceURL, expectedPatchData).respond(201, JSON.stringify({status: "success"}));
             $httpBackend.flush(1);
-            expect(dc.showNewGlobalAlert).toHaveBeenCalled();
+            expect(dc.showNewGlobalAlert).toHaveBeenCalledWith('updateSucceeded');
             expect(dc.courseInstance['title']).toBe('test title');
         });
 
@@ -459,8 +458,7 @@ describe('Unit testing DetailsController', function () {
                 'label="test label">' +
                 '</hu-editable-input>');
             var compiledElement = compile(element)(scope);
-            //scope.$digest();
-            scope.$apply();
+            scope.$digest();
             return compiledElement;
         }
 
@@ -470,81 +468,29 @@ describe('Unit testing DetailsController', function () {
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.flush(2);
             var liElement = directiveElem.find('li');
+            console.log(liElement);
             expect(liElement.find('label').text().trim()).toBe('test label');
             expect(liElement.find('input').prop('id')).toBe('input-course-test-name');
+            expect(liElement.find('input').prop('name')).toBe('input-course-test-name');
             expect(liElement.find('input').prop('maxlength')).toBe(500);
-        });
-
-        it('should show an input element if called with editable=true ' +
-            'and the value should be equal to the form\'s copy of the ' +
-            'model data', function(){
-            dc = $controller('DetailsController', {$scope: scope});
-            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
-            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
-            $httpBackend.flush(2);
-            var liElement = directiveElem.find('li');
-            expect(liElement.find('input').prop('id')).toBe('input-course-test-name');
         });
 
         // skipping this test as I'm pretty sure it's not
         // doing the right thing, I left the code so when we
         // revisit we can see what we tried to do. This will be
         // included in the tech debt item TLT-2539
-        xit('should show regular non-editable text if called with ' +
+        it('should show an input element if called with editable=true ' +
+            'and the value should be equal to the form\'s copy of the ' +
+            'model data');
+
+        // ditto comment above
+        it('should show regular non-editable text if called with ' +
             'editable=false or no editable attribute and show the model ' +
-            'value, not the form copy of the model value', function(){
-            dc = $controller('DetailsController', {$scope: scope});
-            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
-            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
-            $httpBackend.flush(2);
-            var liElement = directiveElem.find('li');
-            console.log(liElement);
-            expect(liElement.find('input')).not.toBeVisible();
-        });
+            'value, not the form copy of the model value');
 
         // skipping the following test, they are tech debt in TLT-2539
-        xit('should only show the label and the loading indicator ' +
+        it('should only show the label and the loading indicator ' +
             'while loading, and hide the loading indicator when no ' +
-            'longer loading', function(){
-        });
+            'longer loading');
     });
-
-    describe('fieldLabelWrapperDirective', function() {
-        var compile, scope, directiveElem;
-        beforeEach(function () {
-             inject(function($compile, $rootScope){
-                compile = $compile;
-                scope = $rootScope.$new();
-              });
-              directiveElem = getCompiledElement();
-            scope = directiveElem.isolateScope();
-        });
-
-        function getCompiledElement(){
-            var element = angular.element('<hu-field-label-wrapper ' +
-                    'is-loading="dc.isUndefined(dc.courseInstance.term)"' +
-                    'field="test-name"' +
-                    'label="fieldLabelWrapperDirective test label">' +
-                '</hu-field-label-wrapper>');
-            var compiledElement = compile(element)(scope);
-            scope.$digest();
-            return compiledElement;
-        }
-
-        it('should display the correct value for label', function(){
-            dc = $controller('DetailsController', {$scope: scope});
-            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
-            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
-            $httpBackend.flush(2);
-            var elem = directiveElem.find('li');
-            expect(elem.find('label').text().trim()).toBe('fieldLabelWrapperDirective test label');
-        });
-        // skipping the following tests, they are tech debt in TLT-2539
-        xit('should call backend with only the editable form fields');
-        xit('should show a message if successful and update the local ' +
-            'course instance data');
-        xit('should show a message if unsuccessful and not update the ' +
-            'local course instance data');
-    });
-
 });

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -274,13 +274,24 @@ describe('Unit testing DetailsController', function () {
             'separately', function(){
             courseInstances.instances[ci.course_instance_id] = ci;
             dc = $controller('DetailsController', {$scope: scope});
+            spyOn(dc, 'handleCourseInstanceResponse');
             $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify(members));
             $httpBackend.flush(2);
+            expect(dc.courseInstance['title']).toEqual(ci.title);
+            expect( dc.courseInstance['members']).toEqual(members.count);
         });
 
         it('should still handle the course instance data even if the ' +
-            'member data fetch fails');
+            'member data fetch fails', function(){
+            courseInstances.instances[ci.course_instance_id] = ci;
+            dc = $controller('DetailsController', {$scope: scope});
+            spyOn(dc, 'handleCourseInstanceResponse');
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
+            $httpBackend.expectGET(peopleURL).respond(500);
+            $httpBackend.flush(2);
+            expect(dc.courseInstance['title']).toEqual(ci.title);
+        });
     });
 
     describe('submitCourseDetailsForm', function() {

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -459,7 +459,8 @@ describe('Unit testing DetailsController', function () {
                 'label="test label">' +
                 '</hu-editable-input>');
             var compiledElement = compile(element)(scope);
-            scope.$digest();
+            //scope.$digest();
+            scope.$apply();
             return compiledElement;
         }
 
@@ -485,7 +486,11 @@ describe('Unit testing DetailsController', function () {
             expect(liElement.find('input').prop('id')).toBe('input-course-test-name');
         });
 
-        it('should show regular non-editable text if called with ' +
+        // skipping this test as I'm pretty sure it's not
+        // doing the right thing, I left the code so when we
+        // revisit we can see what we tried to do. This will be
+        // included in the tech debt item TLT-2539
+        xit('should show regular non-editable text if called with ' +
             'editable=false or no editable attribute and show the model ' +
             'value, not the form copy of the model value', function(){
             dc = $controller('DetailsController', {$scope: scope});
@@ -493,11 +498,11 @@ describe('Unit testing DetailsController', function () {
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.flush(2);
             var liElement = directiveElem.find('li');
+            console.log(liElement);
             expect(liElement.find('input')).not.toBeVisible();
         });
 
-        // skipping this test, can't seem to get it to work.
-        // we can revisit if needed.
+        // skipping the following test, they are tech debt in TLT-2539
         xit('should only show the label and the loading indicator ' +
             'while loading, and hide the loading indicator when no ' +
             'longer loading', function(){
@@ -505,10 +510,40 @@ describe('Unit testing DetailsController', function () {
     });
 
     describe('fieldLabelWrapperDirective', function() {
-        it('should call backend with only the editable form fields');
-        it('should show a message if successful and update the local ' +
+        var compile, scope, directiveElem;
+        beforeEach(function () {
+             inject(function($compile, $rootScope){
+                compile = $compile;
+                scope = $rootScope.$new();
+              });
+              directiveElem = getCompiledElement();
+            scope = directiveElem.isolateScope();
+        });
+
+        function getCompiledElement(){
+            var element = angular.element('<hu-field-label-wrapper ' +
+                    'is-loading="dc.isUndefined(dc.courseInstance.term)"' +
+                    'field="test-name"' +
+                    'label="fieldLabelWrapperDirective test label">' +
+                '</hu-field-label-wrapper>');
+            var compiledElement = compile(element)(scope);
+            scope.$digest();
+            return compiledElement;
+        }
+
+        it('should display the correct value for label', function(){
+            dc = $controller('DetailsController', {$scope: scope});
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
+            $httpBackend.flush(2);
+            var elem = directiveElem.find('li');
+            expect(elem.find('label').text().trim()).toBe('fieldLabelWrapperDirective test label');
+        });
+        // skipping the following tests, they are tech debt in TLT-2539
+        xit('should call backend with only the editable form fields');
+        xit('should show a message if successful and update the local ' +
             'course instance data');
-        it('should show a message if unsuccessful and not update the ' +
+        xit('should show a message if unsuccessful and not update the ' +
             'local course instance data');
     });
 

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -468,7 +468,6 @@ describe('Unit testing DetailsController', function () {
             $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify({status: "success"}));
             $httpBackend.flush(2);
             var liElement = directiveElem.find('li');
-            console.log(liElement);
             expect(liElement.find('label').text().trim()).toBe('test label');
             expect(liElement.find('input').prop('id')).toBe('input-course-test-name');
             expect(liElement.find('input').prop('name')).toBe('input-course-test-name');

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -90,6 +90,7 @@ describe('Unit testing DetailsController', function () {
                 title: 'Test Title',
                 course: {
                     school_id: 'abc',
+                    registrar_code: 'ILE-2222',
                     registrar_code_display: '2222'
                 },
                 term: {
@@ -152,6 +153,7 @@ describe('Unit testing DetailsController', function () {
                 ],
                 course: {
                     school_id: 'abc',
+                    registrar_code: 'ILE-2222',
                     registrar_code_display: '2222',
                     course_id: '789',
                     course_groups: [
@@ -212,8 +214,71 @@ describe('Unit testing DetailsController', function () {
     });
         
     describe('fetchCourseInstanceDetails', function() {
+
+        var ci;
+        var members;
+        beforeEach(function () {
+            ci = {
+                course_instance_id: $routeParams.courseInstanceId,
+                title: 'Test Title',
+                short_title: 'Test',
+                sub_title: 'Jasime is your friend',
+                description: '<p>hello</p>',
+                sites: [
+                    {
+                        external_id: 'https://x.y.z/888',
+                        site_id: '888',
+                        map_type: 'official'
+                    },
+                    {
+                        external_id: 'https://x.y.z/999',
+                        site_id: '999',
+                        map_type: 'unofficial'
+                    }
+                ],
+                course: {
+                    school_id: 'abc',
+                    registrar_code: 'ILE-2222',
+                    registrar_code_display: '2222',
+                    course_id: '789',
+                    course_groups: [
+                        {
+                            name: 'group one',
+                            id: 1
+                        },
+                        {
+                            name: 'group two',
+                            id: 2
+                        }
+                    ],
+                    departments: [
+                        {
+                            name: 'dept1',
+                            id: 1
+                        }
+                    ]
+                },
+                term: {
+                    display_name: 'Summer 2015',
+                    academic_year: '2015',
+                },
+                primary_xlist_instances: [],
+            };
+
+            members = {
+                count: 100
+            };
+        });
+
         it('should handle both successful responses even if they arrive ' +
-            'separately');
+            'separately', function(){
+            courseInstances.instances[ci.course_instance_id] = ci;
+            dc = $controller('DetailsController', {$scope: scope});
+            $httpBackend.expectGET(courseInstanceURL).respond(200, JSON.stringify(ci));
+            $httpBackend.expectGET(peopleURL).respond(200, JSON.stringify(members));
+            $httpBackend.flush(2);
+        });
+
         it('should still handle the course instance data even if the ' +
             'member data fetch fails');
     });

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -196,7 +196,7 @@ describe('Unit testing PeopleController', function() {
                     (ci.course.school_id.toUpperCase());
             expect(scope.courseInstance['term']).toEqual(ci.term.display_name);
             expect(scope.courseInstance['year']).toEqual(ci.term.academic_year);
-            expect(scope.courseInstance['cid']).toEqual(ci.course_instance_id);
+            expect(scope.courseInstance['course_instance_id']).toEqual(ci.course_instance_id);
             expect(scope.courseInstance['registrar_code_display']).toEqual(
                     ci.course.registrar_code_display);
             expect(scope.courseInstance['sites']).toEqual('888');


### PR DESCRIPTION
This PR contains Jasmine tests for TLT-2376

There are a few skipped tests for directives, basically we couldn't figure out how to get the directive and controller data to work together. These have been put in the tech debt item TLT-2539. 