### PR TITLE
Bugfix: fixes "go back to person's courses" link in course details

### DIFF
--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -2,8 +2,7 @@
     angular.module('CourseInfo')
         .controller('DetailsController', DetailsController);
 
-    // todo: remove unused providers
-    function DetailsController($scope, courseInstances, djangoUrl, $http, $log,
+    function DetailsController(courseInstances, djangoUrl, $http, $log,
                                $routeParams) {
 
         var dc = this;
@@ -132,7 +131,12 @@
 
             return courseInstance;
         };
-
+        dc.getPeopleCoursesRoute = function() {
+            // returns URL for the Search People app's course list
+            // route for the user specified by dc.arrivedFromPeopleCourses
+            return window.globals.append_resource_link_id('../people_tool/')
+                + '#/people/' + dc.arrivedFromPeopleCourses + '/courses/';
+        };
         dc.handleAjaxErrorResponse = function(r) {
             dc.handleAjaxError(
                 r.data, r.status, r.headers, r.config, r.statusText);


### PR DESCRIPTION
The link back to the person-courses screen was broken since `59cf167a1e5fbc0ddb945fac6a9273a1a66a5b0d` (https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/pull/160).

Fixing it up.
![screen shot 2016-10-04 at 9 38 08 am](https://cloud.githubusercontent.com/assets/8975317/19077830/012e1654-8a1c-11e6-833d-b682c02e4dfa.png)
