### PR TITLE
Sprint 45 TLT-2545 Post-textarea selenium fix

### DIFF
--- a/course_info/templates/course_info/partials/hu-editable-textarea.html
+++ b/course_info/templates/course_info/partials/hu-editable-textarea.html
@@ -7,7 +7,7 @@
     <div class="col-md-10">
       <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span>
       <div ng-hide="isLoading()">
-        <textarea type="text" class="form-control" id="textarea-course-{{field}}"
+        <textarea type="text" class="form-control" id="input-course-{{field}}"
                   name="textarea-course-{{field}}" ng-show="editable"
                   ng-model="formValue" maxlength="{{maxlength}}">
         </textarea>

--- a/selenium_tests/course_info/page_objects/course_info_search_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_search_page_object.py
@@ -67,7 +67,7 @@ class CourseSearchPageObject(CourseInfoBasePageObject):
         search_textbox.send_keys(search_text)
         self.find_element(*Locators.SEARCH_BUTTON).click()
         # loading the results can take a long time, so explicitly wait longer
-        WebDriverWait(self._driver, 30).until(lambda s: s.find_element(
+        WebDriverWait(self._driver, 45).until(lambda s: s.find_element(
             *Locators.COURSE_RESULTS_TABLE).is_displayed())
 
     def select_course(self, cid=None, title=None):


### PR DESCRIPTION
* The ids on the editable fields are there largely for testing purposes, so let's just use the same naming convention for input and textarea tags to avoid making testing *way* more complicated.
* Also bump the timeout on a wait.