### PR TITLE
Sprint 49: TLT-2558: course details - form updates for Vittorio

### DIFF
--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -232,40 +232,38 @@
                 label="Conclusion Date">
             </hu-editable-input>
 
-            <li class="list-group-item" is-loading="dc.isUndefined(dc.courseInstance.exclude_from_isites)">
-                <div class="row">
-                  <div class="col-sm-2">
-                      <strong>Course Flags </strong>
-                  </div>
-                  <div class="col-sm-10">
-
-                      <hu-editable-checkbox
-                            editable="dc.editable"
-                            is-loading="dc.isUndefined(dc.courseInstance.sync_to_canvas)"
-                            form-value="dc.formDisplayData.sync_to_canvas"
-                            model-value="dc.courseInstance.sync_to_canvas"
-                            field="sync_to_canvas"
-                            label="Sync To Canvas">
-
-                      </hu-editable-checkbox>
-                      <hu-editable-checkbox
-                              editable="dc.editable"
-                              is-loading="dc.isUndefined(dc.courseInstance.exclude_from_isites)"
-                              form-value="dc.formDisplayData.exclude_from_isites"
-                              model-value="dc.courseInstance.exclude_from_isites"
-                              field="exclude_from_isites"
-                              label="Exclude from Course Sites">
-                      </hu-editable-checkbox>
-                      <hu-editable-checkbox
-                              editable="dc.editable"
-                              is-loading="dc.isUndefined(dc.courseInstance.exclude_from_catalog)"
-                              form-value="dc.formDisplayData.exclude_from_catalog"
-                              model-value="dc.courseInstance.exclude_from_catalog"
-                              field="exclude_from_catalog"
-                              label="Exclude from Catalog">
-                      </hu-editable-checkbox>
-                  </div>
+            <li class="list-group-item">
+              <div class="form-group">
+                <label class="col-sm-2">
+                  Course Flags
+                </label>
+                <div class="col-sm-10">
+                  <hu-editable-checkbox
+                      editable="dc.editable"
+                      is-loading="dc.isUndefined(dc.courseInstance.sync_to_canvas)"
+                      form-value="dc.formDisplayData.sync_to_canvas"
+                      model-value="dc.courseInstance.sync_to_canvas"
+                      field="sync_to_canvas"
+                      label="Sync To Canvas">
+                  </hu-editable-checkbox>
+                  <hu-editable-checkbox
+                      editable="dc.editable"
+                      is-loading="dc.isUndefined(dc.courseInstance.exclude_from_isites)"
+                      form-value="dc.formDisplayData.exclude_from_isites"
+                      model-value="dc.courseInstance.exclude_from_isites"
+                      field="exclude_from_isites"
+                      label="Exclude from Course Sites">
+                  </hu-editable-checkbox>
+                  <hu-editable-checkbox
+                      editable="dc.editable"
+                      is-loading="dc.isUndefined(dc.courseInstance.exclude_from_catalog)"
+                      form-value="dc.formDisplayData.exclude_from_catalog"
+                      model-value="dc.courseInstance.exclude_from_catalog"
+                      field="exclude_from_catalog"
+                      label="Exclude from Catalog">
+                  </hu-editable-checkbox>
                 </div>
+              </div>
              </li>
 
           </ul>

--- a/course_info/templates/course_info/partials/hu-editable-checkbox.html
+++ b/course_info/templates/course_info/partials/hu-editable-checkbox.html
@@ -1,24 +1,16 @@
 {% verbatim %}
-  <div class="form-group">
-
-    <div class="col-md-10">
-      <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span>
-      <div ng-hide="isLoading()">
-        <input type="checkbox" id="input-course-{{field}}"
-               name="input-course-{{field}}"
-               ng-true-value="1"
-               ng-false-value="0"
-               ng-checked="modelValue == 1"
-               ng-model="formValue" >
-        </input>
-
-        <label for="input-course-{{field}}">
-          &nbsp;&nbsp;{{label}}
-        </label>
-      </div>
-    </div>
-
+  <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span>
+  <div ng-hide="isLoading()">
+    <label for="input-course-{{field}}">
+      <input type="checkbox" id="input-course-{{field}}"
+             name="input-course-{{field}}"
+             ng-true-value="1"
+             ng-false-value="0"
+             ng-checked="modelValue == 1"
+             ng-model="formValue" >
+      </input>
+      &nbsp;&nbsp;{{label}}
+    </label>
   </div>
-
 {% endverbatim %}
 

--- a/course_info/templates/course_info/partials/hu-editable-input.html
+++ b/course_info/templates/course_info/partials/hu-editable-input.html
@@ -1,10 +1,10 @@
 {% verbatim %}
 <li class="list-group-item">
   <div class="form-group">
-    <label for="input-course-{{field}}" class="col-md-2">
+    <label for="input-course-{{field}}" class="col-sm-2">
       {{label}}
     </label>
-    <div class="col-md-10">
+    <div class="col-sm-10">
       <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span>
       <div ng-hide="isLoading()">
         <input type="text" class="form-control" id="input-course-{{field}}"

--- a/course_info/templates/course_info/partials/hu-editable-textarea.html
+++ b/course_info/templates/course_info/partials/hu-editable-textarea.html
@@ -1,10 +1,10 @@
 {% verbatim %}
 <li class="list-group-item">
   <div class="form-group">
-    <label for="textarea-course-{{field}}" class="col-md-2">
+    <label for="textarea-course-{{field}}" class="col-sm-2">
       {{label}}
     </label>
-    <div class="col-md-10">
+    <div class="col-sm-10">
       <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span>
       <div ng-hide="isLoading()">
         <textarea type="text" class="form-control" id="input-course-{{field}}"

--- a/course_info/templates/course_info/partials/hu-field-label-wrapper.html
+++ b/course_info/templates/course_info/partials/hu-field-label-wrapper.html
@@ -1,10 +1,10 @@
 {% verbatim %}
 <li class="list-group-item">
   <div class="form-group">
-    <label for="input-course-{{field}}" class="col-md-2">
+    <label for="input-course-{{field}}" class="col-sm-2">
       {{label}}
     </label>
-    <div class="col-md-10">
+    <div class="col-sm-10">
       <span ng-show="isLoading()"><i class="fa fa-refresh fa-spin"></i></span>
       <div id="transclude-course-{{field}}" ng-hide="isLoading()" ng-transclude></div>
     </div>


### PR DESCRIPTION
- now uses col-sm-* for all fields (not just the checkboxes)
- bootstrap tweaks

Vittorio has ok'd the padding changes due to the bootstrap changes:
**develop branch**
![screen shot 2016-06-03 at 5 15 41 pm](https://cloud.githubusercontent.com/assets/8975317/15793104/bdeea8f8-29af-11e6-8bf3-649fea7a4325.png)

**this branch**
![screen shot 2016-06-03 at 5 15 32 pm](https://cloud.githubusercontent.com/assets/8975317/15793117/d224f458-29af-11e6-95a0-c9682a70dadf.png)
