### PR TITLE
TLT-1805 publish courses - unit tests

### DIFF
--- a/canvas_account_admin_tools/settings/test.py
+++ b/canvas_account_admin_tools/settings/test.py
@@ -23,3 +23,6 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
     }
 }
+
+RQWORKER_QUEUE_NAME = 'test'
+RQ_QUEUES[RQWORKER_QUEUE_NAME] = RQ_QUEUES['default']

--- a/canvas_account_admin_tools/tests.py
+++ b/canvas_account_admin_tools/tests.py
@@ -13,6 +13,7 @@ class CanvasAccountAdminToolsAPIProxyTests(TestCase):
     longMessage = True
 
     def setUp(self):
+        super(CanvasAccountAdminToolsAPIProxyTests, self).setUp()
         self.user_id = '12345678'
 
     def _setup_request(self, method='GET', path='fake-path/', data=None, request_lti_dict=None):

--- a/publish_courses/api.py
+++ b/publish_courses/api.py
@@ -34,6 +34,8 @@ class ProcessSerializer(ModelSerializer):
 
 
 class LTIPermission(BasePermission):
+    message = 'Invalid LTI session.'
+
     def has_permission(self, request, view):
         return lti_permission_required_check(request, PC_PERMISSION)
 
@@ -88,8 +90,14 @@ class BulkPublishListCreate(ListCreateAPIView):
     permission_classes = (LTIPermission,)
 
     def create(self, request, *args, **kwargs):
-        audit_user_id = self.request.LTI['custom_canvas_user_login_id']
-        account_sis_id = request.LTI['custom_canvas_account_sis_id']
+        lti_session = getattr(self.request, 'LTI', {})
+        audit_user_id = lti_session.get('custom_canvas_user_login_id')
+        account_sis_id = lti_session.get('custom_canvas_account_sis_id')
+        if not all((audit_user_id, account_sis_id)):
+            raise DRFValidationError(
+                'Invalid LTI session: custom_canvas_user_login_id and '
+                'custom_canvas_account_sis_id required')
+
         account = self.request.data.get('account')
         term = self.request.data.get('term')
         if not all((account, term)):

--- a/publish_courses/api.py
+++ b/publish_courses/api.py
@@ -101,7 +101,7 @@ class BulkPublishListCreate(ListCreateAPIView):
 
         process = Process.enqueue(
             bulk_publish_canvas_sites,
-            'bulk_publish_canvas_sites',
+            settings.RQWORKER_QUEUE_NAME,
             account='sis_account_id:school:{}'.format(account),
             term='sis_term_id:{}'.format(term),
             audit_user=audit_user_id)

--- a/publish_courses/tests/test_api.py
+++ b/publish_courses/tests/test_api.py
@@ -91,7 +91,7 @@ class BulkPublishListCreateTestCase(PublishCoursesAPIBaseTestCase):
             'term': '2015-1'
         }
         with self.assertRaises(PermissionDenied):
-            self._prep_request_and_post(data)
+            self._prep_request_and_post(data=data)
 
     def test_missing_data(self):
         """
@@ -101,7 +101,7 @@ class BulkPublishListCreateTestCase(PublishCoursesAPIBaseTestCase):
         data = {}
         msg = 'account and term are required'
         with self.assertRaisesRegexp(DRFValidationError, msg):
-            self._prep_request_and_post(data)
+            self._prep_request_and_post(data=data)
 
     def test_missing_lti_data(self):
         """

--- a/publish_courses/tests/test_api.py
+++ b/publish_courses/tests/test_api.py
@@ -1,75 +1,88 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import json
-from mock import patch, Mock
-import unittest
+from mock import (
+    patch,
+    Mock)
 
-from rest_framework.test import APITestCase
-from rest_framework.exceptions import PermissionDenied
+from django.conf import settings
+import django_rq
+from rest_framework import status
+from rest_framework.exceptions import (
+    PermissionDenied,
+    ValidationError as DRFValidationError)
+from rest_framework.test import (
+    APIRequestFactory,
+    APITestCase)
 
 import publish_courses.api as api
 
+QUEUE_NAME = settings.RQWORKER_QUEUE_NAME
 
-class PublishCoursesAPITestCase(APITestCase):
+
+class PublishCoursesAPIBaseTestCase(APITestCase):
 
     def setUp(self):
-        super(PublishCoursesAPITestCase, self).setUp()
+        super(PublishCoursesAPIBaseTestCase, self).setUp()
+        self.queue = django_rq.get_queue(QUEUE_NAME)
+        self.queue.empty()
+        self.factory = APIRequestFactory()
+        self.post_url = '/publish_courses/api/jobs'
+        self.get_url = '/publish_courses/api/show_summary'
 
-        self.post_data = {
-            'account': 'sis_account_id:school:abc',
-            'term': 'sis_term_id:2015-1'
+    def tearDown(self):
+        super(PublishCoursesAPIBaseTestCase, self).tearDown()
+        self.queue.empty()
+
+
+class BulkPublishListCreateTestCase(PublishCoursesAPIBaseTestCase):
+
+    def setUp(self):
+        super(BulkPublishListCreateTestCase, self).setUp()
+        self.request_data = {
+            'account': 'abc',
+            'term': '2015-1'
         }
         self.lti_data = {
             'custom_canvas_user_login_id': '1',
             'custom_canvas_account_sis_id': 'school:abc',
         }
-        self.get_data = {
-            'account': 'sis_account_id:school:abc',
-            'term': 'sis_term_id:2015-1'
-        }
-        self.user = Mock(is_authenticated=Mock(return_value=True))
-        self.post_url = '/publish_courses/api/jobs'
-        self.get_url = '/publish_courses/api/show_summary'
 
-    def _prep_request_and_post(self, data):
+    def _prep_request_and_post(self, data=None, lti_data=None):
+        request_data = data if data is not None else self.request_data
+        request_lti_data = lti_data if lti_data is not None else self.lti_data
         request_kwargs = {
             'content_type': 'application/json',
-            'data': json.dumps(self.post_data),
+            'data': json.dumps(request_data),
         }
-
-        self.request = self.client.post(self.post_url, **request_kwargs)
-        # these values don't matter; the keys need to be present
-        # for the authorization decorator patches to work
-        self.request.LTI = self.lti_data
-        self.request.data = data
-        self.request.user = self.user
-
+        self.request = self.factory.post(self.post_url, **request_kwargs)
+        setattr(self.request, 'data', request_data)
+        setattr(self.request, 'LTI', request_lti_data)
         bulk_publish = api.BulkPublishListCreate(request=self.request)
         return bulk_publish.create(self.request)
 
-    def _prep_request_and_get(self, query_params=None, data=None):
-        self.request = self.client.get(self.get_url, data=data)
-        self.request.LTI = self.lti_data
-        self.request.user = self.user
-        self.request.query_params = query_params
-
-        summary_list = api.SummaryList(request=self.request)
-        return summary_list.list(self.request)
-
-    # Tests for BulkPublishListCreate:
-    def test_bulk_publish_list_create_success(self):
+    def test_returns_success(self):
         """
-        returns data as expected on success
+        returns expected data and status code on success
         """
-        data = {
-            'account': 'abc',
-            'term': '2015-1'
-        }
-        response = self._prep_request_and_post(data)
-        # validate data and status code on success
-        self.assertEqual(response.status_code, 201)
+        response = self._prep_request_and_post()
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['state'], 'queued')
         self.assertNotEquals(response.data['date_created'], None)
 
-    def test_bulk_publish_list_create_invalid_account(self):
+    def test_queues_job(self):
+        """
+        queues job on success
+        """
+        queue = django_rq.get_queue(QUEUE_NAME)
+        self.assertEqual(queue.count, 0)
+
+        response = self._prep_request_and_post()
+
+        self.assertEqual(queue.count, 1)
+
+    def test_invalid_account(self):
         """
         invalid account raises permission denied
         """
@@ -80,46 +93,107 @@ class PublishCoursesAPITestCase(APITestCase):
         with self.assertRaises(PermissionDenied):
             self._prep_request_and_post(data)
 
-    @unittest.skip('BulkPublishListCreate seems to be bypassing its permission_classes')
-    # all of our unit tests should be failing, because the LTIPermission isn't
-    # being explicitly stubbed out, but they are passing, and this one is
-    # failing; perhaps switching to using the live server will trigger the
-    # permissions classes, or perhaps not mocking out the User object?...
-    @patch('publish_courses.api.LTIPermission.has_permission')
-    def test_bulk_publish_list_create_invalid_lti_session(self, mock_lti_check):
-        """
-        invalid lti session raises permission denied
-        """
-        data = {
-            'account': 'abc',
-            'term': '2015-1'
-        }
-        mock_lti_check.return_value = False
-        with self.assertRaises(PermissionDenied):
-            self._prep_request_and_post(data)
-
-    def test_bulk_publish_list_create_missing_data(self):
+    def test_missing_data(self):
         """
         Invalid/missing data raises Exception (REST framework converts that
-        into a status code 500)
+        into a response with status code 400)
         """
         data = {}
-        with self.assertRaises(Exception):
+        msg = 'account and term are required'
+        with self.assertRaisesRegexp(DRFValidationError, msg):
             self._prep_request_and_post(data)
 
-    # SummaryList tests
-    # invalid LTI session raises permission denied
-    # returns data as expected on successful enqueue()
-    # exception raises 500
+    def test_missing_lti_data(self):
+        """
+        Invalid/missing LTI data raises Exception (REST framework converts that
+        into a response with status code 400)
+        """
+        lti_data = {}
+        msg = 'Invalid LTI session'
+        with self.assertRaisesRegexp(DRFValidationError, msg):
+            self._prep_request_and_post(lti_data=lti_data)
 
-    @unittest.skip('SummaryList returns data as expected on sucess')
-    @patch('publish_courses.api.BulkCourseSettingsOperation.get_canvas_courses')
-    def test_summary_list_success(self, mock_get_canvas_courses):
 
-        mock_get_canvas_courses.return_value.json.return_value = {}
-        query_params = {
+@patch('publish_courses.api.BulkCourseSettingsOperation')
+class SummaryListTestCase(PublishCoursesAPIBaseTestCase):
+
+    def setUp(self):
+        super(SummaryListTestCase, self).setUp()
+        self.request_data = {
             'account_id': 'abc',
             'term_id': '2015-1'
         }
-        response = self._prep_request_and_get(query_params=query_params)
-        self.assertEqual(response.status_code, 200)
+
+    def _prep_request_and_get(self, data=None):
+        request_data = data if data is not None else self.request_data
+        self.request = self.factory.get(self.get_url, data=request_data)
+        self.request.query_params = request_data
+        summary_list = api.SummaryList(request=self.request)
+        return summary_list.list(self.request)
+
+    def test_success_status(self, mock_op):
+        """ returns expected status code on success """
+        mock_op.return_value.get_canvas_courses.return_value = []
+        response = self._prep_request_and_get()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_fetches_expected_courses(self, mock_op):
+        """ gets courses based on expected op_config """
+        expected_op_config = {
+            'account': 'sis_account_id:school:{}'.format(
+                self.request_data['account_id']),
+            'term': 'sis_term_id:{}'.format(self.request_data['term_id'])
+        }
+        response = self._prep_request_and_get()
+        self.assertEqual(mock_op.call_count, 1)
+        args, kwargs = mock_op.call_args
+        self.assertDictEqual(args[0], expected_op_config)
+
+    @patch('publish_courses.api.SummaryList._get_courses')
+    def test_shows_relevant_courses_only(self, mock_get_courses, *args):
+        """ only shows published, unpublished, and completed courses """
+        available = {'workflow_state': 'available'}
+        unpublished = {'workflow_state': 'unpublished'}
+        completed = {'workflow_state': 'completed'}
+        other = {'workflow_state': 'other'}
+        mock_get_courses.return_value = [
+            available, unpublished, completed, other]
+        # Note: `total` counts all courses, but we only expect category counts
+        #       for these relevant workflow types
+        expected_response_data = {
+            'published': 1,
+            'unpublished': 1,
+            'concluded': 1,
+            'total': 4}
+
+        response = self._prep_request_and_get()
+
+        self.assertDictEqual(response.data, expected_response_data)
+
+
+class PublishCoursesAPILTIPermissionsTestCase(PublishCoursesAPIBaseTestCase):
+    def setUp(self):
+        super(PublishCoursesAPILTIPermissionsTestCase, self).setUp()
+        # Even if we don't add IsAuthenticated to the APIView permission_classes
+        # tuple, we need to do this because of the way DRF handles permissions
+        # https://github.com/tomchristie/django-rest-framework/blob/3.5.3/rest_framework/views.py#L164
+        self.user = Mock(is_authenticated=Mock(return_value=True))
+        self.client.force_authenticate(user=self.user)
+
+    def test_create_job_invalid_lti_session(self):
+        """
+        invalid lti session raises permission denied
+        """
+        request_kwargs = {
+            'content_type': 'application/json',
+            'data': json.dumps({}),
+        }
+        response = self.client.post(self.post_url, **request_kwargs)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn('Invalid LTI session', response.data['detail'])
+
+    def test_summary_list_invalid_lti_session(self):
+        response = self.client.get(self.get_url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn('Invalid LTI session', response.data['detail'])

--- a/publish_courses/tests/test_async_operations.py
+++ b/publish_courses/tests/test_async_operations.py
@@ -1,6 +1,129 @@
-# Test TODOs
-# process status, timestamps updated when activated
-# job updated with process id when activated
-# process updated with job id when activated
-# process status, timestamps, details updated when successfully completed
-# process status, timestamps, details updated when failed (completed)
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from mock import patch
+
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.test import TestCase
+from django_rq.queues import get_queues
+from django_rq.workers import get_exception_handlers
+from rq import (
+    get_current_job,
+    SimpleWorker)
+
+from async.models import Process
+from publish_courses.async_operations import bulk_publish_canvas_sites
+
+QUEUE_NAME = settings.RQWORKER_QUEUE_NAME
+
+
+# modeled from https://github.com/ui/django-rq/blob/v0.9.4/django_rq/workers.py
+# but needed to change Worker to SimpleWorker to avoid RQ's forking behavior
+# while in Django test cases (see http://python-rq.org/docs/testing/).
+def get_simple_worker(*queue_names):
+    """
+    Returns a RQ worker for all queues or specified ones.
+    """
+    queues = get_queues(*queue_names)
+    return SimpleWorker(queues,
+                        connection=queues[0].connection,
+                        exception_handlers=get_exception_handlers() or None)
+
+
+class BulkPublishCanvasSitesBaseTestCase(TestCase):
+    def setUp(self):
+        super(BulkPublishCanvasSitesBaseTestCase, self).setUp()
+        self.account = 'colgsas'
+        self.term = '2017-1'
+        self.test_user_id = '12345678'
+        self.process = Process.enqueue(
+            bulk_publish_canvas_sites,
+            QUEUE_NAME,
+            account='sis_account_id:school:{}'.format(self.account),
+            term='sis_term_id:{}'.format(self.term),
+            audit_user=self.test_user_id)
+
+        self._refresh_from_db()
+        self.assertIsNotNone(self.process.date_created)
+        self.assertIsNone(self.process.date_active)
+        self.assertEqual(self.process.state, Process.QUEUED)
+        self.assertEqual(self.process.status, '')
+
+    @staticmethod
+    def _flush_jobs():
+        get_simple_worker(QUEUE_NAME).work(burst=True)
+
+    def _refresh_from_db(self):
+        self.process.refresh_from_db()
+
+
+@patch('publish_courses.async_operations.BulkCourseSettingsOperation.execute')
+class ActiveStateTestCase(BulkPublishCanvasSitesBaseTestCase):
+
+    def _add_handler(self):
+        post_save.connect(self._process_save_signal_handler, sender=Process)
+
+    def _remove_handler(self):
+        post_save.disconnect(self._process_save_signal_handler, sender=Process)
+
+    def _process_save_signal_handler(self, sender, instance, **kwargs):
+        self.assertIsNotNone(instance.date_created)
+        self.assertIsNotNone(instance.date_active)
+        self.assertEqual(instance.state, Process.ACTIVE)
+        self.assertEqual(instance.status, '')
+        self.have_asserted_active = True
+
+    def test_activate(self, mock_execute, *args, **kwargs):
+        # process status, timestamps updated when activated
+
+        self.have_asserted_active = False
+        self._add_handler()
+        mock_execute.side_effect = self._remove_handler
+        self._flush_jobs()
+        self.assertTrue(self.have_asserted_active)
+
+
+@patch('publish_courses.async_operations.BulkCourseSettingsOperation.execute')
+class JobLinkedToProcessTestCase(BulkPublishCanvasSitesBaseTestCase):
+
+    def _assert_job_contains_process_metadata(self):
+        self.job = get_current_job()
+        self.assertDictContainsSubset(
+            {'process_id': self.process.id},
+            self.job.meta)
+
+    def test_job_linked_to_process(self, mock_execute, *args, **kwargs):
+        # job updated with process id when activated
+        # process updated with job id when activated
+        mock_execute.side_effect = self._assert_job_contains_process_metadata
+        self._flush_jobs()
+        self._refresh_from_db()
+        self.assertDictContainsSubset(
+            {'rq_job_id': self.job.id},
+            self.process.details)
+
+
+@patch('publish_courses.async_operations.BulkCourseSettingsOperation.execute')
+class CompletedStateTestCase(BulkPublishCanvasSitesBaseTestCase):
+
+    def _assert_complete(self):
+        self.assertIsNotNone(self.process.date_active)
+        self.assertIsNotNone(self.process.date_complete)
+        self.assertEqual(self.process.state, Process.COMPLETE)
+
+    def test_completed(self, mock_execute, *args, **kwargs):
+        # process status, timestamps, details updated when successfully completed
+        self._flush_jobs()
+        self._refresh_from_db()
+        self._assert_complete()
+        self.assertEqual(self.process.status, '')
+        self.assertNotIn('error', self.process.details.keys())
+
+    def test_failed(self, mock_execute, *args, **kwargs):
+        # process status, timestamps, details updated when failed (completed)
+        mock_execute.side_effect = RuntimeError
+        self._flush_jobs()
+        self._refresh_from_db()
+        self._assert_complete()
+        self.assertEqual(self.process.status, 'failed')
+        self.assertIn('error', self.process.details.keys())


### PR DESCRIPTION
unit tests for async_operations and api
- publish_courses.api.BulkPublishListCreate now puts jobs on the queue defined in project settings (instead of hardcoded)
- more robust LTI session error handling for create job