### PR TITLE
tlt-2900: cross list courses - fix to show user-friendly errors when …

### DIFF
--- a/cross_list_courses/static/cross_list_courses/js/controllers/ListController.js
+++ b/cross_list_courses/static/cross_list_courses/js/controllers/ListController.js
@@ -115,15 +115,29 @@
                     };
                 }, function DeleteFailed(response) {
                     $scope.handleAjaxErrorResponse(response);
-                    var errorMessage = (((response||{}).data||{}).detail||'');
-                    if (errorMessage.indexOf('has multiple site maps') > -1) {
-                         errorText =  'These courses cannot be de-cross-listed because '+
-                              primary + ' and/or '+secondary+' is currently associated with more than '+
-                             'one course site. Please contact '+
-                             'academictechnology@harvard.edu for further assistance.';
-                    } else{
-                        errorText = 'Could not de-cross-list ' + primary +
-                            ' and ' + secondary + '. Please try again later.';
+                    var defaultErrorText = primary + ' could not be ' +
+                        'crosslisted with ' + secondary + ' at this ' +
+                        'time. Please check the course instance IDs ' +
+                        'and try again.';
+                    var errorText = defaultErrorText;
+                    var validationErrors = ((response || {}).data || []);
+                    if ((response || {}).status == 400 && angular.isArray(validationErrors)) {
+                        // transform backend errors to user-friendly versions
+                        var errorsForUI = validationErrors.map(function(errorDetail) {
+                            if (errorDetail.indexOf('has multiple site maps') > -1) {
+                                msg = 'These courses cannot be de-cross-' +
+                                    'listed because ' + primary + ' and/or ' +
+                                    secondary + ' is currently associated ' +
+                                    'with more than one course site. Please ' +
+                                    'contact academictechnology@harvard.edu ' +
+                                    'for further assistance.';
+                                return msg;
+                            } else {
+                                return defaultErrorText;
+                            }
+                        });
+                        // backend returns array of errors; use only the first
+                        errorText = errorsForUI[0];
                     }
                     $scope.message = {alertType: 'danger', text: errorText};
                 }).finally(function cleanupAfterDelete() {

--- a/cross_list_courses/static/cross_list_courses/js/controllers/ListController.js
+++ b/cross_list_courses/static/cross_list_courses/js/controllers/ListController.js
@@ -115,10 +115,9 @@
                     };
                 }, function DeleteFailed(response) {
                     $scope.handleAjaxErrorResponse(response);
-                    var defaultErrorText = primary + ' could not be ' +
-                        'crosslisted with ' + secondary + ' at this ' +
-                        'time. Please check the course instance IDs ' +
-                        'and try again.';
+                    var defaultErrorText = 'Could not de-cross-list ' +
+                        primary + ' and ' + secondary + '. Please try again ' +
+                        'later.';
                     var errorText = defaultErrorText;
                     var validationErrors = ((response || {}).data || []);
                     if ((response || {}).status == 400 && angular.isArray(validationErrors)) {


### PR DESCRIPTION
…deleting xlist_maps.

When the REST API DELETE view throws a ValidationError, it sends a simple list of errors encountered (currently, just one is possible). This is different from the Django rest framework's handling of serializer errors in the POST view, so the logic around where to look in the response is a bit different.

Basically, we transform the specific, but brief, API error into a user-friendly version if we encounter it; any other error(s) are reflected to the user as a generic failure message.