### PR TITLE
Task/sapnamysore/tlt 2645/fix breadcrumb style

### DIFF
--- a/canvas_site_creator/static/canvas_site_creator/css/app.css
+++ b/canvas_site_creator/static/canvas_site_creator/css/app.css
@@ -3,12 +3,6 @@
     text-decoration: underline;
 }
 
-body.lti-tool-bootstrap {
-    /* overrides body.lti-tool from lti-css/bulkSiteCreator.css */
-    /* matches bootstrap.css body font-size default that we use elsewhere */
-    font-size: 14px;
-}
-
 .breadcrumb-font{
      font-size: 24px;
 }
@@ -22,6 +16,12 @@ body.lti-tool-bootstrap {
 
 .col-align-center {
     text-align: center;
+}
+.courses {
+    padding: 1em 0.5em;
+    border-top: 1px solid #e9e9e9;
+    border-bottom: 1px solid #e9e9e9;
+    margin-bottom: 1em;
 }
 
 /* this is a select element on create new course form.
@@ -47,6 +47,17 @@ body.lti-tool-bootstrap {
     color: #a51c30;
 }
 
+#createForm {
+    width: 80%;
+    margin: 0 auto;
+    text-align: center;
+}
+#createForm h2{
+    font-size : 1.5em;
+    width: 80%;
+    margin: 0 auto;
+    text-align: center;
+}
 #createSitesButton, #createNewCourseButton{
     text-decoration:none;
     font-weight: bold;

--- a/canvas_site_creator/static/canvas_site_creator/css/app.css
+++ b/canvas_site_creator/static/canvas_site_creator/css/app.css
@@ -9,6 +9,13 @@ body.lti-tool-bootstrap {
     font-size: 14px;
 }
 
+.breadcrumb-font{
+     font-size: 24px;
+}
+.breadcrumb-font a{
+    text-decoration:none;
+}
+
 .bsc-btn-fixed-width {
     width: 70px;  /* gives enough room to display options list labels */
 }

--- a/canvas_site_creator/templates/canvas_site_creator/audit.html
+++ b/canvas_site_creator/templates/canvas_site_creator/audit.html
@@ -21,7 +21,7 @@
 {% block body %}
 <body class="lti-tool" role="application" ng-app="app">
     <header>
-        <h3 class="breadcrumbs breadcrumb-font">
+        <h3 class="breadcrumbs">
             <a href="{% url 'dashboard_account' %}">Admin Console</a>
             <small><i class="fa fa-chevron-right"></i></small>
            <a href="{% url 'canvas_site_creator:index' %}">Canvas Site Creator</a>

--- a/canvas_site_creator/templates/canvas_site_creator/audit.html
+++ b/canvas_site_creator/templates/canvas_site_creator/audit.html
@@ -9,7 +9,6 @@
     <script>
         window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';
     </script>
-    <script src="{% static 'canvas_site_creator/js/app.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/controllers/AuditController.js' %}"></script>
 {% endblock js %}
 

--- a/canvas_site_creator/templates/canvas_site_creator/audit.html
+++ b/canvas_site_creator/templates/canvas_site_creator/audit.html
@@ -21,7 +21,7 @@
 {% block body %}
 <body class="lti-tool" role="application" ng-app="app">
     <header>
-        <h3>
+        <h3 class="breadcrumbs breadcrumb-font">
             <a href="{% url 'dashboard_account' %}">Admin Console</a>
             <small><i class="fa fa-chevron-right"></i></small>
            <a href="{% url 'canvas_site_creator:index' %}">Canvas Site Creator</a>

--- a/canvas_site_creator/templates/canvas_site_creator/audit.html
+++ b/canvas_site_creator/templates/canvas_site_creator/audit.html
@@ -5,12 +5,7 @@
 {% load django_helpers %}
 
 
-{% block css %}
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.7/media/css/jquery.dataTables.min.css' %}" media="screen"/>
-{% endblock css %}
-
 {% block js %}
-    <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.js' %}"></script>
     <script>
         window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';
     </script>

--- a/canvas_site_creator/templates/canvas_site_creator/base.html
+++ b/canvas_site_creator/templates/canvas_site_creator/base.html
@@ -8,16 +8,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <link rel="stylesheet" type="text/css" href="{% static 'font-awesome-4.5.0/css/font-awesome.min.css' %}">
     <link rel="stylesheet" href="{% static 'canvas_site_creator/css/app.css' %}">
-    <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}" media="screen"/>
 
-    {% block css %}
-      {% if debug %}
-        <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.css' %}" media="screen"/>
-      {% else %}
-        <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}" media="screen"/>
-      {% endif %}
-    {% endblock css %}
 {% if debug %}
+    {#  Note: retain the order for proper styles, first load the jquery.datatables.css and then bootstrap   #}
+    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.7/media/css/jquery.dataTables.css' %}" media="screen"/>
+    <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.css' %}" media="screen"/>
     <script src="{% static 'jquery-2.2.2/jquery-2.2.2.js' %}"></script>
     <script src="{% static 'underscore-1.8.2/underscore.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular.js' %}"></script>
@@ -25,8 +20,13 @@
     <script src="{% static 'angular-1.5.2/angular-sanitize.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular-animate.js' %}"></script>
     <script src="{% static 'angular-ui-bootstrap-0.14.3/ui-bootstrap-tpls-0.14.3.js' %}"></script>
+    <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.js' %}"></script>
+    <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.js' %}"></script>
     <script src="{% static 'djangular/js/django-angular.js' %}"></script>
+
 {% else %}
+    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.7/media/css/jquery.dataTables.min.css' %}" media="screen"/>
+    <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}" media="screen"/>
     <script src="{% static 'jquery-2.2.2/jquery-2.2.2.min.js' %}"></script>
     <script src="{% static 'underscore-1.8.2/underscore.min.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular.min.js' %}"></script>
@@ -34,6 +34,8 @@
     <script src="{% static 'angular-1.5.2/angular-sanitize.min.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular-animate.min.js' %}"></script>
     <script src="{% static 'angular-ui-bootstrap-0.14.3/ui-bootstrap-tpls-0.14.3.min.js' %}"></script>
+    <script src="{% static "bootstrap-3.3.6/dist/js/bootstrap.min.js" %}"></script>
+    <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.min.js' %}"></script>
     <script src="{% static 'djangular/js/django-angular.min.js' %}"></script>
 {% endif %}
     {# fixes safari autocomplete issue #}

--- a/canvas_site_creator/templates/canvas_site_creator/base.html
+++ b/canvas_site_creator/templates/canvas_site_creator/base.html
@@ -7,9 +7,16 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <link rel="stylesheet" type="text/css" href="{% static 'font-awesome-4.5.0/css/font-awesome.min.css' %}">
-    <link rel="stylesheet" href="{% static 'lti-css/bulkSiteCreator.css' %}">
     <link rel="stylesheet" href="{% static 'canvas_site_creator/css/app.css' %}">
-    {% block css %}{% endblock css %}
+    <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}" media="screen"/>
+
+    {% block css %}
+      {% if debug %}
+        <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.css' %}" media="screen"/>
+      {% else %}
+        <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}" media="screen"/>
+      {% endif %}
+    {% endblock css %}
 {% if debug %}
     <script src="{% static 'jquery-2.2.2/jquery-2.2.2.js' %}"></script>
     <script src="{% static 'underscore-1.8.2/underscore.js' %}"></script>

--- a/canvas_site_creator/templates/canvas_site_creator/base.html
+++ b/canvas_site_creator/templates/canvas_site_creator/base.html
@@ -34,13 +34,15 @@
     <script src="{% static 'angular-1.5.2/angular-sanitize.min.js' %}"></script>
     <script src="{% static 'angular-1.5.2/angular-animate.min.js' %}"></script>
     <script src="{% static 'angular-ui-bootstrap-0.14.3/ui-bootstrap-tpls-0.14.3.min.js' %}"></script>
-    <script src="{% static "bootstrap-3.3.6/dist/js/bootstrap.min.js" %}"></script>
+    <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.min.js' %}"></script>
     <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.min.js' %}"></script>
     <script src="{% static 'djangular/js/django-angular.min.js' %}"></script>
 {% endif %}
     {# fixes safari autocomplete issue #}
     {# (see https://github.com/angular/angular.js/issues/1460) #}
     <script src="{% static 'course_info/js/polyfills/autofill-event.js' %}"></script>
+    <script src="{% static 'canvas_site_creator/js/app.js' %}"></script>
+
     {% include 'django_auth_lti/resource_link_id.html' %}
     <script>
         window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';

--- a/canvas_site_creator/templates/canvas_site_creator/bulk_job_detail.html
+++ b/canvas_site_creator/templates/canvas_site_creator/bulk_job_detail.html
@@ -5,12 +5,10 @@
 
 
 {% block css %}
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.7/media/css/jquery.dataTables.min.css' %}" media="screen"/>
     <link rel="stylesheet" href="{% static 'lti-css/progressbar.css' %}">
 {% endblock css %}
 
 {% block js %}
-    <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.js' %}"></script>
     <script>
         window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';
         window.globals.CANVAS_URL = '{% settings_value "CANVAS_URL" %}';

--- a/canvas_site_creator/templates/canvas_site_creator/bulk_job_detail.html
+++ b/canvas_site_creator/templates/canvas_site_creator/bulk_job_detail.html
@@ -13,7 +13,6 @@
         window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';
         window.globals.CANVAS_URL = '{% settings_value "CANVAS_URL" %}';
     </script>
-    <script src="{% static 'canvas_site_creator/js/app.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/models/ErrorModel.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/controllers/ErrorController.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/models/BulkJobDetailModel.js' %}"></script>
@@ -57,7 +56,7 @@
             <form>
                 <div class="progress">
                     {% verbatim %}
-                    <div class="progress-bar" role="progressbar" aria-valuenow="{{ bulkJobDetailModel.completeCourseJobs }}" aria-valuemin="0" aria-valuemax="100" ng-style="getProgressBarStyle()">
+                    <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="{{ bulkJobDetailModel.completeCourseJobs }}" aria-valuemin="0" aria-valuemax="100" ng-style="getProgressBarStyle()">
                         <span ng-cloak ng-show="bulkJobDetailModel.completeCourseJobs">
                             {{ bulkJobDetailModel.completeCourseJobs }} out of {{ bulkJobDetailModel.totalCourseJobs }} course site creation jobs completed
                         </span>

--- a/canvas_site_creator/templates/canvas_site_creator/course_selection.html
+++ b/canvas_site_creator/templates/canvas_site_creator/course_selection.html
@@ -26,7 +26,7 @@
 {% block body %}
 <body class="lti-tool" role="application" ng-app="app">
     <header>
-        <h3 class="breadcrumbs breadcrumb-font" >
+        <h3 class="breadcrumbs" >
             <a href="{% url 'dashboard_account' %}">Admin Console</a>
             <small><i class="fa fa-chevron-right"></i></small>
             <a href="{% url 'canvas_site_creator:index' %}">Canvas Site Creator</a>
@@ -86,7 +86,7 @@
                 {% endif %}
 
                 {% verbatim %}
-                <button type="button" ng-cloak class="btn btn-submit" ng-disabled="selectedTemplate == 'default'" data-toggle="modal" data-target="#confirmCreate">Create {{ getCreateButtonMessage() }}
+                <button type="button" ng-cloak class="btn btn-submit btn-primary" ng-disabled="selectedTemplate == 'default'" data-toggle="modal" data-target="#confirmCreate">Create {{ getCreateButtonMessage() }}
                 </button>
                 {% endverbatim %}
 

--- a/canvas_site_creator/templates/canvas_site_creator/course_selection.html
+++ b/canvas_site_creator/templates/canvas_site_creator/course_selection.html
@@ -3,15 +3,7 @@
 {% load static %}
 {% load collections %}
 
-
-{% block css %}
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.7/media/css/jquery.dataTables.min.css' %}" media="screen"/>
-    <link rel="stylesheet" href="{% static 'lti-css/tooltipModal.css' %}">
-{% endblock css %}
-
 {% block js %}
-    <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.js' %}"></script>
-    <script type="text/javascript" language="javascript" src="{% static 'js/tooltipModal.js' %}"></script>
     {% include 'canvas_site_creator/_selected_filters.html' %}
     <script src="{% static 'canvas_site_creator/js/app.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/models/ErrorModel.js' %}"></script>
@@ -47,9 +39,9 @@
             {{ school.name }} <i class="fa fa-chevron-right"></i>
             {{ term.name }}
             {% if department %}
-            <i class="fa fa-chevron-right"></i> {{ department.name }}
+            <small><i class="fa fa-chevron-right"></i></small> {{ department.name }}
             {% elif course_group %}
-            <i class="fa fa-chevron-right"></i> {{ course_group.name }}
+            <small><i class="fa fa-chevron-right"></i></small> {{ course_group.name }}
             {% endif %}
             <a href="{% url 'canvas_site_creator:index' %}&school={{ school.id }}&term={{ term.id }}&department={{ department.id }}&course_group={{ course_group.id }}">
                 Edit Selection
@@ -86,7 +78,7 @@
                 {% endif %}
 
                 {% verbatim %}
-                <button type="button" ng-cloak class="btn btn-submit btn-primary" ng-disabled="selectedTemplate == 'default'" data-toggle="modal" data-target="#confirmCreate">Create {{ getCreateButtonMessage() }}
+                <button type="button" ng-cloak class="btn btn-primary" ng-disabled="selectedTemplate == 'default'" data-toggle="modal" data-target="#confirmCreate">Create {{ getCreateButtonMessage() }}
                 </button>
                 {% endverbatim %}
 
@@ -119,7 +111,7 @@
                     <div class="modal-footer">
                         <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
 
-                        <button ng-show="courseInstanceModel.getSelectedCourseIdsCount()" id="createCoursesConfirmed" type="button" class="btn btn-submit" ng-click="handleCreate()">
+                        <button ng-show="courseInstanceModel.getSelectedCourseIdsCount()" id="createCoursesConfirmed" type="button" class="btn btn-primary" ng-click="handleCreate()">
                             Yes, Create
                             <span ng-show="courseInstanceModel.getSelectedCourseIdsCount()">
                                 <ng-pluralize count="courseInstanceModel.getSelectedCourseIdsCount()"

--- a/canvas_site_creator/templates/canvas_site_creator/course_selection.html
+++ b/canvas_site_creator/templates/canvas_site_creator/course_selection.html
@@ -26,7 +26,7 @@
 {% block body %}
 <body class="lti-tool" role="application" ng-app="app">
     <header>
-        <h3 class="breadcrumbs">
+        <h3 class="breadcrumbs breadcrumb-font" >
             <a href="{% url 'dashboard_account' %}">Admin Console</a>
             <small><i class="fa fa-chevron-right"></i></small>
             <a href="{% url 'canvas_site_creator:index' %}">Canvas Site Creator</a>

--- a/canvas_site_creator/templates/canvas_site_creator/course_selection.html
+++ b/canvas_site_creator/templates/canvas_site_creator/course_selection.html
@@ -5,7 +5,6 @@
 
 {% block js %}
     {% include 'canvas_site_creator/_selected_filters.html' %}
-    <script src="{% static 'canvas_site_creator/js/app.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/models/ErrorModel.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/models/CourseInstanceModel.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/models/CourseInstanceFilterModel.js' %}"></script>

--- a/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
+++ b/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
@@ -4,7 +4,6 @@
 {% load collections %}
 
 {% block js %}
-  <script src="{% static 'canvas_site_creator/js/app.js' %}"></script>
   <script>
     // NOTE: Should come after loading app.js (because it defines the
     //       module), but before CreateNewCourseController.js (because it

--- a/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
+++ b/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
@@ -35,7 +35,7 @@
 {% endblock js %}
 
 {% block body %}
-  <body class="lti-tool lti-tool-bootstrap" role="application" ng-app="app">
+  <body class="lti-tool" role="application" ng-app="app">
   <header>
     <h3 class="breadcrumbs">
       <a href="{% url 'dashboard_account' %}">Admin Console</a>

--- a/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
+++ b/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
@@ -3,23 +3,7 @@
 {% load static %}
 {% load collections %}
 
-{% block css %}
-  <link rel="stylesheet" type="text/css" href="{% static 'datatables-bootstrap3/BS3/assets/css/datatables.css' %}" media="screen"/>
-  {% if debug %}
-    <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.css' %}" media="screen"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.7/media/css/jquery.dataTables.css' %}" media="screen"/>
-  {% else %}
-    <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}" media="screen"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'datatables-1.10.7/media/css/jquery.dataTables.min.css' %}" media="screen"/>
-  {% endif %}
-{% endblock css %}
-
 {% block js %}
-  {% if debug %}
-    <script src="{% static 'bootstrap-3.3.6/dist/js/bootstrap.js' %}"></script>
-  {% else %}
-    <script src="{% static "bootstrap-3.3.6/dist/js/bootstrap.min.js" %}"></script>
-  {% endif %}
   <script src="{% static 'canvas_site_creator/js/app.js' %}"></script>
   <script>
     // NOTE: Should come after loading app.js (because it defines the

--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -5,17 +5,7 @@
 {% load django_helpers %}
 
 
-{% block css %}
-
-    {% if debug %}
-        <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.css' %}" media="screen"/>
-    {% else %}
-        <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.3.6/dist/css/bootstrap.min.css' %}" media="screen"/>
-    {% endif %}
- {% endblock css %}
-
 {% block js %}
-    <script src="{% static 'datatables-1.10.7/media/js/jquery.dataTables.js' %}"></script>
     <script src="{% static 'datatables-bootstrap3/BS3/assets/js/datatables.js' %}"></script>
     <script>
         window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';

--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -6,13 +6,11 @@
 
 
 {% block js %}
-    <script src="{% static 'datatables-bootstrap3/BS3/assets/js/datatables.js' %}"></script>
     <script>
         window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';
     </script>
     {% include 'canvas_site_creator/_selected_filters.html' %}
     {% include 'canvas_site_creator/_filter_options.html' %}
-    <script src="{% static 'canvas_site_creator/js/app.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/models/ErrorModel.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/models/CourseInstanceFilterModel.js' %}"></script>
     <script src="{% static 'canvas_site_creator/js/models/CourseInstanceModel.js' %}"></script>


### PR DESCRIPTION
Removed the custom lti-css/bulkSiteCreator.css that was in place that had partial styles from bootstrap and then some custom ones. Swapped it with standard bootstrap.css in all screens. Moved from styles from bulkSiteCreator.css to app.css to fix some positioning styles.

The screens in Canvas Site Creator are now more consistent with the rest of teh tools in admin console. Any custom styles can be fixed or added as enhancement once @Vittorio2015 and the PO take a look.

The code is deployed on Dev https://canvas.dev.tlt.harvard.edu/accounts/8/external_tools/44