### PR TITLE
Sprint 44 TLT-2545 Multiline fields need textareas

### DIFF
--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -1,7 +1,6 @@
 (function () {
     angular.module('CourseInfo')
         .controller('DetailsController', DetailsController)
-        .directive('huEditableInput', editableInputDirective)
         .directive('huFieldLabelWrapper', fieldLabelWrapperDirective);
 
     function DetailsController($scope, $routeParams, courseInstances, $compile,
@@ -227,40 +226,6 @@
         };
 
         dc.init();
-    }
-
-    function editableInputDirective() {
-        return {
-            scope: {
-                editable: '=', // can be < in angular 1.5;
-                               // if not provided, defaults to null/false
-                field: '@',
-                formValue: '=',
-                isLoading: '&',
-                label: '@',
-                maxlength: '@',
-                modelValue: '='
-            },
-            template: ' \
-<li class="list-group-item"> \
-  <div class="form-group"> \
-    <label for="input-course-{{field}}" class="col-md-2"> \
-      {{label}} \
-    </label> \
-    <div class="col-md-10"> \
-      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span> \
-      <div ng-hide="isLoading()"> \
-        <input type="text" class="form-control" id="input-course-{{field}}" \
-               name="input-course-{{field}}" ng-show="editable" \
-               ng-model="formValue" maxlength="{{maxlength}}"/> \
-        <span id="span-course-{{field}}" \
-              ng-hide="editable">{{modelValue}}</span> \
-      </div> \
-    </div> \
-  </div> \
-</li> \
-'
-        }
     }
 
     function fieldLabelWrapperDirective() {

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -1,7 +1,6 @@
 (function () {
     angular.module('CourseInfo')
-        .controller('DetailsController', DetailsController)
-        .directive('huFieldLabelWrapper', fieldLabelWrapperDirective);
+        .controller('DetailsController', DetailsController);
 
     function DetailsController($scope, $routeParams, courseInstances, $compile,
                                djangoUrl, $http, $q, $log, $uibModal, $sce) {
@@ -227,30 +226,4 @@
 
         dc.init();
     }
-
-    function fieldLabelWrapperDirective() {
-        return {
-            //templateUrl: 'directives/field_label_wrapper.html'
-            scope: {
-                field: '@',
-                isLoading: '&',
-                label: '@'
-            },
-            transclude: true,
-            template: ' \
-<li class="list-group-item"> \
-  <div class="form-group"> \
-    <label for="input-course-{{field}}" class="col-md-2"> \
-      {{label}} \
-    </label> \
-    <div class="col-md-10"> \
-      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span> \
-      <div id="transclude-course-{{field}}" ng-hide="isLoading()" ng-transclude></div> \
-    </div> \
-  </div> \
-</li> \
-'
-        }
-    }
-
 })();

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -170,7 +170,9 @@
 
             // if they confirm, then do the work
             $scope.confirmRemoveModalInstance.result
-                .then($scope.removeMembership)
+                .then(function() {
+                    $scope.removeMembership();
+                })
                 .finally(function() {
                     $scope.confirmRemoveModalInstance = null;
                 });

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -170,9 +170,14 @@
 
             // if they confirm, then do the work
             $scope.confirmRemoveModalInstance.result
-                .then(function() {
-                    $scope.removeMembership();
-                })
+                .then(
+                    function modalSuccess(membership) {
+                        $scope.removeMembership(membership);
+                    },
+                    function modalFailure(failure) {
+                        $log.error('remove confirmation modal failure: ' + failure);
+                    }
+                )
                 .finally(function() {
                     $scope.confirmRemoveModalInstance = null;
                 });

--- a/course_info/static/course_info/js/directives/HuEditableInput.js
+++ b/course_info/static/course_info/js/directives/HuEditableInput.js
@@ -1,0 +1,20 @@
+(function() {
+    var app = angular.module('CourseInfo');
+    app.directive('huEditableInput', huEditableInput);
+
+    function huEditableInput() {
+	return {
+            restrict: 'E',
+	    scope: {
+		editable: '<',  // if not provided, defaults to null/false
+		field: '@',
+		formValue: '=',
+		isLoading: '&',
+		label: '@',
+		maxlength: '@',
+		modelValue: '='
+	    },
+            templateUrl: 'partials/hu-editable-input.html',
+        };
+    }
+})();

--- a/course_info/static/course_info/js/directives/HuEditableTextarea.js
+++ b/course_info/static/course_info/js/directives/HuEditableTextarea.js
@@ -1,0 +1,20 @@
+(function() {
+    var app = angular.module('CourseInfo');
+    app.directive('huEditableTextarea', huEditableTextarea);
+
+    function huEditableTextarea() {
+        return {
+            restrict: 'E',
+            scope: {
+                editable: '<',  // if not provided, defaults to null/false
+                field: '@',
+                formValue: '=',
+                isLoading: '&',
+                label: '@',
+                maxlength: '@',
+                modelValue: '='
+            },
+            templateUrl: 'partials/hu-editable-textarea.html',
+        };
+    }
+})();

--- a/course_info/static/course_info/js/directives/HuFieldLabelWrapper.js
+++ b/course_info/static/course_info/js/directives/HuFieldLabelWrapper.js
@@ -1,0 +1,16 @@
+(function() {
+    var app = angular.module('CourseInfo');
+    app.directive('huFieldLabelWrapper', huFieldLabelWrapper);
+
+    function huFieldLabelWrapper() {
+        return {
+            scope: {
+                field: '@',
+                isLoading: '&',
+                label: '@'
+            },
+            templateUrl: 'partials/hu-field-label-wrapper.html',
+            transclude: true,
+        };
+    }
+})();

--- a/course_info/templates/course_info/index.html
+++ b/course_info/templates/course_info/index.html
@@ -60,5 +60,6 @@
     <script src="{% static 'course_info/js/directives/BadgeDirective.js' %}"></script>
     <script src="{% static 'course_info/js/directives/HuEditableInput.js' %}"></script>
     <script src="{% static 'course_info/js/directives/HuEditableTextarea.js' %}"></script>
+    <script src="{% static 'course_info/js/directives/HuFieldLabelWrapper.js' %}"></script>
   </body>
 </html>

--- a/course_info/templates/course_info/index.html
+++ b/course_info/templates/course_info/index.html
@@ -58,5 +58,6 @@
     <script src="{% static 'course_info/js/controllers/DetailsController.js' %}"></script>
     <script src="{% static 'course_info/js/services/CourseInstancesService.js' %}"></script>
     <script src="{% static 'course_info/js/directives/BadgeDirective.js' %}"></script>
+    <script src="{% static 'course_info/js/directives/HuEditableTextarea.js' %}"></script>
   </body>
 </html>

--- a/course_info/templates/course_info/index.html
+++ b/course_info/templates/course_info/index.html
@@ -58,6 +58,7 @@
     <script src="{% static 'course_info/js/controllers/DetailsController.js' %}"></script>
     <script src="{% static 'course_info/js/services/CourseInstancesService.js' %}"></script>
     <script src="{% static 'course_info/js/directives/BadgeDirective.js' %}"></script>
+    <script src="{% static 'course_info/js/directives/HuEditableInput.js' %}"></script>
     <script src="{% static 'course_info/js/directives/HuEditableTextarea.js' %}"></script>
   </body>
 </html>

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -116,22 +116,22 @@
                 field="sub_title"
                 label="Subtitle"></hu-editable-input>
 
-            <hu-editable-input
+            <hu-editable-textarea
                 editable="dc.editable"
                 is-loading="dc.isUndefined(dc.courseInstance.description)"
                 form-value="dc.formDisplayData.description"
                 model-value="dc.courseInstance.description"
                 field="description"
-                label="Description"></hu-editable-input>
+                label="Description"></hu-editable-textarea>
 
-            <hu-editable-input
+            <hu-editable-textarea
                 editable="dc.editable"
                 is-loading="dc.isUndefined(dc.courseInstance.notes)"
                 form-value="dc.formDisplayData.notes"
                 model-value="dc.courseInstance.notes"
                 maxlength="2000"
                 field="notes"
-                label="Notes"></hu-editable-input>
+                label="Notes"></hu-editable-textarea>
 
             <hu-editable-input
                 editable="dc.editable"

--- a/course_info/templates/course_info/partials/hu-editable-input.html
+++ b/course_info/templates/course_info/partials/hu-editable-input.html
@@ -1,0 +1,19 @@
+{% verbatim %}
+<li class="list-group-item">
+  <div class="form-group">
+    <label for="input-course-{{field}}" class="col-md-2">
+      {{label}}
+    </label>
+    <div class="col-md-10">
+      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span>
+      <div ng-hide="isLoading()">
+        <input type="text" class="form-control" id="input-course-{{field}}"
+               name="input-course-{{field}}" ng-show="editable"
+               ng-model="formValue" maxlength="{{maxlength}}"/>
+        <span id="span-course-{{field}}"
+              ng-hide="editable">{{modelValue}}</span>
+      </div>
+    </div>
+  </div>
+</li>
+{% endverbatim %}

--- a/course_info/templates/course_info/partials/hu-editable-textarea.html
+++ b/course_info/templates/course_info/partials/hu-editable-textarea.html
@@ -1,0 +1,20 @@
+{% verbatim %}
+<li class="list-group-item">
+  <div class="form-group">
+    <label for="textarea-course-{{field}}" class="col-md-2">
+      {{label}}
+    </label>
+    <div class="col-md-10">
+      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span>
+      <div ng-hide="isLoading()">
+        <textarea type="text" class="form-control" id="textarea-course-{{field}}"
+                  name="textarea-course-{{field}}" ng-show="editable"
+                  ng-model="formValue" maxlength="{{maxlength}}">
+        </textarea>
+        <span id="span-course-{{field}}"
+              ng-hide="editable">{{modelValue}}</span>
+      </div>
+    </div>
+  </div>
+</li>
+{% endverbatim %}

--- a/course_info/templates/course_info/partials/hu-field-label-wrapper.html
+++ b/course_info/templates/course_info/partials/hu-field-label-wrapper.html
@@ -1,0 +1,13 @@
+{% verbatim %}
+<li class="list-group-item">
+  <div class="form-group">
+    <label for="input-course-{{field}}" class="col-md-2">
+      {{label}}
+    </label>
+    <div class="col-md-10">
+      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span>
+      <div id="transclude-course-{{field}}" ng-hide="isLoading()" ng-transclude></div>
+    </div>
+  </div>
+</li>
+{% endverbatim %}

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -10,7 +10,8 @@ describe('Unit testing DetailsController', function () {
 
     var peopleURL =
         '/angular/reverse/?djng_url_name=icommons_rest_api_proxy&djng_url_args' +
-        '=api%2Fcourse%2Fv2%2Fcourse_instances%2F' + courseInstanceId + '%2Fpeople%2F&-source=xreg_map';
+        '=api%2Fcourse%2Fv2%2Fcourse_instances%2F' + courseInstanceId +
+        '%2Fpeople%2F&-source=xreg_map';
 
     // set up the test environment
     beforeEach(function () {

--- a/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/DetailsControllerSpec.js
@@ -1,6 +1,6 @@
 describe('Unit testing DetailsController', function () {
     var $controller, $rootScope, $routeParams, courseInstances, $compile, djangoUrl,
-        $httpBackend, $window, $log, $uibModal, $sce;
+        $httpBackend, $window, $log, $uibModal, $sce, $templateCache;
 
     var controller, scope;
     var courseInstanceId = 1234567890;
@@ -15,10 +15,12 @@ describe('Unit testing DetailsController', function () {
 
     // set up the test environment
     beforeEach(function () {
+        // load the app and the templates-as-module
         module('CourseInfo');
+        module('templates');
         inject(function (_$controller_, _$rootScope_, _$routeParams_, _courseInstances_,
                          _$compile_, _djangoUrl_, _$httpBackend_, _$window_, _$log_,
-                         _$uibModal_, _$sce_) {
+                         _$uibModal_, _$sce_, _$templateCache_) {
             $controller = _$controller_;
             $rootScope = _$rootScope_;
             $routeParams = _$routeParams_;
@@ -30,6 +32,7 @@ describe('Unit testing DetailsController', function () {
             $log = _$log_;
             $uibModal = _$uibModal_;
             $sce = _$sce_;
+            $templateCache = _$templateCache_;
 
             // this comes from django_auth_lti, just stub it out so that the $httpBackend
             // sanity checks in afterEach() don't fail
@@ -52,7 +55,7 @@ describe('Unit testing DetailsController', function () {
     // DI sanity check
     it('should inject the providers we requested', function () {
         [$controller, $rootScope, $routeParams, courseInstances, $compile,
-            djangoUrl, $httpBackend, $window, $log, $sce].forEach(function (thing) {
+            djangoUrl, $httpBackend, $window, $log, $sce, $templateCache].forEach(function (thing) {
             expect(thing).not.toBeUndefined();
             expect(thing).not.toBeNull();
         });

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -27,7 +27,7 @@ function validateURIHasParameters(uri, params) {
 
 describe('Unit testing PeopleController', function() {
     var $controller, $rootScope, $routeParams, courseInstances, $compile, djangoUrl,
-        $httpBackend, $window, $log, $uibModal;
+        $httpBackend, $window, $log, $uibModal, $templateCache;
     var controller, scope;
     var courseInstanceId = 1234567890;
     var courseInstanceURL =
@@ -37,10 +37,12 @@ describe('Unit testing PeopleController', function() {
 
     // set up the test environment
     beforeEach(function() {
+        // load in the app and the templates-as-module
         module('CourseInfo');
+        module('templates');
         inject(function(_$controller_, _$rootScope_, _$routeParams_, _courseInstances_,
                         _$compile_, _djangoUrl_, _$httpBackend_, _$window_, _$log_,
-                        _$uibModal_) {
+                        _$uibModal_, _$templateCache_) {
             $controller = _$controller_;
             $rootScope = _$rootScope_;
             $routeParams = _$routeParams_;
@@ -51,6 +53,7 @@ describe('Unit testing PeopleController', function() {
             $window = _$window_;
             $log = _$log_;
             $uibModal = _$uibModal_;
+            $templateCache = _$templateCache_;
 
             // this comes from django_auth_lti, just stub it out so that the $httpBackend
             // sanity checks in afterEach() don't fail
@@ -833,9 +836,6 @@ describe('Unit testing PeopleController', function() {
     });
 
     describe('confirmRemove', function() {
-        var modalContentsPartialURL =
-            'partials/remove-course-membership-confirmation.html';
-
         beforeEach(function() {
             var ci = {
                 course_instance_id: $routeParams.courseInstanceId,
@@ -845,11 +845,9 @@ describe('Unit testing PeopleController', function() {
             controller = $controller('PeopleController', {$scope: scope});
         });
 
-        it('should get the partial and stick the instance on the scope', function() {
+        it('should stick the instance on the scope', function() {
             scope.confirmRemove();
             expect(scope.confirmRemoveModalInstance).not.toBeNull();
-            $httpBackend.expectGET(modalContentsPartialURL).respond(200, '');
-            $httpBackend.flush(1);
         });
 
         it('should call removeMembership and remove itself from the scope on close',
@@ -857,8 +855,6 @@ describe('Unit testing PeopleController', function() {
                var membership = {};
                spyOn(scope, 'removeMembership');
                scope.confirmRemove();
-               $httpBackend.expectGET(modalContentsPartialURL).respond(200, '');
-               $httpBackend.flush(1);
                scope.confirmRemoveModalInstance.close(membership);
                scope.$digest();  // resolves confirmRemoveModalInstance result
                expect(scope.removeMembership).toHaveBeenCalled();

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -855,6 +855,7 @@ describe('Unit testing PeopleController', function() {
                var membership = {};
                spyOn(scope, 'removeMembership');
                scope.confirmRemove();
+               scope.$digest();  // resolves modal instantiation
                scope.confirmRemoveModalInstance.close(membership);
                scope.$digest();  // resolves confirmRemoveModalInstance result
                expect(scope.removeMembership).toHaveBeenCalled();

--- a/course_info/tests/jasmine/controllers/SearchControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/SearchControllerSpec.js
@@ -2,11 +2,13 @@
 
 describe('Unit testing SearchController', function() {
     beforeEach(module('CourseInfo'));
+    beforeEach(module('templates'));
 
-    var $controller, $window, $document, $httpBackend, $rootScope;
+    var $controller, $window, $document, $httpBackend, $rootScope, $templateCache;
     var scope, controller;
 
-    beforeEach(inject(function(_$controller_, _$window_, _$document_, _$httpBackend_, _$rootScope_) {
+    beforeEach(inject(function(_$controller_, _$window_, _$document_, 
+                               _$httpBackend_, _$rootScope_, _$templateCache_) {
         // The injector unwraps the underscores (_) from around
         // the parameter names when matching
         $controller = _$controller_;
@@ -14,6 +16,7 @@ describe('Unit testing SearchController', function() {
         $document = _$document_;
         $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
+        $templateCache = _$templateCache_;
 
         // this comes from django_auth_lti, just stub it out so that the $httpBackend
         // sanity checks in afterEach() don't fail

--- a/course_info/tests/jasmine/directives/BadgeDirectiveSpec.js
+++ b/course_info/tests/jasmine/directives/BadgeDirectiveSpec.js
@@ -1,10 +1,12 @@
 describe('Unit testing BadgeDirective', function() {
     beforeEach(module('CourseInfo'));
+    beforeEach(module('templates'));
 
-    var $compile, $rootScope;
-    beforeEach(inject(function(_$compile_, _$rootScope_) {
+    var $compile, $rootScope, $templateCache;
+    beforeEach(inject(function(_$compile_, _$rootScope_, _$templateCache_) {
         $compile = _$compile_;
         $rootScope = _$rootScope_;
+        $templateCache = _$templateCache_;
     }));
 
     // sanity check the test framework

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,8 +20,9 @@ module.exports = function(config) {
       'node_modules/datatables.net/js/jquery.dataTables.js',
       'node_modules/datatables.net-bs/js/dataTables.bootstrap.js',
       'node_modules/angular-datatables/dist/angular-datatables.js',
-      'node_modules/angular-ui-bootstrap/ui-bootstrap-tpls.js',
-      'course_info/**/*.js'
+      'node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js',
+      'course_info/**/*.js',
+      'course_info/templates/course_info/partials/*.html',
     ],
 
 
@@ -33,6 +34,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+      'course_info/templates/course_info/partials/*.html': ['ng-html2js'],
     },
 
 
@@ -66,6 +68,11 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false
+    singleRun: false,
+
+    ngHtml2JsPreprocessor: {
+      moduleName: 'templates',
+      stripPrefix: 'course_info/templates/course_info/',
+    },
   });
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "karma": "^0.13.22",
     "karma-jasmine": "^0.3.8",
     "karma-jasmine-jquery": "^0.1.1",
+    "karma-ng-html2js-preprocessor": "^0.2.1",
     "karma-phantomjs-launcher": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.7"
   }

--- a/package.json
+++ b/package.json
@@ -2,20 +2,19 @@
   "name": "CanvasAccountAdminTools-JasmineTests",
   "description": "Unit tests for Javascript in CanvasAccountAdminTools project",
   "devDependencies": {
-    "angular": "1.3.9",
-    "angular-datatables": "^0.4.3",
-    "angular-mocks": "1.3.9",
-    "angular-route": "^1.4.8",
-    "angular-sanitize": "1.3.9",
-    "angular-ui-bootstrap": "^0.14.3",
-    "datatables.net": "^1.10.9",
-    "datatables.net-bs": "^1.10.9",
+    "angular": "1.5.2",
+    "angular-datatables": "0.5.3",
+    "angular-mocks": "1.5.2",
+    "angular-route": "1.5.2",
+    "angular-sanitize": "1.5.2",
+    "angular-ui-bootstrap": "1.2.5",
+    "datatables.net": "1.10.11",
     "jasmine-core": "^2.4.1",
-    "jquery": "^2.1.4",
-    "karma": "^0.13.21",
-    "karma-jasmine": "^0.3.7",
+    "jquery": "2.2.2",
+    "karma": "^0.13.22",
+    "karma-jasmine": "^0.3.8",
     "karma-jasmine-jquery": "^0.1.1",
     "karma-phantomjs-launcher": "^1.0.0",
-    "phantomjs-prebuilt": "^2.1.4"
+    "phantomjs-prebuilt": "^2.1.7"
   }
 }


### PR DESCRIPTION
Some fields on a course instance may be multiline text, which means we need a `<textarea>`, not an `<input type="text">`.  Add a `<hu-editable-textarea>` directive that mirrors the existing `<hu-editable-input>` one.

bonus: bump the packages used for js unit testing to match those actually in use in the app.