### PR TITLE
pycharm splits the line into two, causing some issues in Jenkins (cau…

### DIFF
--- a/canvas_account_admin_tools/requirements/local.txt
+++ b/canvas_account_admin_tools/requirements/local.txt
@@ -20,5 +20,4 @@ xlrd==0.9.4
 # icommons_common and into ccsw, work around the circular dependency by calling
 # out the ccsw dependency here.
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.8#egg=django-canvas-course-site-wizard==1.3.8
-git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1
-.7#egg=selenium-common==1.7
+git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1.7#egg=selenium-common==1.7


### PR DESCRIPTION
…sing failures with the rest api helper method tests).

https://jenkins.tlt.harvard.edu/job/canvas_account_admin_tools_selenium_tests/124/console
Fixing this to go on one line.