### PR TITLE
Task/eparker71/tlt 2569/crosslisting button visible to ba's only

### DIFF
--- a/canvas_account_admin_tools/templates/canvas_account_admin_tools/dashboard_account.html
+++ b/canvas_account_admin_tools/templates/canvas_account_admin_tools/dashboard_account.html
@@ -58,13 +58,14 @@
           </a>
         </div>
 
+      {% if cross_listing_allowed %}
         <div class="list-group col-md-4">
           <a type="button" class="btn btn-primary list-group-item active" href="{% url 'cross_list_courses:index' %}" class="list-group-item active">
               <h4 class="list-group-item-heading">Cross-list Courses</h4>
               <p class="list-group-item-text">Set up and modify cross-listings <br>&nbsp;</p>
           </a>
         </div>
-
+      {% endif %}
 
 
 {% endblock content %}

--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -15,6 +15,7 @@ from proxy.views import proxy_view
 from django_auth_lti import const
 from django_auth_lti.decorators import lti_role_required
 from lti_permissions.decorators import lti_permission_required
+from lti_permissions.verification import is_allowed
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,9 @@ def lti_launch(request):
 @require_http_methods(['GET'])
 def dashboard_account(request):
     custom_canvas_account_id = request.LTI['custom_canvas_account_id']
+    custom_canvas_account_sis_id = request.LTI['custom_canvas_account_sis_id']
+    canvas_user_id = request.LTI['custom_canvas_user_id']
+    custom_canvas_membership_roles = request.LTI['custom_canvas_membership_roles']
 
     canvas_site_creator = ExternalTool.objects.get_external_tool_url_by_name_and_canvas_account_id(
         ExternalTool.CANVAS_SITE_CREATOR,
@@ -75,11 +79,16 @@ def dashboard_account(request):
         custom_canvas_account_id
     )
 
+    cross_listing_is_allowed = is_allowed(custom_canvas_membership_roles,
+                                          settings.PERMISSION_XLIST_TOOL,
+                                          canvas_account_sis_id=custom_canvas_account_sis_id)
+
     return render(request, 'canvas_account_admin_tools/dashboard_account.html', {
         'canvas_site_creator': canvas_site_creator,
         'conclude_courses': conclude_courses,
         'lti_tools_usage': lti_tools_usage,
         'courses_in_this_account': courses_in_this_account,
+        'cross_listing_allowed': cross_listing_is_allowed,
     })
 
 

--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -79,6 +79,10 @@ def dashboard_account(request):
         custom_canvas_account_id
     )
 
+    """
+    Verify that the curernt user has permission to see the cross listing button
+    on the dashboard TLT-2569
+    """
     cross_listing_is_allowed = is_allowed(custom_canvas_membership_roles,
                                           settings.PERMISSION_XLIST_TOOL,
                                           canvas_account_sis_id=custom_canvas_account_sis_id)


### PR DESCRIPTION
Added permission check to verify that the current user has permission to see the cross listing button on the account admin dashboard page. If the user does have the correct permission the button will be displayed, otherwise it will not. 