### PR TITLE
Select all checkbox functions properly across pages

### DIFF
--- a/publish_courses/static/publish_courses/js/controllers/IndexController.js
+++ b/publish_courses/static/publish_courses/js/controllers/IndexController.js
@@ -69,6 +69,7 @@
                     $scope.removeSelectedCourse($scope.dataTable.row(tr).data());
                 }
             });
+            $scope.updateDataTableSelectAllCtrl();
         };
 
         $scope.syncSelectionCheckboxes = function(){

--- a/publish_courses/static/publish_courses/js/controllers/IndexController.js
+++ b/publish_courses/static/publish_courses/js/controllers/IndexController.js
@@ -64,9 +64,9 @@
                 var $checkbox = $(tr).find('.col-select');
                 $checkbox.prop('checked', $scope.selectAll);
                 if ($scope.selectAll) {
-                    $scope.addSelectedCourse($scope.dataTable.row(index).data());
+                    $scope.addSelectedCourse($scope.dataTable.row(tr).data());
                 } else {
-                    $scope.removeSelectedCourse($scope.dataTable.row(index).data());
+                    $scope.removeSelectedCourse($scope.dataTable.row(tr).data());
                 }
             });
         };
@@ -182,6 +182,30 @@
 
         $scope.initialize();
 
+
+        // Will set the top and bottom select all boxes to their correct values on every table draw.
+        $scope.updateDataTableSelectAllCtrl = function (){
+            if ($scope.dataTable) {
+                var $table             = $scope.dataTable.table().node();
+                var $chkbox_all        = $('tbody input[type="checkbox"]', $table);
+                var $chkbox_checked    = $('tbody input[type="checkbox"]:checked', $table);
+                var chkbox_select_all_top  = $('thead input[name="select_all_top"]', $table).get(0);
+                var chkbox_select_all_btm  = $('tfoot input[name="select_all_btm"]', $table).get(0);
+
+                // If all of the checkboxes are checked
+                 if ($chkbox_checked.length === $chkbox_all.length){
+                     chkbox_select_all_top.checked = true;
+                     chkbox_select_all_btm.checked = true;
+
+                // If some or none of the checkboxes are checked
+                } else {
+                    chkbox_select_all_top.checked = false;
+                    chkbox_select_all_btm.checked = false;
+                }
+            }
+        };
+
+
         // Makes the call to get all courses information for the selected term and account and display that information
         // as both a summary and a data table.
         $scope.loadCourseData = function() {
@@ -236,6 +260,7 @@
                         $scope.showDataTable = true;
                         $scope.loadingSummary = false;
                         $scope.operationInProgress = false;
+                        $scope.updateDataTableSelectAllCtrl();
                     }
                 });
             });

--- a/publish_courses/templates/publish_courses/partials/list.html
+++ b/publish_courses/templates/publish_courses/partials/list.html
@@ -172,14 +172,14 @@
     <p>You may select individual course sites from the list below to be published.</p>
     <table id="courseInfoDT" class="display" cellspacing="0" width="100%">
       <thead>
-        <th><input type="checkbox" class="col-select" ng-checked="selectAll" ng-click="toggleSelectAll()"/></th>
+        <th><input name="select_all_top" type="checkbox" class="col-select" ng-checked="selectAll" ng-click="toggleSelectAll()"/></th>
         <th class="sorting" tabindex="0">Course Title</th>
         <th class="sorting" tabindex="0">Canvas ID</th>
         <th class="sorting" tabindex="0">Course Code</th>
         <th class="sorting" tabindex="0">SIS ID</th>
       </thead>
       <tfoot>
-        <th><input type="checkbox" class="col-select" ng-checked="selectAll" ng-click="toggleSelectAll()"/></th>
+        <th><input name="select_all_btm" type="checkbox" class="col-select" ng-checked="selectAll" ng-click="toggleSelectAll()"/></th>
         <th class="sorting" tabindex="0">Course Title</th>
         <th class="sorting" tabindex="0">Canvas ID</th>
         <th class="sorting" tabindex="0">Course Code</th>


### PR DESCRIPTION
Fixes issue where the select all checkbox was selecting the first X records from the unsorted data rather than selecting the first X records from the sorted data.
The top and bottom select all checkboxes now act uniformly across datatable pages.