### PR TITLE
TLT-3185 Blueprint Courses

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -12,7 +12,7 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-w
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.5#egg=django-auth-lti==1.2.5
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.16.2#egg=django-icommons-common[async]==1.16.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.5.1#egg=django-icommons-ui==1.5.1
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.9.1#egg=canvas-python-sdk==0.9.1
+git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10.2#egg=canvas-python-sdk==0.10.2
 hiredis==0.2.0
 ims_lti_py==0.6
 kitchen==1.2.4

--- a/canvas_site_creator/api.py
+++ b/canvas_site_creator/api.py
@@ -252,9 +252,8 @@ def create_canvas_course_and_section(request):
             )
             try:
                 update_course(**update_parameters).json()
-            except Exception as e:
+            except:
                 logger.exception("Error creating blueprint course via update with request {}".format(update_parameters))
-                logger.exception("Exception details: {}".format(e))
                 return JsonResponse({}, status=500)
     except Exception as e:
         message = u'Error creating new course via SDK with request={}'.format(

--- a/canvas_site_creator/api.py
+++ b/canvas_site_creator/api.py
@@ -250,7 +250,12 @@ def create_canvas_course_and_section(request):
                 id=course_result['id'],
                 course_blueprint=True
             )
-            update_result = update_course(**update_parameters).json()
+            try:
+                update_course(**update_parameters).json()
+            except Exception as e:
+                logger.exception("Error creating blueprint course via update with request {}".format(update_parameters))
+                logger.exception("Exception details: {}".format(e))
+                return JsonResponse({}, status=500)
     except Exception as e:
         message = u'Error creating new course via SDK with request={}'.format(
             request_parameters)

--- a/canvas_site_creator/api.py
+++ b/canvas_site_creator/api.py
@@ -230,8 +230,6 @@ def create_canvas_course_and_section(request):
         logger.exception(message)
         return JsonResponse({'error': message}, status=400)
 
-    # TODO need to make check for blueprint, if so create ILE in top account
-
     request_parameters = dict(
         request_ctx=SDK_CONTEXT,
         account_id=account_id,

--- a/canvas_site_creator/api.py
+++ b/canvas_site_creator/api.py
@@ -213,8 +213,9 @@ def create_canvas_course_and_section(request):
 
     try:
         data = json.loads(request.body)
-        account_id = 'sis_account_id:%s' % data['dept_id']
         is_blueprint = data['is_blueprint']
+        # If this is a blueprint course, create course at school level not in the ILE sub account
+        account_id = 'sis_account_id:%s' % (data['school_id'] if is_blueprint else data['dept_id'])
         # not using .get() default because we want to fall back on course_code
         # if short_title is an empty string
         course_code = data.get('short_title', '').strip() or data['course_code']

--- a/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
@@ -51,6 +51,18 @@
             }
         };
 
+        // Handles the blueprint checkbox change event
+        // If checked, set the courses code type to have the prefix BLU
+        // On an uncheck, set the code type back to the initial option value of ILE
+        $scope.blueprintBoxChange = function() {
+            if($scope.isBlueprint) {
+                $scope.course.codeType = 'BLU'
+            } else {
+                $scope.course.codeType = 'ILE'
+            }
+            $scope.setCourseCode()
+        };
+
         $scope.createButtonEnabled = function(){
             if ($scope.course.term && $scope.course.code
                 && $scope.course.title && !$scope.courseCreationInProgress) {
@@ -225,18 +237,21 @@
                                 ['api/course/v2/courses/']);
             var departmentId = $scope.departments[$scope.course.codeType.toLowerCase()];
             var data = {
-                departments: [departmentId],
                 registrar_code: $scope.course.code,
                 registrar_code_display: $scope.course.code,
-                school: $scope.school.id,
+                school: $scope.school.id
             };
+            // Only include departments if this is not a blueprint course
+            if(!$scope.isBlueprint) {
+                data.departments = [departmentId]
+            }
 
             $http.post(url, data).then(
                 function createCourseInstanceAfterCourse(response){
                     $scope.course.section = '001';
                     $scope.createCourseInstance(response.data.course_id);
                 }, $scope.handleAjaxErrorWithMessage
-                );
+            );
 
         };
 

--- a/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
@@ -243,7 +243,7 @@
             };
             // Only include departments if this is not a blueprint course
             if(!$scope.isBlueprint) {
-                data.departments = [departmentId]
+                data.departments = [departmentId];
             }
 
             $http.post(url, data).then(

--- a/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
@@ -241,14 +241,18 @@
         };
 
         $scope.createCanvasCourse = function(){
-            //format the department info to be passed into canvas as an account id
+            // format the department info to be passed into canvas as an account id
             var departmentId = 'dept:' + $scope.departments[
                     $scope.course.codeType.toLowerCase()];
+
+            // Format the school ID, which will be used instead of the department ID if this is a blueprint course
+            var schoolId = 'school:' + $scope.school.id;
             var url = djangoUrl.reverse(
                 'canvas_site_creator:api_create_canvas_course');
             //get the template id
             var templateId = $scope.selectedTemplate;
             var data = {
+                school_id: schoolId,
                 dept_id: departmentId,
                 course_instance_id: $scope.newCourseInstance.course_instance_id,
                 course_code: $scope.course.code,

--- a/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
@@ -31,6 +31,7 @@
         $scope.sectionId = '';
         $scope.selectedTerm = null;
         $scope.terms = [];
+        $scope.isBlueprint = false;
 
         $scope.setCourseCode = function() {
             if ($scope.course.codeType
@@ -256,6 +257,7 @@
                 title: $scope.course.title,
                 short_title: $scope.course.shortTitle,
                 school: $scope.school.id,
+                is_blueprint: $scope.isBlueprint
             };
             $http.post(url, data).then(
                 function setCanvasCourse(response){

--- a/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
+++ b/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
@@ -147,12 +147,13 @@
               <select id="course-code-type"
                       name="course-code-type"
                       class="form-control"
-                      ng-disabled="courseCreationInProgress"
+                      ng-disabled="courseCreationInProgress || isBlueprint"
                       ng-init="course.codeType = 'ILE'"
                       ng-model="course.codeType"
                       ng-change="setCourseCode()">
                 <option value="ILE">ILE</option>
                 <option value="SB">SB</option>
+                <option value="BLU" ng-show="isBlueprint" ng-selected="isBlueprint">BLU</option>
               </select>
               <input type="text"
                      class="form-control pull-right"
@@ -263,6 +264,8 @@
             ILE = Informal Learning Experience
             <br>
             SB = Sandbox
+            <br>
+            BLU = Blueprint
           </div>
 
         </div> <!-- End Form row: form instructions -->

--- a/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
+++ b/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
@@ -220,7 +220,7 @@
             <label for="templateSelect">Blueprint Course</label>
             <div class="checkbox" style="margin-top: 0px">
               <label>
-                <input type="checkbox" ng-model="isBlueprint"> Enable course as a Blueprint Course
+                <input type="checkbox" ng-model="isBlueprint" ng-change="blueprintBoxChange()"> Enable course as a Blueprint Course
               </label>
             </div>
           </div>

--- a/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
+++ b/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
@@ -117,7 +117,7 @@
       <form ng-submit="handleCreate()">
         <div class="row"> <!-- Form row: term, course code -->
 
-          <div class="col-md-6 margin-bottom-md">
+          <div class="col-sm-6 margin-bottom-md">
             <label for="course-term">Term <span
                 class="required-field-marker">*</span></label>
             <div ng-switch="terms.length > 0">
@@ -140,7 +140,7 @@
           </div>
 
 
-          <div class="col-md-6 margin-bottom-md">
+          <div class="col-sm-6 margin-bottom-md">
             <label for="course-code">New Course Code <span
                 class="required-field-marker">*</span></label>
             <div class="input-group" id="course-code-input-group">
@@ -189,7 +189,7 @@
                    ng-model="course.title">
           </div>
 
-          <div class="col-sm-3 margin-bottom-md">
+          <div class="col-sm-6 margin-bottom-md">
             <label for="course-short-title">New Short Title</label>
             <input type="text"
                    class="form-control"
@@ -214,6 +214,16 @@
                 </select>
             </div>
           </div>
+
+          <div class="col-sm-3 margin-bottom-md">
+            <label for="templateSelect">Blueprint Course</label>
+            <div class="checkbox" style="margin-top: 0px">
+              <label>
+                <input type="checkbox" ng-model="isBlueprint"> Enable course as a Blueprint Course
+              </label>
+            </div>
+          </div>
+
   {% verbatim %}
 
         </div> <!-- End Form row: course title, short title -->


### PR DESCRIPTION
[TLT-3185](https://jira.huit.harvard.edu/browse/TLT-3185)
This adds the newly released feature of creating a Canvas blueprint course.
Accounts selected to be a blueprint course in the 'Canvas Site Creator' will have the BLU- prefix and be created at the school level rather than the ILE or SB sub-accounts.

This is currently waiting on the 0.10.2 release of the Canvas Python SDK located at
https://github.com/penzance/canvas_python_sdk/releases
Until that is released, the update functionality will not work on dev and you will receive an error message.