### PR TITLE
Sprint 44 TLT-2376 Look for the new uib template path

### DIFF
--- a/course_info/static/course_info/js/app.js
+++ b/course_info/static/course_info/js/app.js
@@ -18,8 +18,8 @@
                     //
                     // window.globals.append_resource_link_id function added by
                     // django_auth_lti/js/resource_link_id.js
-                    if (!(config.url.startsWith('template/alert/') ||
-                                config.url.startsWith('template/modal/'))) {
+                    if (!(config.url.startsWith('uib/template/alert/') ||
+                                config.url.startsWith('uib/template/modal/'))) {
                         config.url = window.globals.append_resource_link_id(config.url);
                     }
                     return config;


### PR DESCRIPTION
Sorry I missed this.  The angular-ui-bootstrap project changed the path they look for their built-in templates on, and our "don't add `resource_link_id` to the url for uib template urls" logic needed to know about it.