### PR TITLE
Changed ng-show to ng-if for blueprint option

### DIFF
--- a/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
+++ b/canvas_site_creator/templates/canvas_site_creator/create_new_course.html
@@ -153,7 +153,7 @@
                       ng-change="setCourseCode()">
                 <option value="ILE">ILE</option>
                 <option value="SB">SB</option>
-                <option value="BLU" ng-show="isBlueprint" ng-selected="isBlueprint">BLU</option>
+                <option value="BLU" ng-if="isBlueprint" ng-selected="isBlueprint">BLU</option>
               </select>
               <input type="text"
                      class="form-control pull-right"


### PR DESCRIPTION
Safari was not properly handling ng-show for the BLU option in the dropdown menu. This caused BLU to be a selectable option outside of checking the box. This changed the ng-show for that option to ng-if.
Currently deployed on dev.
Tested on Chrome, Firefox and Safari.