### PR TITLE
Changes to display  cross listing errors on trying to cross list or 

### DIFF
--- a/cross_list_courses/scripts/associated_site_sitemap_cleanup.sql
+++ b/cross_list_courses/scripts/associated_site_sitemap_cleanup.sql
@@ -1,0 +1,38 @@
+/*
+Note:
+a)This is related to tlt-2900 and addresses AC #4 which is :
+'Run a database query to remove secondary course site associations
+from secondary courses for older cross-listed courses
+(i.e. all cross-listing relationships up until the release of this enhancement).'
+
+b) Needs to be run when 2900 is released
+*/
+
+
+
+/*This following SQL displays a list of course_sites and site_maps that are associated with
+the all the secondary cross listed courses, that have external 'canvas' links that
+do not match the teh corresponding ci.canvas_id (that would be updated with the
+primary when they are cross listed)
+Currently 763 in production
+*/
+select  ci.canvas_course_id, sm.*,cs.*
+from site_map sm, course_site cs ,xreg_map xm, course_instance ci
+where sm.course_instance_id= xm.secondary_course_instance
+and sm.course_site_id=cs.course_site_id
+and sm.course_instance_id=ci.course_instance_id
+and external_id like '%https://canvas%edu/%'  --(only delete canvas links:current count=763)
+and instr(external_id,canvas_course_id )<=0
+order by sm.course_instance_id desc
+
+/*This SQL is the same as above but only selects the course_site_id, site_map_id
+to be used for deleting the records from the 2 tables
+*/
+select cs.course_site_id, site_map_id
+from site_map sm, course_site cs ,xreg_map xm, course_instance ci
+where sm.course_instance_id= xm.secondary_course_instance
+and sm.course_site_id=cs.course_site_id
+and sm.course_instance_id=ci.course_instance_id
+and external_id like '%https://canvas.harvard.edu/%'
+and instr(external_id,canvas_course_id )<=0
+order by sm.course_instance_id desc;

--- a/cross_list_courses/static/cross_list_courses/js/controllers/ListController.js
+++ b/cross_list_courses/static/cross_list_courses/js/controllers/ListController.js
@@ -115,8 +115,16 @@
                     };
                 }, function DeleteFailed(response) {
                     $scope.handleAjaxErrorResponse(response);
-                    errorText = 'Could not de-cross-list ' + primary +
-                        ' and ' + secondary + '. Please try again later.';
+                    var errorMessage = (((response||{}).data||{}).detail||'');
+                    if (errorMessage.indexOf('has multiple site maps') > -1) {
+                         errorText =  'These courses cannot be de-cross-listed because '+
+                              primary + ' and/or '+secondary+' is currently associated with more than '+
+                             'one course site. Please contact '+
+                             'academictechnology@harvard.edu for further assistance.';
+                    } else{
+                        errorText = 'Could not de-cross-list ' + primary +
+                            ' and ' + secondary + '. Please try again later.';
+                    }
                     $scope.message = {alertType: 'danger', text: errorText};
                 }).finally(function cleanupAfterDelete() {
                     // always reload, in case the failure was a 404
@@ -227,6 +235,11 @@
                             if (errorDetail.indexOf('unique set') > -1) {
                                 return primary + ' is already crosslisted ' +
                                     'with ' + secondary + '.';
+                            } else if (errorDetail.indexOf('has multiple site maps') > -1) {
+                                return 'These courses cannot be cross-listed because '+
+                                    primary + ' and/or '+secondary+' is currently associated with more than '+
+                                    'one course site. Please contact '+
+                                    'academictechnology@harvard.edu for further assistance.';
                             } else {
                                 return errorDetail;
                             }


### PR DESCRIPTION
de-cross list courses that have associated sites.([TLT-2900](https://jira.huit.harvard.edu/browse/TLT-2900))

Note:  Related to this icommons-rest-api branch which is yet to be merged - https://github.com/Harvard-University-iCommons/icommons_rest_api/tree/task/elliottyates/tlt-2900/cross_list_courses_primary_site_only


@cmurtaugh , @elliottyates  :
Note:  the  associated_site_sitemap_cleanup.sql contains the sql to list  secondary  course site associations  to be cleaned up for older cross-listed courses. (deletes can be built off of this list when we are ready to cleanup) 
I ran the query in prod and put the results and sql  in this spreadsheet.
https://docs.google.com/spreadsheets/d/1e_9Mc5CUBApr6soZCxu-HbCa7wP5TTqIZ4c0x9VcNo8/edit#gid=1378234984