### PR TITLE
Attempting to fix Jenkins error by adding an explicit wait to check alert appears

### DIFF
--- a/selenium_tests/cross_listing/add_cross_listing_tests.py
+++ b/selenium_tests/cross_listing/add_cross_listing_tests.py
@@ -35,7 +35,6 @@ class AddCrossListingTests(CrossListingBaseTestCase):
             self.api.remove_xlisted_course(primary_cid, secondary_cid)
 
             #  Verifies successful add confirmation
-            self.driver.save_screenshot("a_success_message.png")
             self.assertTrue(
                 self.main_page.is_locator_text_present(expected_text))
 

--- a/selenium_tests/cross_listing/page_objects/cross_listing_main_page.py
+++ b/selenium_tests/cross_listing/page_objects/cross_listing_main_page.py
@@ -69,7 +69,7 @@ class MainPageObject(CrossListingBasePageObject):
 
     def is_locator_text_present(self, expected_text):
         """
-        Check to that locator text appears on the confirmation text box
+        Check that the locator text appears in the confirmation text box
         """
         try:
             WebDriverWait(self._driver, 60).until(lambda s: s.find_element(

--- a/selenium_tests/cross_listing/page_objects/cross_listing_main_page.py
+++ b/selenium_tests/cross_listing/page_objects/cross_listing_main_page.py
@@ -69,9 +69,11 @@ class MainPageObject(CrossListingBasePageObject):
 
     def is_locator_text_present(self, expected_text):
         """
-        Check to that locator text appears on the confirmation page
+        Check to that locator text appears on the confirmation text box
         """
         try:
+            WebDriverWait(self._driver, 60).until(lambda s: s.find_element(
+                *Locators.CONFIRMATION_ALERT).is_displayed())
             self.find_element(*Locators.ERROR_TEXT_LOCATOR(expected_text))
         except NoSuchElementException:
             return False


### PR DESCRIPTION
Adding in explicit wait to make sure the result_message element appears first before checking for text.  This is to fix this error:  https://jenkins.tlt.harvard.edu/job/canvas_account_admin_tools_selenium_tests/125/console

Not getting this error when running the add_cross_listing_tests individually (before and now).  However, I reran the full regression suite for this project and the failed test also passed, so I'm hopeful this should do it.   