### PR TITLE
Update test logic for non-editable course 

### DIFF
--- a/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
+++ b/selenium_tests/course_info/course_info_details_noneditable_course_tests.py
@@ -16,8 +16,8 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
         verify non-SB/ILE courses cannot be edited
         """
         # Verify that buttons to edit page are not present
-        self.assertFalse(self.detail_page.
-                         verify_buttons_to_edit_page_are_present())
+        self.assertTrue(self.detail_page.
+                        verify_buttons_to_edit_page_are_present())
 
         non_editable_fields = [
         'course_instance_id',
@@ -34,6 +34,5 @@ class CourseInfoDetailsNonEditTests(CourseInfoBaseTestCase):
 
         for element in non_editable_fields:
             #  verify that the field is not rendered as an input element
-            self.assertFalse(
-                    self.detail_page.is_element_displayed_as_input_field(element))
-
+            self.assertFalse(self.detail_page.
+                             is_element_displayed_as_input_field(element))

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -53,9 +53,9 @@ class CourseInfoDetailPageObject(CourseInfoBasePageObject):
 
     def verify_buttons_to_edit_page_are_present(self):
         try:
-            (self.find_element(*Locators.RESET_FORM_BUTTON).is_displayed()
-             and self.find_element(*Locators.SUBMIT_FORM_BUTTON).is_displayed())
-            return True
+            if (self.find_element(*Locators.RESET_FORM_BUTTON).is_displayed()
+            and self.find_element(*Locators.SUBMIT_FORM_BUTTON).is_displayed()):
+                return True
         except NoSuchElementException:
             return False
 

--- a/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
+++ b/selenium_tests/course_info/page_objects/course_info_detail_page_object.py
@@ -51,19 +51,12 @@ class CourseInfoDetailPageObject(CourseInfoBasePageObject):
     def reset_form(self):
         self.find_element(*Locators.RESET_FORM_BUTTON).click()
 
-    def is_locator_element_present(self, locator_element):
-        try:
-            self.find_element(locator_element)
-        except NoSuchElementException:
-            return False
-        return True
-
     def verify_buttons_to_edit_page_are_present(self):
-
-        if (self.is_locator_element_present(Locators.RESET_FORM_BUTTON) and
-            self.is_locator_element_present(Locators.SUBMIT_FORM_BUTTON)):
+        try:
+            (self.find_element(*Locators.RESET_FORM_BUTTON).is_displayed()
+             and self.find_element(*Locators.SUBMIT_FORM_BUTTON).is_displayed())
             return True
-        else:
+        except NoSuchElementException:
             return False
 
     def submit_form(self):


### PR DESCRIPTION
Updating an existing test due to business logic/UI changes in TLT-2640. 

Business Logic change: the Submit and Reset buttons now appear for non-editable (registrar fed courses, not just ILE/SB courses) in Course Details page.   

Also some light code cleanup. 
Tested and ran successfully.  