### PR TITLE
Update remove-course-membership-confirmation.html

### DIFF
--- a/course_info/templates/course_info/partials/remove-course-membership-confirmation.html
+++ b/course_info/templates/course_info/partials/remove-course-membership-confirmation.html
@@ -17,7 +17,7 @@
   <p>from this course?</p>
   <div class="alert alert-warning" role="alert" ng-show="membership.source.indexOf('feed') > 0">
     The person you are removing is fed from the registrar and will
-    be re-enrolled within 5 minutes unless the 'Sync to Canvas' box
+    be re-enrolled unless the 'Sync to Canvas' box
     is unchecked in Course Details.
   </div>
 </div>


### PR DESCRIPTION
Removed 'within 5 minutes' from warning confirmation because it was inaccurate.