### PR TITLE
Sprint 44 TLT-1310 Exit with error code on error from selenium

### DIFF
--- a/canvas_account_admin_tools/settings/local.py
+++ b/canvas_account_admin_tools/settings/local.py
@@ -51,7 +51,7 @@ SELENIUM_CONFIG = {
    'icommons_rest_api': {
       'base_path': 'api/course/v2'
    },
-   'run_locally': False,
+   'run_locally': SECURE_SETTINGS.get('selenium_run_locally', False),
    'selenium_username': SECURE_SETTINGS.get('selenium_user'),
    'selenium_password': SECURE_SETTINGS.get('selenium_password'),
    'selenium_grid_url': SECURE_SETTINGS.get('selenium_grid_url'),

--- a/selenium_tests/regression_suite.py
+++ b/selenium_tests/regression_suite.py
@@ -43,4 +43,6 @@ suite = unittest.defaultTestLoader.discover(
 )
 
 # run the suite
-runner.run(suite)
+result = runner.run(suite)
+if not result.wasSuccessful():
+    raise SystemExit(1)


### PR DESCRIPTION
Includes a change to get selenium's `run_locally` from `secure.py`.