### PR TITLE
Check if a CI’s subtitle and title are not the same

### DIFF
--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -261,7 +261,7 @@
                             render: function(data, type, row, meta) {
                                 var url = '#/details/' + row.cid;
                                 var sub_title = '';
-                                if (row.sub_title && row.sub_title != row.description) {
+                                if (row.sub_title && row.sub_title.toLowerCase() != row.description.toLowerCase()) {
                                     sub_title += ': ' + row.sub_title;
                                 }
                                 return '<a href="' + url + '">' + row.description + sub_title + '</a>';

--- a/course_info/static/course_info/js/controllers/SearchController.js
+++ b/course_info/static/course_info/js/controllers/SearchController.js
@@ -260,7 +260,10 @@
                             data: null,
                             render: function(data, type, row, meta) {
                                 var url = '#/details/' + row.cid;
-                                var sub_title = row.sub_title ? ': ' + row.sub_title : '';
+                                var sub_title = '';
+                                if (row.sub_title && row.sub_title != row.description) {
+                                    sub_title += ': ' + row.sub_title;
+                                }
                                 return '<a href="' + url + '">' + row.description + sub_title + '</a>';
                             },
                         },


### PR DESCRIPTION
Some schools set the title and subtitle to be the same content.
This creates a check before appending the CI subtitle to the title in the 'Search Courses' app.

Example courses to test this can be viewed on dev by using the 'Search Courses' app and searching in HKS and the title “ile”.
Course with a title and subtitle, not equal to each other: 378076
Course with a title and subtitle that are the same: 362996
