### PR TITLE
Added subtitle to ‘Course Details’ column in ’Search Courses’ datable

### DIFF
--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -260,10 +260,7 @@
                             data: null,
                             render: function(data, type, row, meta) {
                                 var url = '#/details/' + row.cid;
-                                var sub_title = '';
-                                if (row.sub_title) {
-                                    sub_title += ': ' + row.sub_title;
-                                }
+                                var sub_title = row.sub_title ? ': ' + row.sub_title : '';
                                 return '<a href="' + url + '">' + row.description + sub_title + '</a>';
                             },
                         },

--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -131,6 +131,7 @@
                 // TODO: Eventually move the reusable logic to a separate library
                 var cinfo = {};
                 cinfo['description'] = $scope.getCourseDescription(course);
+                cinfo['sub_title'] = course.sub_title ? course.sub_title : '';
                 cinfo['year'] = course.term ? course.term.academic_year : '';
                 cinfo['term'] = course.term ? course.term.display_name : '';
                 cinfo['term_code'] = course.term ? course.term.term_code : '';
@@ -259,7 +260,7 @@
                             data: null,
                             render: function(data, type, row, meta) {
                                 var url = '#/details/' + row.cid;
-                                return '<a href="' + url + '">' + row.description + '</a>';
+                                return '<a href="' + url + '">' + row.description + ': ' + row.sub_title + '</a>';
                             },
                         },
                         {data: 'year'},

--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -260,7 +260,11 @@
                             data: null,
                             render: function(data, type, row, meta) {
                                 var url = '#/details/' + row.cid;
-                                return '<a href="' + url + '">' + row.description + ': ' + row.sub_title + '</a>';
+                                var sub_title = '';
+                                if (row.sub_title) {
+                                    sub_title += ': ' + row.sub_title;
+                                }
+                                return '<a href="' + url + '">' + row.description + sub_title + '</a>';
                             },
                         },
                         {data: 'year'},


### PR DESCRIPTION
[TLT-2898](https://jira.huit.harvard.edu/browse/TLT-2898)
If a subtitle exists for a course instance, it will be added to the title in the 'Course Details' column in the 'Search Courses' data table.
"course_title: course_sub_title"

Needs the changes made to the rest api in: https://github.com/Harvard-University-iCommons/icommons_rest_api/pull/105

Both branches currently deployed on dev. Search for "sub title" in the 'Search Courses' app under HKS to see an example.