### PR TITLE
Created a base_test_case...

### DIFF
--- a/selenium_tests/canvas_account_admin_tools_base_test_case.py
+++ b/selenium_tests/canvas_account_admin_tools_base_test_case.py
@@ -1,0 +1,29 @@
+from urlparse import urljoin
+
+from django.conf import settings
+
+from selenium_common.base_test_case import BaseSeleniumTestCase
+from selenium_common.pin.page_objects.pin_login_page_object import PinLoginPageObject
+from selenium_tests.account_admin.page_objects.account_admin_dashboard_page_object import AccountAdminDashboardPage
+
+
+class AccountAdminBaseTestCase(BaseSeleniumTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(AccountAdminBaseTestCase, cls).setUpClass()
+
+        cls.USERNAME = settings.SELENIUM_CONFIG['selenium_username']
+        cls.PASSWORD = settings.SELENIUM_CONFIG['selenium_password']
+        cls.CANVAS_BASE_URL = settings.SELENIUM_CONFIG['canvas_base_url']
+        cls.TOOL_RELATIVE_URL = settings.SELENIUM_CONFIG['account_admin']['relative_url']
+        cls.TOOL_URL = urljoin(cls.CANVAS_BASE_URL, cls.TOOL_RELATIVE_URL)
+
+        cls.acct_admin_dashboard_page = AccountAdminDashboardPage(cls.driver)
+        cls.acct_admin_dashboard_page.get(cls.TOOL_URL)
+        login_page = PinLoginPageObject(cls.driver)
+        if login_page.is_loaded():
+            login_page.login_xid(cls.USERNAME, cls.PASSWORD)
+        else:
+            print '(User {} already logged in to PIN)'.format(cls.USERNAME)
+

--- a/selenium_tests/canvas_account_admin_tools_base_test_case.py
+++ b/selenium_tests/canvas_account_admin_tools_base_test_case.py
@@ -25,5 +25,5 @@ class AccountAdminBaseTestCase(BaseSeleniumTestCase):
         if login_page.is_loaded():
             login_page.login_xid(cls.USERNAME, cls.PASSWORD)
         else:
-            print '(User {} already logged in to PIN)'.format(cls.USERNAME)
+            print '(User {} is already logged in)'.format(cls.USERNAME)
 

--- a/selenium_tests/cross_listing/cross_listing_base_test_case.py
+++ b/selenium_tests/cross_listing/cross_listing_base_test_case.py
@@ -1,48 +1,23 @@
-from django.conf import settings
-from urlparse import urljoin
-
-from selenium_common.base_test_case import BaseSeleniumTestCase
-from selenium_common.pin.page_objects.pin_login_page_object \
-    import PinLoginPageObject
-
-from selenium_tests.account_admin.page_objects.account_admin_dashboard_page_object \
-    import AccountAdminDashboardPage
+from selenium_tests.canvas_account_admin_tools_base_test_case \
+    import AccountAdminBaseTestCase
 from selenium_tests.cross_listing.page_objects.cross_listing_main_page \
     import MainPageObject
 
 
-class CrossListingBaseTestCase(BaseSeleniumTestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super(CrossListingBaseTestCase, cls).setUpClass()
-
-        cls.USERNAME = settings.SELENIUM_CONFIG['selenium_username']
-        cls.PASSWORD = settings.SELENIUM_CONFIG['selenium_password']
-
-        cls.CANVAS_BASE_URL = settings.SELENIUM_CONFIG['canvas_base_url']
-        cls.TOOL_RELATIVE_URL = settings.SELENIUM_CONFIG['account_admin']['relative_url']
-        cls.TOOL_URL = urljoin(cls.CANVAS_BASE_URL, cls.TOOL_RELATIVE_URL)
-
-        cls.account_admin_dashboard_page = AccountAdminDashboardPage(cls.driver)
-        cls.account_admin_dashboard_page.get(cls.TOOL_URL)
-        login_page = PinLoginPageObject(cls.driver)
-        if login_page.is_loaded():
-            login_page.login_xid(cls.USERNAME, cls.PASSWORD)
-        else:
-            print '(User {} already logged in to PIN)'.format(cls.USERNAME)
-
-        cls.index_page = MainPageObject(cls.driver)
+class CrossListingBaseTestCase(AccountAdminBaseTestCase):
 
     def setUp(self):
-        super(CrossListingBaseTestCase, self).setUp()
+        super(AccountAdminBaseTestCase, self).setUp()
+
+        # instantiate
+        self.index_page = MainPageObject(self.driver)
 
         # initialize
-        if not self.account_admin_dashboard_page.is_loaded():
-            self.account_admin_dashboard_page.get(self.TOOL_URL)
+        if not self.acct_admin_dashboard_page.is_loaded():
+            self.acct_admin_dashboard_page.get(self.TOOL_URL)
 
         # navigate to cross-list tool
-        self.account_admin_dashboard_page.select_cross_listing_link()
+        self.acct_admin_dashboard_page.select_cross_listing_link()
 
         # check if page is loaded (which will also set the focus on the tool)
         self.assertTrue(self.index_page.is_loaded())


### PR DESCRIPTION
at the PROJECT level, so all the apps in this project can use the setUpClass. 
All apps in the canvas_account_admin_tools lands on the dashboard.  

This should address the DRY feedback here:  
https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/pull/113#discussion_r60966617

If this is the right approach, other apps in this project can be refactored the same way when we touch those projects. Tested, and it works!  