### PR TITLE
041816 fix up stale element failure in remove tests

### DIFF
--- a/selenium_tests/course_info/course_info_remove_people_tests.py
+++ b/selenium_tests/course_info/course_info_remove_people_tests.py
@@ -46,12 +46,12 @@ class RemovePeopleTests(CourseInfoBaseTestCase):
 
         '''Note: Page needs to reloaded as tests are persistently failing
         for element not found - perhaps cache has changed" for different test
-        id (as the test ID are being removed so DOM has changed. This ensures
+        id (as the test ID are being removed so DOM has changed). This ensures
         that the page is reloaded.'''
         self.driver.refresh()
         self.setUp()
         self._load_test_course()
 
-        # Verifies that user has been removed from course.  
+        # Verifies that user has been removed from course.
         self.assertTrue(
             self.people_page.is_person_removed_from_list(test_user))

--- a/selenium_tests/course_info/course_info_remove_people_tests.py
+++ b/selenium_tests/course_info/course_info_remove_people_tests.py
@@ -43,5 +43,15 @@ class RemovePeopleTests(CourseInfoBaseTestCase):
         self.people_page.delete_user(test_user)
 
         self.assertTrue(self.people_page.delete_was_successful())
+
+        '''Note: Page needs to reloaded as tests are persistently failing
+        for element not found - perhaps cache has changed" for different test
+        id (as the test ID are being removed so DOM has changed. This ensures
+        that the page is reloaded.'''
+        self.driver.refresh()
+        self.setUp()
+        self._load_test_course()
+
+        # Verifies that user has been removed from course.  
         self.assertTrue(
             self.people_page.is_person_removed_from_list(test_user))


### PR DESCRIPTION
 canvas_account_course_admin project has not had a successful run in Jenkins since late March.

There appears to be a persistent failure in the "course_info_remove_people_tests" -  it's failing due to "StaleElementReferenceException: Message: Element not found in the cache - perhaps the page has changed since it was looked up"

Error is relatively persistent;  the test user at which it failed on is not at all consistent.  This issue is  reproducible on Jenkins and locally.  Adding the code fixes this issue.   I have not been able to reproduce the stale_element error with this change locally and when I run it on Jenkins anymore.