### PR TITLE
Task/sapnamysore/tlt 2523/selenium test regular course not editable

### DIFF
--- a/selenium_tests/course_info/course_info_details_edit_tests.py
+++ b/selenium_tests/course_info/course_info_details_edit_tests.py
@@ -56,12 +56,6 @@ class CourseInfoDetailsEditTests(CourseInfoBaseTestCase):
         for f in self.editable_fields:
             self.assertEqual(api_data[f], new_field_values[f])
 
-    def test_regular_course_not_editable(self):
-        """
-        verify non-SB/ILE courses cannot be edited
-        """
-
-        pass
 
     def test_reset_form(self):
         """

--- a/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
+++ b/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
@@ -1,10 +1,7 @@
-from selenium.webdriver.support import expected_conditions as EC
-
 from selenium_tests.course_info.course_info_base_test_case \
     import CourseInfoBaseTestCase
 from selenium_tests.course_info.page_objects.course_info_detail_page_object \
     import  Locators
-
 
 
 class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
@@ -26,14 +23,6 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         self.assertEquals(self.detail_page.is_locator_element_present
                           (Locators.SAVE_FORM_BUTTON), False)
 
-        # The tests are validating against an exact match for the class
-        # attribute of non-editable fields
-        # (Editable fields also contain a "ng-binding" but it is always
-        # accompanied by additional suffixes "ng-binding some_value",
-        # which is not an exact match).
-
-        expected_class_name = "ng-binding"
-
         # The span element exists only there if is a value in the field.
         # Limitation:  Each of the fields of the test site is
         # populated with a value. When testing a new course, note that
@@ -52,11 +41,17 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         'title'
         ]
 
-        # loops through each of the non-editable fields and looks for the
-        # exact class associated with non-editable fields and also
-        # verifies that the field is not rendered as an input element
+        # The tests are validating against an exact match for the class
+        # attribute of non-editable fields
+        # (Editable fields also contain a "ng-binding" but it is always
+        # accompanied by additional suffixes "ng-binding some_value",
+        # which is not an exact match).
+        expected_class_name = "ng-binding"
+
 
         for element in non_editable_fields:
+            # assert exact class associated with non-editable fields
+            # and also verifies that the field is not rendered as an input element
             self.assertEqual(self.detail_page.get_span_element_class(element),
                              expected_class_name)
             self.assertFalse(

--- a/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
+++ b/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
@@ -1,0 +1,32 @@
+from selenium_tests.course_info.course_info_base_test_case \
+    import CourseInfoBaseTestCase
+from selenium_tests.course_info.page_objects.course_info_detail_page_object \
+    import CourseInfoDetailPageObject, Locators
+
+
+class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
+
+    def setUp(self):
+        super(CourseInfoDetailsNonEditTests, self).setUp()
+        #Load a non-ILE course to validate non editable courses
+        self._load_test_course()
+        self.assertTrue(self.detail_page.is_loaded())
+
+    def test_regular_course_not_editable(self):
+        """
+        verify non-SB/ILE courses cannot be edited
+        """
+
+        #Assert that the Save and Reset button are not present
+        self.assertEquals(self.detail_page.is_locator_element_present
+                          (Locators.RESET_FORM_BUTTON), False)
+        self.assertEquals(self.detail_page.is_locator_element_present
+                          (Locators.SAVE_FORM_BUTTON), False)
+
+        # assert that an editable field(ex:  title) element is present, but not editable
+        # Note - this is WIP , not working yet.
+        editable_field ='title'
+        result = self.detail_page.get_input_field(editable_field)
+
+
+

--- a/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
+++ b/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
@@ -11,7 +11,7 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
 
     def setUp(self):
         super(CourseInfoDetailsNonEditTests, self).setUp()
-        #Load a non-ILE course to validate non editable courses
+        # Load a non-ILE course to validate non editable courses
         self._load_test_course()
         self.assertTrue(self.detail_page.is_loaded())
 
@@ -26,14 +26,15 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         self.assertEquals(self.detail_page.is_locator_element_present
                           (Locators.SAVE_FORM_BUTTON), False)
 
+        # The tests are validating against an exact match for the class
+        # attribute of non-editable fields
+        # (Editable fields also contain a "ng-binding" but it is always
+        # accompanied by additional suffixes "ng-binding some_value",
+        # which is not an exact match).
 
-        """TLT-2523: Every field has a span/input id regardless of whether
-        the field is editable, so tests cannot rely on the presence of an
-        span/input id.  The tests are validating against a class
-        element for non-editable fields
-        """
+        expected_class_name = "ng-binding"
 
-        # NOTE: The span element exists only there is a value in the field.
+        # The span element exists only there if is a value in the field.
         # Limitation:  Each of the fields of the test site is
         # populated with a value. When testing a new course, note that
         # tests may break if field values are null.
@@ -52,9 +53,9 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         ]
 
         # loops through each of the non-editable fields and looks for the
-        # unique class element associated with non-editable fields and also
-        # verifies that the field is not rendered as an input
-        expected_class_name = "ng-binding"
+        # exact class associated with non-editable fields and also
+        # verifies that the field is not rendered as an input element
+
         for element in non_editable_fields:
             self.assertEqual(self.detail_page.get_span_element_class(element),
                              expected_class_name)

--- a/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
+++ b/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
@@ -1,7 +1,5 @@
 from selenium_tests.course_info.course_info_base_test_case \
     import CourseInfoBaseTestCase
-from selenium_tests.course_info.page_objects.course_info_detail_page_object \
-    import  Locators
 
 
 class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
@@ -12,21 +10,14 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         self._load_test_course()
         self.assertTrue(self.detail_page.is_loaded())
 
-
     def test_regular_course_not_editable(self):
         """
+        TLT-2523 (AC 2)
         verify non-SB/ILE courses cannot be edited
         """
-        # Assert that the Save and Reset button are not present
-        self.assertEquals(self.detail_page.is_locator_element_present
-                          (Locators.RESET_FORM_BUTTON), False)
-        self.assertEquals(self.detail_page.is_locator_element_present
-                          (Locators.SAVE_FORM_BUTTON), False)
-
-        # The span element exists only there if is a value in the field.
-        # Limitation:  Each of the fields of the test site is
-        # populated with a value. When testing a new course, note that
-        # tests may break if field values are null.
+        # Verify that buttons to edit page are not present
+        self.assertFalse(self.detail_page.
+                         verify_buttons_to_edit_page_are_present())
 
         non_editable_fields = [
         'course_instance_id',
@@ -41,18 +32,8 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         'title'
         ]
 
-        # The tests are validating against an exact match for the class
-        # attribute of non-editable fields
-        # (Editable fields also contain a "ng-binding" but it is always
-        # accompanied by additional suffixes "ng-binding some_value",
-        # which is not an exact match).
-        expected_class_name = "ng-binding"
-
-
         for element in non_editable_fields:
-            # assert exact class associated with non-editable fields
-            # and also verifies that the field is not rendered as an input element
-            self.assertEqual(self.detail_page.get_span_element_class(element),
-                             expected_class_name)
+            #  verify that the field is not rendered as an input element
             self.assertFalse(
                     self.detail_page.is_element_displayed_as_input_field(element))
+

--- a/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
+++ b/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
@@ -29,23 +29,22 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
 
         """TLT-2523: Every field has a span/input id regardless of whether
         the field is editable, so tests cannot rely on the presence of an
-        span/input id.  The tests are validating against a unique class
+        span/input id.  The tests are validating against a class
         element for non-editable fields
         """
 
-        # The span element exists only there is a value in the field.
+        # NOTE: The span element exists only there is a value in the field.
         # Limitation:  Each of the fields of the test site is
         # populated with a value. When testing a new course, note that
         # tests may break if field values are null.
 
         non_editable_fields = [
         'course_instance_id',
-        # 'departments',
         'description',
         'instructors_display',
         'location',
         'meeting_time',
-        # 'notes',
+        'notes',
         'registrar_code_display',
         'sub_title',
         'term',
@@ -53,10 +52,11 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         ]
 
         # loops through each of the non-editable fields and looks for the
-        # unique class element associated with non-editable fields
+        # unique class element associated with non-editable fields and also
+        # verifies that the field is not rendered as an input
         expected_class_name = "ng-binding"
         for element in non_editable_fields:
             self.assertEqual(self.detail_page.get_span_element_class(element),
                              expected_class_name)
-
-
+            self.assertFalse(
+                    self.detail_page.is_element_displayed_as_input_field(element))

--- a/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
+++ b/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
@@ -1,7 +1,11 @@
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
 from selenium_tests.course_info.course_info_base_test_case \
     import CourseInfoBaseTestCase
 from selenium_tests.course_info.page_objects.course_info_detail_page_object \
     import CourseInfoDetailPageObject, Locators
+
 
 
 class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
@@ -16,17 +20,35 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         """
         verify non-SB/ILE courses cannot be edited
         """
-
-        #Assert that the Save and Reset button are not present
+        # Assert that the Save and Reset button are not present
         self.assertEquals(self.detail_page.is_locator_element_present
                           (Locators.RESET_FORM_BUTTON), False)
         self.assertEquals(self.detail_page.is_locator_element_present
                           (Locators.SAVE_FORM_BUTTON), False)
 
-        # assert that an editable field(ex:  title) element is present, but not editable
-        # Note - this is WIP , not working yet.
-        editable_field ='title'
-        result = self.detail_page.get_input_field(editable_field)
+
+        #TODO: #1. update locators on details PO to find xpath details,
+        # # by ID isn't working for some reasons
+        # Non-Working locator:
+        # element = self.detail_page.get_input_field_for_non_editable_fields(
+        #             'registrar_code_display')
+
+
+        """
+        Every field element has a span/input id so the test needs to check on
+        the presence of a unique class element for non-editable fields.
+        """
+
+        #TODO: #2. refactor "find elements" and reusable locators to the PO
+        #TODO: #3. loop through all the fields that are editable for this test
+
+        # WORKING TEST
+        # Tests that the specific field is non-editable
+        element = self.driver.find_element_by_xpath(
+            ".//*[@id='span-course-course_instance_id"
+            "']").find_elements(*Locators.NON_EDITABLE_FIELD_CLASS_NAME)
+        self.assertTrue(EC.presence_of_element_located(element))
+
 
 
 

--- a/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
+++ b/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
@@ -1,5 +1,4 @@
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
 
 from selenium_tests.course_info.course_info_base_test_case \
     import CourseInfoBaseTestCase
@@ -27,28 +26,25 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
                           (Locators.SAVE_FORM_BUTTON), False)
 
 
-        #TODO: #1. update locators on details PO to find xpath details,
-        # # by ID isn't working for some reasons
-        # Non-Working locator:
-        # element = self.detail_page.get_input_field_for_non_editable_fields(
-        #             'registrar_code_display')
-
-
-        """
-        Every field element has a span/input id so the test needs to check on
-        the presence of a unique class element for non-editable fields.
+        """TLT-2523: Every field has a span/input id regardless of whether
+        the field is editable, so tests cannot rely on the presence of an
+        span/input id.  The tests are validating against a unique class
+        element for non-editable fields
         """
 
-        #TODO: #2. refactor "find elements" and reusable locators to the PO
-        #TODO: #3. loop through all the fields that are editable for this test
+        non_editable_fields = [
+        'term',
+        'registrar_code_display'
+        ]
+        # TODO: get the full list of fields to loop through
 
-        # WORKING TEST
-        # Tests that the specific field is non-editable
-        element = self.driver.find_element_by_xpath(
-            ".//*[@id='span-course-course_instance_id"
-            "']").find_elements(*Locators.NON_EDITABLE_FIELD_CLASS_NAME)
-        self.assertTrue(EC.presence_of_element_located(element))
+        # loops through each of the non-editable fields and looks for the
+        # unique class element associated with non-editable fields
+        for element in non_editable_fields:
+            field_element = self.driver.find_element(
+                *Locators.SPAN_ELEMENT_BY_FIELD_NAME(
+                element)).find_elements(
+                *Locators.NON_EDITABLE_FIELD_CLASS_NAME)
 
-
-
-
+        # verifies that the fields are non-editable
+        self.assertTrue(EC.presence_of_element_located(field_element))

--- a/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
+++ b/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
@@ -32,9 +32,23 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         element for non-editable fields
         """
 
+        # The span element exists only there is a value in the field.
+        # Limitation:  Each of the fields of the test site is
+        # populated with a value. When testing a new course, note that
+        # tests may break if field values are null.
+
         non_editable_fields = [
+        'course_instance_id',
+        'departments',
+        'description',
+        'instructors_display',
+        'location',
+        'meeting_time',
+        'notes',
+        'registrar_code_display',
+        'sub_title',
         'term',
-        'registrar_code_display'
+        'title'
         ]
         # TODO: get the full list of fields to loop through
 

--- a/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
+++ b/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
@@ -3,7 +3,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium_tests.course_info.course_info_base_test_case \
     import CourseInfoBaseTestCase
 from selenium_tests.course_info.page_objects.course_info_detail_page_object \
-    import CourseInfoDetailPageObject, Locators
+    import  Locators
 
 
 
@@ -14,6 +14,7 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         #Load a non-ILE course to validate non editable courses
         self._load_test_course()
         self.assertTrue(self.detail_page.is_loaded())
+
 
     def test_regular_course_not_editable(self):
         """
@@ -39,26 +40,23 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
 
         non_editable_fields = [
         'course_instance_id',
-        'departments',
+        # 'departments',
         'description',
         'instructors_display',
         'location',
         'meeting_time',
-        'notes',
+        # 'notes',
         'registrar_code_display',
         'sub_title',
         'term',
         'title'
         ]
-        # TODO: get the full list of fields to loop through
 
         # loops through each of the non-editable fields and looks for the
         # unique class element associated with non-editable fields
+        expected_class_name = "ng-binding"
         for element in non_editable_fields:
-            field_element = self.driver.find_element(
-                *Locators.SPAN_ELEMENT_BY_FIELD_NAME(
-                element)).find_elements(
-                *Locators.NON_EDITABLE_FIELD_CLASS_NAME)
+            self.assertEqual(self.detail_page.get_span_element_class(element),
+                             expected_class_name)
 
-        # verifies that the fields are non-editable
-        self.assertTrue(EC.presence_of_element_located(field_element))
+

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -46,6 +46,11 @@ class CourseInfoDetailPageObject(CourseInfoBasePageObject):
         input = self.find_element(*Locators.INPUT_BY_FIELD_NAME(field_name))
         return input.get_attribute('value')
 
+    def is_element_displayed_as_input_field(self, field_name):
+        is_displayed = self.find_element(*Locators.INPUT_BY_FIELD_NAME(
+                field_name)).is_displayed()
+        return is_displayed
+
     def get_span_element_class(self, field_name):
         span_element = self.find_element(
                 *Locators.SPAN_ELEMENT_BY_FIELD_NAME(field_name))

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -12,11 +12,6 @@ class Locators(object):
     MAIN_TAG = (By.CSS_SELECTOR, "main.course-info-details-page")
     RESET_FORM_BUTTON = (By.ID, "course-details-form-reset")
     SAVE_FORM_BUTTON = (By.ID, "course-details-form-submit")
-    # The class locator is unique to non-editable fields, which will match
-    # this exact value.  Editable fields also contain a "ng-binding" but it
-    # is always accompanied by additional suffixes "ng-binding some_value",
-    # which is not an exact match.
-    NON_EDITABLE_FIELD_CLASS_NAME = (By.CLASS_NAME, "ng-binding")
 
     @classmethod
     def INPUT_BY_FIELD_NAME(cls, field_name):

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -23,12 +23,13 @@ class Locators(object):
         """
         return By.ID, 'input-course-{}'.format(field_name)
 
-    def INPUT_BY_FIELD_NAME_FOR_NON_EDITABLE_FIELDS(cls, field_name):
+    @classmethod
+    def SPAN_ELEMENT_BY_FIELD_NAME(cls, field_name):
         """
         returns a locator for an span field for a course instance record
         field name (e.g. title, sub_title, description)
         """
-        return By.XPATH, ".//*[@id='span-course-{}']".format(field_name)
+        return By.ID, 'span-course-{}'.format(field_name)
 
 
 class CourseInfoDetailPageObject(CourseInfoBasePageObject):
@@ -48,14 +49,6 @@ class CourseInfoDetailPageObject(CourseInfoBasePageObject):
     def get_input_field(self, field_name):
         self._wait_for_input_field_to_be_visible(field_name)
         input = self.find_element(*Locators.INPUT_BY_FIELD_NAME(field_name))
-        return input
-
-    def get_input_field_for_non_editable_fields(self, field_name):
-        self._wait_for_input_field_to_be_visible(field_name)
-        input = self.find_element(
-                *Locators.INPUT_BY_FIELD_NAME_FOR_NON_EDITABLE_FIELDS(
-                        field_name)
-        )
         return input
 
     def go_to_people_page(self):

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -1,5 +1,7 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
+from selenium.common.exceptions import NoSuchElementException
+
 
 from selenium_tests.course_info.page_objects.course_info_base_page_object \
     import CourseInfoBasePageObject
@@ -9,6 +11,7 @@ class Locators(object):
     PEOPLE_LINK = (By.ID, "people-link")
     MAIN_TAG = (By.CSS_SELECTOR, "main.course-info-details-page")
     RESET_FORM_BUTTON = (By.ID, "course-details-form-reset")
+    SAVE_FORM_BUTTON = (By.ID, "course-details-form-submit")
 
     @classmethod
     def INPUT_BY_FIELD_NAME(cls, field_name):
@@ -33,11 +36,23 @@ class CourseInfoDetailPageObject(CourseInfoBasePageObject):
         input = self.find_element(*Locators.INPUT_BY_FIELD_NAME(field_name))
         return input.get_attribute('value')
 
+    def get_input_field(self, field_name):
+        self._wait_for_input_field_to_be_visible(field_name)
+        input = self.find_element(*Locators.INPUT_BY_FIELD_NAME(field_name))
+        return input
+
     def go_to_people_page(self):
         self.find_element(*Locators.PEOPLE_LINK).click()
 
     def reset_form(self):
         self.find_element(*Locators.RESET_FORM_BUTTON).click()
+
+    def is_locator_element_present(self, locator_element):
+        try:
+            self.find_element(locator_element)
+        except NoSuchElementException:
+            return False
+        return True
 
     def _wait_for_input_field_to_be_visible(self, field_name):
         # only want to access input elements once the values are loaded from the

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -67,6 +67,8 @@ class CourseInfoDetailPageObject(CourseInfoBasePageObject):
         try:
             self.find_element(locator_element)
         except NoSuchElementException:
+            return False
+        return True
 
     def submit_form(self):
         self.find_element(*Locators.SUBMIT_FORM_BUTTON).click()

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -46,10 +46,10 @@ class CourseInfoDetailPageObject(CourseInfoBasePageObject):
         input = self.find_element(*Locators.INPUT_BY_FIELD_NAME(field_name))
         return input.get_attribute('value')
 
-    def get_input_field(self, field_name):
-        self._wait_for_input_field_to_be_visible(field_name)
-        input = self.find_element(*Locators.INPUT_BY_FIELD_NAME(field_name))
-        return input
+    def get_span_element_class(self, field_name):
+        span_element = self.find_element(
+                *Locators.SPAN_ELEMENT_BY_FIELD_NAME(field_name))
+        return span_element.get_attribute('class')
 
     def go_to_people_page(self):
         self.find_element(*Locators.PEOPLE_LINK).click()

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -1,8 +1,7 @@
+from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
-from selenium.common.exceptions import NoSuchElementException
-
 
 from selenium_tests.course_info.page_objects.course_info_base_page_object \
     import CourseInfoBasePageObject

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -12,7 +12,6 @@ class Locators(object):
     PEOPLE_LINK = (By.ID, "people-link")
     MAIN_TAG = (By.CSS_SELECTOR, "main.course-info-details-page")
     RESET_FORM_BUTTON = (By.ID, "course-details-form-reset")
-    SAVE_FORM_BUTTON = (By.ID, "course-details-form-submit")
     SUBMIT_FORM_BUTTON = (By.ID, "course-details-form-submit")
     SUBMIT_SUCCESS_MSG = (By.ID, "alert-success-update-succeeded")
 
@@ -23,14 +22,6 @@ class Locators(object):
         field name (e.g. title, sub_title, description)
         """
         return By.ID, 'input-course-{}'.format(field_name)
-
-    @classmethod
-    def SPAN_ELEMENT_BY_FIELD_NAME(cls, field_name):
-        """
-        returns a locator for an span field for a course instance record
-        field name (e.g. title, sub_title, description)
-        """
-        return By.ID, 'span-course-{}'.format(field_name)
 
 
 class CourseInfoDetailPageObject(CourseInfoBasePageObject):
@@ -48,14 +39,12 @@ class CourseInfoDetailPageObject(CourseInfoBasePageObject):
         return input.get_attribute('value')
 
     def is_element_displayed_as_input_field(self, field_name):
-        is_displayed = self.find_element(*Locators.INPUT_BY_FIELD_NAME(
-                field_name)).is_displayed()
-        return is_displayed
-
-    def get_span_element_class(self, field_name):
-        span_element = self.find_element(
-                *Locators.SPAN_ELEMENT_BY_FIELD_NAME(field_name))
-        return span_element.get_attribute('class')
+        try:
+            is_displayed = self.find_element(*Locators.INPUT_BY_FIELD_NAME(
+                    field_name)).is_displayed()
+            return is_displayed
+        except NoSuchElementException:
+            return False
 
     def go_to_people_page(self):
         self.find_element(*Locators.PEOPLE_LINK).click()
@@ -69,6 +58,14 @@ class CourseInfoDetailPageObject(CourseInfoBasePageObject):
         except NoSuchElementException:
             return False
         return True
+
+    def verify_buttons_to_edit_page_are_present(self):
+
+        if (self.is_locator_element_present(Locators.RESET_FORM_BUTTON) and
+            self.is_locator_element_present(Locators.SUBMIT_FORM_BUTTON)):
+            return True
+        else:
+            return False
 
     def submit_form(self):
         self.find_element(*Locators.SUBMIT_FORM_BUTTON).click()

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -12,6 +12,8 @@ class Locators(object):
     MAIN_TAG = (By.CSS_SELECTOR, "main.course-info-details-page")
     RESET_FORM_BUTTON = (By.ID, "course-details-form-reset")
     SAVE_FORM_BUTTON = (By.ID, "course-details-form-submit")
+    # The class locator is unique to non-editable fields
+    NON_EDITABLE_FIELD_CLASS_NAME = (By.CLASS_NAME, "ng-binding")
 
     @classmethod
     def INPUT_BY_FIELD_NAME(cls, field_name):
@@ -20,6 +22,13 @@ class Locators(object):
         field name (e.g. title, sub_title, description)
         """
         return By.ID, 'input-course-{}'.format(field_name)
+
+    def INPUT_BY_FIELD_NAME_FOR_NON_EDITABLE_FIELDS(cls, field_name):
+        """
+        returns a locator for an span field for a course instance record
+        field name (e.g. title, sub_title, description)
+        """
+        return By.XPATH, ".//*[@id='span-course-{}']".format(field_name)
 
 
 class CourseInfoDetailPageObject(CourseInfoBasePageObject):
@@ -39,6 +48,14 @@ class CourseInfoDetailPageObject(CourseInfoBasePageObject):
     def get_input_field(self, field_name):
         self._wait_for_input_field_to_be_visible(field_name)
         input = self.find_element(*Locators.INPUT_BY_FIELD_NAME(field_name))
+        return input
+
+    def get_input_field_for_non_editable_fields(self, field_name):
+        self._wait_for_input_field_to_be_visible(field_name)
+        input = self.find_element(
+                *Locators.INPUT_BY_FIELD_NAME_FOR_NON_EDITABLE_FIELDS(
+                        field_name)
+        )
         return input
 
     def go_to_people_page(self):

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -12,7 +12,10 @@ class Locators(object):
     MAIN_TAG = (By.CSS_SELECTOR, "main.course-info-details-page")
     RESET_FORM_BUTTON = (By.ID, "course-details-form-reset")
     SAVE_FORM_BUTTON = (By.ID, "course-details-form-submit")
-    # The class locator is unique to non-editable fields
+    # The class locator is unique to non-editable fields, which will match
+    # this exact value.  Editable fields also contain a "ng-binding" but it
+    # is always accompanied by additional suffixes "ng-binding some_value",
+    # which is not an exact match.
     NON_EDITABLE_FIELD_CLASS_NAME = (By.CLASS_NAME, "ng-binding")
 
     @classmethod

--- a/selenium_tests/course_info/page_objects/course_info_search_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_search_page_object.py
@@ -20,7 +20,7 @@ class Locators(object):
     @classmethod
     def COURSE_LINK_HREF_CSS(cls, cid):
         """ returns a locator for a course detail link in the course table """
-        return By.CSS_SELECTOR, 'a[href="#/people/{}"]'.format(cid)
+        return By.CSS_SELECTOR, 'a[href="#/details/{}"]'.format(cid)
 
 
 class CourseSearchPageObject(CourseInfoBasePageObject):

--- a/selenium_tests/regression_suite.py
+++ b/selenium_tests/regression_suite.py
@@ -27,7 +27,7 @@ if settings.SELENIUM_CONFIG.get('use_htmlrunner', True):
     report_file_obj = file(os.path.join(report_file_path, report_name), 'wb')
     runner = HTMLTestRunner.HTMLTestRunner(
         stream=report_file_obj,
-        title='Canvas Account Admint Tools test suite report',
+        title='Canvas Account Admin Tools test suite report',
         description='Result of tests in {}'.format(__file__)
     )
 else:


### PR DESCRIPTION
This PR contains selenium tests for verifying that non-ILE courses are not editable.

Separated out the test into it’s own class as this logic was different from the editable tests. And also the test course being loaded in the setUp()method for the other test cases was different(ILE vs non-ILE ).
 Since then, the test has been modified in another branch to separate it out. But I think it can stay separate but happy to convinced otherwise. 
