### PR TITLE
Added the newly created librarian role (role_id=16), to the list cont…

### DIFF
--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -340,7 +340,7 @@ PERMISSION_SITE_CREATOR = 'manage_courses'
 # in search courses, when you add a person to a course. This list
 # controls which roles show up in the drop down. The list contains
 # user role id's from the course manager database
-ADD_PEOPLE_TO_COURSE_ALLOWED_ROLES_LIST = [0, 1, 2, 5, 7, 9, 10, 11, 12, 15]
+ADD_PEOPLE_TO_COURSE_ALLOWED_ROLES_LIST = [0, 1, 2, 5, 7, 9, 10, 11, 12, 15, 16]
 
 BULK_COURSE_CREATION = {
     'log_long_running_jobs': True,


### PR DESCRIPTION
…rolling the dropdown roles
Note: The role has been added in Canvas as well as the DB in both prod and QA. The role_id(16) in user_role table needs to match in both environments as it is set in the base.py. The canvas_role_id can be different

This is deployed on dev:
https://canvas.dev.tlt.harvard.edu/accounts/10/external_tools/79