### PR TITLE
Tlt 2645 selenium tests for bulk create

### DIFF
--- a/canvas_account_admin_tools/settings/local.py
+++ b/canvas_account_admin_tools/settings/local.py
@@ -43,16 +43,16 @@ SELENIUM_CONFIG = {
             'course_short_title': 'Selenium Auto Test 101',
             'course_title': 'Selenium Automated Test Course 101',
             'template': 'None',  # No Template
-            'term': '1',
+            'term': 'string:5209',
 
             #TLT-2522 - Testing course with and without registrar_code_display
             'course_with_registrar_code_display': {
-                'registrar_code_display': 'selenium_test',
-                'sis_id_value': '341697',
+                'registrar_code_display': 'Automated_Test',
+                'sis_id_value': '362568',
             },
             'course_without_registrar_code_display': {
-                'registrar_code_display': '109581',
-                'sis_id_value': '342916',
+                'registrar_code_display': '117138',
+                'sis_id_value': '360031',
             },
         },
     },

--- a/canvas_account_admin_tools/settings/local.py
+++ b/canvas_account_admin_tools/settings/local.py
@@ -54,11 +54,7 @@ SELENIUM_CONFIG = {
                 'registrar_code_display': '109581',
                 'sis_id_value': '342916',
             },
-
-
         },
-        'url': 'accounts/10/external_tools/11',
-
     },
    'canvas_base_url': CANVAS_URL,
    'course_info_tool': {

--- a/canvas_account_admin_tools/settings/local.py
+++ b/canvas_account_admin_tools/settings/local.py
@@ -43,7 +43,10 @@ SELENIUM_CONFIG = {
             'course_short_title': 'Selenium Auto Test 101',
             'course_title': 'Selenium Automated Test Course 101',
             'template': 'None',  # No Template
-            'term': 'string:5209',
+            'term': 'string:5209', # Term value in dropdown when creating a
+            # site for existing course
+            'term_new_course': 'number:5209',  # Term value in dropdown when
+            # creating a site for a new course
 
             #TLT-2522 - Testing course with and without registrar_code_display
             'course_with_registrar_code_display': {

--- a/selenium_tests/account_admin/page_objects/account_admin_dashboard_page_object.py
+++ b/selenium_tests/account_admin/page_objects/account_admin_dashboard_page_object.py
@@ -9,6 +9,8 @@ class AccountAdminDashboardPageLocators(object):
     # if PAGE_TITLE uses contains() it will match for sub-pages as well, so
     # use text() for exact match (should only match on dashboard page)
     PAGE_TITLE = (By.XPATH, '//h3[text()="Admin Console"]')
+    CREATE_CANVAS_SITE_LINK = (By.XPATH, "//a[contains(.,'Create Canvas "
+                                        "Sites')]")
     COURSE_INFO_LINK = (By.XPATH, "//a[contains(.,'Search Courses')]")
     CROSS_LISTING_DIV = (By.XPATH, "//a[contains(., 'Cross-list Courses')]")
 
@@ -46,6 +48,14 @@ class AccountAdminDashboardPage(AccountAdminBasePage):
         self.find_element(
             *AccountAdminDashboardPageLocators.COURSE_INFO_LINK).click()
 
+    def select_create_canvas_site_link(self):
+        """
+        select the bulk create card and and click it
+        """
+        self.focus_on_tool_frame()
+        self.find_element(
+            *AccountAdminDashboardPageLocators.CREATE_CANVAS_SITE_LINK).click()
+
     def select_cross_listing_link(self):
         """
         select the cross list link element and click it
@@ -53,5 +63,4 @@ class AccountAdminDashboardPage(AccountAdminBasePage):
         self.focus_on_tool_frame()
         self.find_element(
             *AccountAdminDashboardPageLocators.CROSS_LISTING_DIV).click()
-
 

--- a/selenium_tests/bulk_create/bulk_create_base_test_case.py
+++ b/selenium_tests/bulk_create/bulk_create_base_test_case.py
@@ -2,35 +2,36 @@ from django.conf import settings
 from os.path import abspath, dirname, join
 from urlparse import urljoin
 
-from selenium_common.base_test_case import BaseSeleniumTestCase
-from selenium_common.pin.page_objects.pin_login_page_object \
-    import PinLoginPageObject
+from selenium_tests.canvas_account_admin_tools_base_test_case \
+    import AccountAdminBaseTestCase
+from selenium_tests.bulk_create.page_objects.index_page import IndexPageObject
 
 CANVAS_PERMISSION_ROLES = join(dirname(abspath(__file__)),
                                'test_data', 'roles_access.xlsx')
 
 
-class BulkCreateBaseTestCase(BaseSeleniumTestCase):
+class BulkCreateBaseTestCase(AccountAdminBaseTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        super(BulkCreateBaseTestCase, cls).setUpClass()
-        cls.username = settings.SELENIUM_CONFIG.get('selenium_username')
-        cls.password = settings.SELENIUM_CONFIG.get('selenium_password')
-        cls.canvas_base_url = settings.SELENIUM_CONFIG.get('canvas_base_url')
-        cls.tool_relative_url = settings.SELENIUM_CONFIG['bulk_create']['url']
-        cls.base_url = urljoin(cls.canvas_base_url, cls.tool_relative_url)
-        cls.test_data = settings.SELENIUM_CONFIG['bulk_create']['test_data']
-        cls.test_data_course1 = settings.SELENIUM_CONFIG[
-            'bulk_create']['test_data']['course_with_registrar_code_display']
-        cls.test_data_course2 = settings.SELENIUM_CONFIG[
-            'bulk_create']['test_data']['course_without_registrar_code_display']
-        # Login to PIN
-        cls.driver.get(cls.base_url)
+    def setUp(self):
 
-        login_page = PinLoginPageObject(cls.driver)
-        if login_page.is_loaded():
-            print "Logging in XID user {}".format(cls.username)
-            login_page.login_xid(cls.username, cls.password)
-        else:
-            print '(XID user {} already logged in)'.format(cls.username)
+        super(AccountAdminBaseTestCase, self).setUp()
+
+        self.test_data = settings.SELENIUM_CONFIG['bulk_create']['test_data']
+        self.test_data_course1 = settings.SELENIUM_CONFIG['bulk_create'][
+            'test_data']['course_with_registrar_code_display']
+        self.test_data_course2 = settings.SELENIUM_CONFIG['bulk_create'][
+            'test_data']['course_without_registrar_code_display']
+        self.main_page = IndexPageObject(self.driver)
+
+
+        # initialize
+        if not self.acct_admin_dashboard_page.is_loaded():
+            self.acct_admin_dashboard_page.get(self.TOOL_URL)
+
+        # navigate to the create canvas site card on dashboard
+        self.acct_admin_dashboard_page.select_create_canvas_site_link()
+
+        # check if page is loaded (which will also set the focus on the tool)
+        self.assertTrue(self.main_page.is_loaded())
+
+

--- a/selenium_tests/bulk_create/bulk_create_base_test_case.py
+++ b/selenium_tests/bulk_create/bulk_create_base_test_case.py
@@ -17,9 +17,9 @@ class BulkCreateBaseTestCase(AccountAdminBaseTestCase):
         super(AccountAdminBaseTestCase, self).setUp()
 
         self.test_data = settings.SELENIUM_CONFIG['bulk_create']['test_data']
-        self.test_data_course1 = settings.SELENIUM_CONFIG['bulk_create'][
+        self.test_data_course_with_registrar_code_display = settings.SELENIUM_CONFIG['bulk_create'][
             'test_data']['course_with_registrar_code_display']
-        self.test_data_course2 = settings.SELENIUM_CONFIG['bulk_create'][
+        self.test_data_course_without_registrar_code_display = settings.SELENIUM_CONFIG['bulk_create'][
             'test_data']['course_without_registrar_code_display']
         self.main_page = IndexPageObject(self.driver)
 

--- a/selenium_tests/bulk_create/bulk_create_permission_tests.py
+++ b/selenium_tests/bulk_create/bulk_create_permission_tests.py
@@ -3,15 +3,15 @@ from ddt import ddt, data, unpack
 from selenium_common.base_test_case import get_xl_data
 from selenium_common.canvas.canvas_masquerade_page_object \
     import CanvasMasqueradePageObject
-from selenium_tests.bulk_create.bulk_create_base_test_case \
-    import BulkCreateBaseTestCase
+from selenium_tests.account_admin.account_admin_base_test_case \
+    import AccountAdminBaseTestCase
 from selenium_tests.bulk_create.bulk_create_base_test_case \
     import CANVAS_PERMISSION_ROLES
 from selenium_tests.bulk_create.page_objects.index_page import IndexPageObject
 
 
 @ddt
-class BulkCreatePermissionTests(BulkCreateBaseTestCase):
+class BulkCreatePermissionTests(AccountAdminBaseTestCase):
     @data(*get_xl_data(CANVAS_PERMISSION_ROLES))
     @unpack
     def test_roles_access(self, user_id, given_access):
@@ -22,14 +22,14 @@ class BulkCreatePermissionTests(BulkCreateBaseTestCase):
         """
 
         masquerade_page = CanvasMasqueradePageObject(self.driver,
-                                                     self.canvas_base_url)
+                                                     self.CANVAS_BASE_URL)
         index_page = IndexPageObject(self.driver)
 
         # Masquerade as a user defined in the Test_Data/Roles Access spreadsheet
         masquerade_page.masquerade_as(user_id)
 
-        # Once masqueraded as user, go to Course Create Tool
-        self.driver.get(self.base_url)
+        # Once masqueraded as user, go back to Account Admin Console
+        self.driver.get(self.TOOL_URL)
 
         if given_access == 'no':
             print "Verifying user %s is denied access to course bulk create " \
@@ -40,9 +40,12 @@ class BulkCreatePermissionTests(BulkCreateBaseTestCase):
         elif given_access == 'yes':
             print "Verifying user %s is granted access to course bulk create " \
                   "tool" % user_id
-            self.assertTrue(index_page.is_authorized(),
-                            'User {} unexpectedly denied access'.format(
-                                user_id))
+
+            # Clicks into Canvas Site Create tool
+            self.acct_admin_dashboard_page.select_create_canvas_site_link()
+
+            # Verifies that the user can click into the bulk create tool
+            self.assertTrue(index_page.is_loaded())
 
         else:
             raise ValueError('given_access column for user {} must be either '

--- a/selenium_tests/bulk_create/bulk_create_tests.py
+++ b/selenium_tests/bulk_create/bulk_create_tests.py
@@ -15,8 +15,7 @@ class BulkCreateTests(BulkCreateBaseTestCase):
         self.index_page = IndexPageObject(self.driver)
         self.course_selection_page = CourseSelectionPageObject(self.driver)
 
-        # Get base_url and switch frame whenever loading up bulk create tool
-        self.driver.get(self.base_url)
+        # Switch frame after loading up bulk create tool
         self.index_page.focus_on_tool_frame()
 
         self.assertTrue(self.index_page.is_loaded())
@@ -51,7 +50,6 @@ class BulkCreateTests(BulkCreateBaseTestCase):
             self.course_selection_page.is_create_selected_button_enabled()
         )
 
-
     def test_course_with_registrar_code_display(self):
 
         """
@@ -73,10 +71,8 @@ class BulkCreateTests(BulkCreateBaseTestCase):
         registrar_code_element = self.driver.find_element(
                 *Locators.COURSE_CODE_LOCATOR_R4_C3)
         actual_registrar_code = registrar_code_element.text
-
         self.assertEqual(expected_registrar_code, actual_registrar_code,
                          "Registrar code display does not match")
-
 
     def test_course_without_registrar_code_display(self):
 
@@ -100,5 +96,8 @@ class BulkCreateTests(BulkCreateBaseTestCase):
                 *Locators.COURSE_CODE_LOCATOR_R3_C3)
         actual_registrar_code = registrar_code_element.text
 
+        # Compare the expected registrar code with actual registrar code on the
+        # page
         self.assertEqual(expected_registrar_code, actual_registrar_code,
                          "Registrar code does not match")
+

--- a/selenium_tests/bulk_create/bulk_create_tests.py
+++ b/selenium_tests/bulk_create/bulk_create_tests.py
@@ -64,7 +64,7 @@ class BulkCreateTests(BulkCreateBaseTestCase):
 
         """
         self._load_bulk_create_tool()
-        expected_registrar_code = self.test_data_course1[
+        expected_registrar_code = self.test_data_course_with_registrar_code_display[
             'registrar_code_display']
 
         # This returns the text of a specific locator on bulk_create table
@@ -88,7 +88,7 @@ class BulkCreateTests(BulkCreateBaseTestCase):
 
         """
         self._load_bulk_create_tool()
-        expected_registrar_code = self.test_data_course2[
+        expected_registrar_code = self.test_data_course_without_registrar_code_display[
             'registrar_code_display']
 
         # This returns the text of a specific locator on bulk_create table

--- a/selenium_tests/bulk_create/create_new_ci_tests.py
+++ b/selenium_tests/bulk_create/create_new_ci_tests.py
@@ -1,5 +1,5 @@
 from selenium_common.canvas.canvas_course_page_object import \
-    CanvasCoursePage, Locators
+    CanvasCoursePage
 from selenium_common.canvas.course_settings_page_object import CourseSettingsPage
 from selenium_common.decorators import screenshot_on_test_exception
 from selenium_tests.bulk_create.bulk_create_base_test_case \
@@ -31,13 +31,13 @@ class CreateCourseInstanceTests(BulkCreateBaseTestCase):
         # (2) Using same course_title, to get the modal window
 
         # If a course has course title, the course code is the short title.
+
         expected_course_code_text = self.test_data['course_short_title']
 
         self._test_create_site(
             self.test_data['course_code'],
             self.test_data['course_title'],
             self.test_data['course_short_title'],
-            self.test_data['term'],
             expected_course_code_text)
 
     @screenshot_on_test_exception
@@ -54,11 +54,10 @@ class CreateCourseInstanceTests(BulkCreateBaseTestCase):
             self.test_data['course_code'],
             self.test_data['course_title'],
             '',  # simulates no short title entered in form
-            self.test_data['term'],
             expected_course_code_text)
 
     def _test_create_site(self, course_code, course_title, course_short_title,
-                          course_term, expected_course_code):
+                          expected_course_code):
         """
         Common logic for testing site creation.
         """
@@ -67,8 +66,9 @@ class CreateCourseInstanceTests(BulkCreateBaseTestCase):
         canvas_course = CanvasCoursePage(self.driver)
         canvas_settings = CourseSettingsPage(self.driver)
 
-        # Go to the Course Site Creator Tool
-        self.driver.get(self.base_url)
+        # Go to Course Site Creator Tool
+        self.driver.get(self.TOOL_URL)
+        self.acct_admin_dashboard_page.select_create_canvas_site_link()
 
         # Switch to active frame
         canvas_course.focus_on_tool_frame()
@@ -81,7 +81,6 @@ class CreateCourseInstanceTests(BulkCreateBaseTestCase):
             course_code,
             course_title,
             course_short_title,
-            course_term
         )
 
         # Verify confirmation modal window, if course for term and

--- a/selenium_tests/bulk_create/create_new_ci_tests.py
+++ b/selenium_tests/bulk_create/create_new_ci_tests.py
@@ -38,6 +38,7 @@ class CreateCourseInstanceTests(BulkCreateBaseTestCase):
             self.test_data['course_code'],
             self.test_data['course_title'],
             self.test_data['course_short_title'],
+            self.test_data['term_new_course'],
             expected_course_code_text)
 
     @screenshot_on_test_exception
@@ -54,9 +55,11 @@ class CreateCourseInstanceTests(BulkCreateBaseTestCase):
             self.test_data['course_code'],
             self.test_data['course_title'],
             '',  # simulates no short title entered in form
+            self.test_data['term_new_course'],
             expected_course_code_text)
 
-    def _test_create_site(self, course_code, course_title, course_short_title,
+    def _test_create_site(self, course_code, course_title,
+                          course_short_title, course_term,
                           expected_course_code):
         """
         Common logic for testing site creation.
@@ -81,6 +84,7 @@ class CreateCourseInstanceTests(BulkCreateBaseTestCase):
             course_code,
             course_title,
             course_short_title,
+            course_term
         )
 
         # Verify confirmation modal window, if course for term and

--- a/selenium_tests/bulk_create/create_new_ci_tests.py
+++ b/selenium_tests/bulk_create/create_new_ci_tests.py
@@ -59,7 +59,7 @@ class CreateCourseInstanceTests(BulkCreateBaseTestCase):
             expected_course_code_text)
 
     def _test_create_site(self, course_code, course_title,
-                          course_short_title, course_term,
+                          course_short_title, term_new_course,
                           expected_course_code):
         """
         Common logic for testing site creation.
@@ -84,7 +84,7 @@ class CreateCourseInstanceTests(BulkCreateBaseTestCase):
             course_code,
             course_title,
             course_short_title,
-            course_term
+            term_new_course
         )
 
         # Verify confirmation modal window, if course for term and

--- a/selenium_tests/bulk_create/page_objects/create_course_page.py
+++ b/selenium_tests/bulk_create/page_objects/create_course_page.py
@@ -31,7 +31,7 @@ class CreateCoursePageObject(BulkCreateBasePageObject):
                                 course_code,
                                 course_title,
                                 course_short_title,
-                                term):
+                                ):
         """
         This function will fill the form and button click to create the
         course
@@ -40,7 +40,6 @@ class CreateCoursePageObject(BulkCreateBasePageObject):
         self.get_course_code(course_code)
         self.get_course_title(course_title)
         self.get_short_title(course_short_title)
-        self.get_term(term)
 
         add_course_link = self.find_element(*Locators.CREATE_NEW_COURSE_BUTTON)
         if add_course_link.is_enabled():

--- a/selenium_tests/bulk_create/page_objects/create_course_page.py
+++ b/selenium_tests/bulk_create/page_objects/create_course_page.py
@@ -31,7 +31,7 @@ class CreateCoursePageObject(BulkCreateBasePageObject):
                                 course_code,
                                 course_title,
                                 course_short_title,
-                                term):
+                                term_new_course):
         """
         This function will fill the form and button click to create the
         course
@@ -40,7 +40,7 @@ class CreateCoursePageObject(BulkCreateBasePageObject):
         self.get_course_code(course_code)
         self.get_course_title(course_title)
         self.get_short_title(course_short_title)
-        self.get_term(term)
+        self.get_term(term_new_course)
 
         add_course_link = self.find_element(*Locators.CREATE_NEW_COURSE_BUTTON)
         if add_course_link.is_enabled():

--- a/selenium_tests/bulk_create/page_objects/create_course_page.py
+++ b/selenium_tests/bulk_create/page_objects/create_course_page.py
@@ -31,7 +31,7 @@ class CreateCoursePageObject(BulkCreateBasePageObject):
                                 course_code,
                                 course_title,
                                 course_short_title,
-                                ):
+                                term):
         """
         This function will fill the form and button click to create the
         course
@@ -40,6 +40,7 @@ class CreateCoursePageObject(BulkCreateBasePageObject):
         self.get_course_code(course_code)
         self.get_course_title(course_title)
         self.get_short_title(course_short_title)
+        self.get_term(term)
 
         add_course_link = self.find_element(*Locators.CREATE_NEW_COURSE_BUTTON)
         if add_course_link.is_enabled():

--- a/selenium_tests/bulk_create/page_objects/index_page.py
+++ b/selenium_tests/bulk_create/page_objects/index_page.py
@@ -53,6 +53,8 @@ class IndexPageObject(BulkCreateBasePageObject):
         select.select_by_visible_text(department)
 
     def select_term(self, term):
+        WebDriverWait(self._driver, 30).until(EC.visibility_of_element_located(
+                Locators.TERM_SELECT_DROPDOWN))
         select = Select(self.find_element(*Locators.TERM_SELECT_DROPDOWN))
         select.select_by_value(term)
 

--- a/selenium_tests/canvas_account_admin_tools_base_test_case.py
+++ b/selenium_tests/canvas_account_admin_tools_base_test_case.py
@@ -3,8 +3,10 @@ from urlparse import urljoin
 from django.conf import settings
 
 from selenium_common.base_test_case import BaseSeleniumTestCase
-from selenium_common.pin.page_objects.pin_login_page_object import PinLoginPageObject
-from selenium_tests.account_admin.page_objects.account_admin_dashboard_page_object import AccountAdminDashboardPage
+from selenium_common.pin.page_objects.pin_login_page_object \
+    import PinLoginPageObject
+from selenium_tests.account_admin.page_objects.account_admin_dashboard_page_object \
+    import AccountAdminDashboardPage
 
 
 class AccountAdminBaseTestCase(BaseSeleniumTestCase):


### PR DESCRIPTION
- Refactored selenium tests with the move over from icommons_lti_tool to canvas_account_admin (particularly around using admin dashboard instead of passing into direct bulk create URL) 
- Fixed test data 
- Added explicit wait to better selenium performance

Tested, and ran regression test for the project successfully.  