### PR TITLE
TLT-3189 Conclude and unconclude individual enrollments in a course

### DIFF
--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -98,3 +98,15 @@ table.course-info-table {
 #alert-pane-success {
     border: none;
 }
+
+.popover-success {
+    color: #3c763d;
+    background-color: #dff0d8;
+    border-color: #d6e9c6;
+}
+
+.popover-danger {
+    color: #a94442;
+    background-color: #f2dede;
+    border-color: #ebccd1;
+}

--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -98,37 +98,3 @@ table.course-info-table {
 #alert-pane-success {
     border: none;
 }
-
-.input-group-error {
-    border: 3px solid transparent;
-    border-radius: 5px;
-    -webkit-animation: error 2s; /* Chrome, Safari, Opera */
-    animation: error 2s;
-}
-
-/* Chrome, Safari, Opera */
-@-webkit-keyframes error {
-    50% {border-color: red;}
-}
-
-/* Standard syntax */
-@keyframes error {
-    50% {border-color: red;}
-}
-
-.input-group-success {
-    border: 3px solid transparent;
-    border-radius: 5px;
-    -webkit-animation: success 2s; /* Chrome, Safari, Opera */
-    animation: success 2s;
-}
-
-/* Chrome, Safari, Opera */
-@-webkit-keyframes success {
-    50% {border-color: green;}
-}
-
-/* Standard syntax */
-@keyframes success {
-    50% {border-color: green;}
-}

--- a/course_info/static/course_info/css/index.css
+++ b/course_info/static/course_info/css/index.css
@@ -98,3 +98,37 @@ table.course-info-table {
 #alert-pane-success {
     border: none;
 }
+
+.input-group-error {
+    border: 3px solid transparent;
+    border-radius: 5px;
+    -webkit-animation: error 2s; /* Chrome, Safari, Opera */
+    animation: error 2s;
+}
+
+/* Chrome, Safari, Opera */
+@-webkit-keyframes error {
+    50% {border-color: red;}
+}
+
+/* Standard syntax */
+@keyframes error {
+    50% {border-color: red;}
+}
+
+.input-group-success {
+    border: 3px solid transparent;
+    border-radius: 5px;
+    -webkit-animation: success 2s; /* Chrome, Safari, Opera */
+    animation: success 2s;
+}
+
+/* Chrome, Safari, Opera */
+@-webkit-keyframes success {
+    50% {border-color: green;}
+}
+
+/* Standard syntax */
+@keyframes success {
+    50% {border-color: green;}
+}

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -624,7 +624,6 @@
             var inputElement = $(this).find('input');
             var previousValue = inputElement.val();
 
-            // TODO make a check to see if element has a datepicker before creating a new one
             var dp = inputElement.datepicker({
                 autoclose: true,
                 todayHighlight: 1,

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -589,9 +589,10 @@
 
             // If there is a conclude date, format it to be MM/dd/yyyy and create an input field
             if (full.conclude_date){
-                concludeDate = $filter('date')(new Date(full.conclude_date), 'MM/dd/yyyy', 'Z');
+                // If the date is not split up, it returns an 'Invalid Date' in Safari
+                var d = full.conclude_date.split(/[^0-9]/);
+                concludeDate = $filter('date')(new Date(d[0],d[1]-1,d[2],d[3],d[4],d[5] ), 'MM/dd/yyyy', 'Z');
             }
-
             concludeDateDiv += $scope.getCalButtonHTML(full.user_id, concludeDate);
 
             concludeDateDiv += '</div>';
@@ -606,14 +607,13 @@
                                     '<span class="fa fa-calendar"></span>' +
                                 '</label>' +
                              '</div>';
-            return inputHTML
+            return inputHTML;
         };
 
         $scope.getCalButtonHTML= function(id, value) {
-             var createInputFieldFunc = 'createInputField('+id+',"'+value+'")';
              var calHTML =  '<div class="col-sm-10">'+value+'</div>' +
                             '<div class="col-sm-2">' +
-                               '<a href="" ng-click='+createInputFieldFunc+'>' +
+                               '<a href="" ng-click=createInputField('+id+',"'+value+'"\)>' +
                                    '<span class="fa fa-calendar"></span>' +
                                '</a>' +
                            '</div>';
@@ -635,8 +635,7 @@
 
             var dp = inputElement.datepicker({
                 autoclose: true,
-                todayHighlight: 1,
-                format: 'mm/dd/yyyy'
+                todayHighlight: 1
             });
 
             // When the date picker window has been closed, validate the selected date and send PATCH
@@ -653,7 +652,7 @@
                         // before it is rendered.
                         setTimeout(
                             function() {
-                              $scope.addPopOverToCell(userID, 'failure', "Selected date is prior to today's date");
+                              $scope.addPopOverToCell(userID, 'failure', 'You can only pick a date in the future.');
                             }, 100)
                     } else {
                         var roleID = $scope.peopleData[userID]['role']['role_id'];
@@ -698,7 +697,7 @@
 
         // Creates an input field in the given div ID
         $scope.createInputField = function(divID, inputVal) {
-            inputVal = (typeof inputVal !== 'undefined') ?  inputVal : '';
+            inputVal = (typeof inputVal !== 'undefined') ? inputVal : '';
             var input_group = $scope.getInputHTML(divID, inputVal);
 
             $('#'+divID).html($compile(angular.element(input_group))($scope));
@@ -711,7 +710,7 @@
 
         // Creates a calendar button for the given divID
         $scope.createCalButton = function(divID, concludeDate) {
-            concludeDate = (typeof concludeDate !== 'undefined') ?  concludeDate : '';
+            concludeDate = (typeof concludeDate !== 'undefined') ? concludeDate : '';
             var cal_button = $scope.getCalButtonHTML(divID, concludeDate);
 
             $('#'+divID).html($compile(angular.element(cal_button))($scope));
@@ -750,11 +749,11 @@
                 .success(function finalizeCourseDetailsPatch() {
                     // Reset the display to show conclude date and calendar button
                     $scope.createCalButton(patchData['user_id'], concludeDate);
-                    $scope.addPopOverToCell(userID, 'success', "User with HUID: " + userID + " successfully updated");
+                    $scope.addPopOverToCell(userID, 'success', 'The enrollment details have been updated.');
                 })
                 .error(function(data, status, headers, config, statusText) {
                     $scope.handleAjaxError(data, status, headers, config, statusText);
-                    $scope.addPopOverToCell(userID, 'failure', "Error updating user with HUID: " + userID);
+                    $scope.addPopOverToCell(userID, 'failure', 'An error occurred during the update.');
                 })
         };
 

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -747,6 +747,9 @@
 
             $http.patch(url, patchData)
                 .success(function finalizeCourseDetailsPatch() {
+                    // If update is successful, then touch the course instance so the last_updated field is updated
+                    // so that changes will be picked up in feed
+                    $scope.updateCourseInstanceLastUpdated();
                     // Reset the display to show conclude date and calendar button
                     $scope.createCalButton(patchData['user_id'], concludeDate);
                     $scope.addPopOverToCell(userID, 'success', 'The enrollment details have been updated.');
@@ -755,6 +758,14 @@
                     $scope.handleAjaxError(data, status, headers, config, statusText);
                     $scope.addPopOverToCell(userID, 'failure', 'An error occurred during the update.');
                 })
+        };
+
+        // Updates the current course instances 'last_updated' field to be the current date and time.
+        $scope.updateCourseInstanceLastUpdated = function() {
+            var url = djangoUrl.reverse('icommons_rest_api_proxy',
+                                        ['api/course/v2/course_instances/'
+                                         + $scope.courseInstanceId + '/']);
+            $http.patch(url);
         };
 
         $scope.selectRole = function(role) {

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -633,6 +633,7 @@
 
             // When the date picker window has been closed, validate the selected date and send PATCH
             dp.on('hide', function() {
+                $scope.clearMessages();
                 var selectedDate = inputElement.val();
 
                 if (selectedDate != previousValue) {
@@ -690,7 +691,6 @@
 
         // Perform the PATCH with the given user ID, role_id, conclude_date
         $scope.updateConcludeDate = function(userID, roleID, concludeDate) {
-            $scope.clearMessages();
             var patchData = {
                 'user_id': userID,
                 'role_id': roleID,

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -676,7 +676,7 @@
             if (date) {
                 concludeDate = $filter('date')(new Date(date), 'yyyy-MM-dd', 'Z')+'T00:01:00Z';
             }
-            return concludeDate
+            return concludeDate;
         };
 
         // Checks if the given date is prior to today's date.

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -302,18 +302,18 @@
 </div>
 <!-- end alert pane -->
 
-<div ng-if="!removeFailure" class="row add-top-margin">
+<div ng-if="concludeDateUpdateMessage.failure" class="row add-top-margin">
   <div class="col-xs-12">
     <uib-alert type="danger">
-      There was an error updating that users conclusion date override field
+      {{concludeDateUpdateMessage.failure}}
     </uib-alert>
   </div>
 </div>
 
-<div ng-if="!removeFailure" class="row add-top-margin">
+<div ng-if="concludeDateUpdateMessage.success" class="row add-top-margin">
   <div class="col-xs-12">
     <uib-alert type="success">
-      User X was successfully updated
+      {{concludeDateUpdateMessage.success}}
     </uib-alert>
   </div>
 </div>

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -302,6 +302,16 @@
 </div>
 <!-- end alert pane -->
 
+<div ng-if="!removeFailure" class="row add-top-margin">
+  <div class="col-xs-12">
+    <!-- begin remove failure warning alerts -->
+    <uib-alert type="danger" close="closeAlert('removeFailure')">
+      There was an error updating that users conclusion date override field.
+    </uib-alert>
+  </div>
+</div>
+
+
 <div class="row add-top-margin">
   <!-- end add people interface -->
   <div class="col-md-12">

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -302,22 +302,6 @@
 </div>
 <!-- end alert pane -->
 
-<div ng-if="concludeDateUpdateMessage.failure" class="row add-top-margin">
-  <div class="col-xs-12">
-    <uib-alert type="danger">
-      {{concludeDateUpdateMessage.failure}}
-    </uib-alert>
-  </div>
-</div>
-
-<div ng-if="concludeDateUpdateMessage.success" class="row add-top-margin">
-  <div class="col-xs-12">
-    <uib-alert type="success">
-      {{concludeDateUpdateMessage.success}}
-    </uib-alert>
-  </div>
-</div>
-
 
 <div class="row add-top-margin">
   <!-- end add people interface -->

--- a/course_info/templates/course_info/partials/people.html
+++ b/course_info/templates/course_info/partials/people.html
@@ -304,9 +304,16 @@
 
 <div ng-if="!removeFailure" class="row add-top-margin">
   <div class="col-xs-12">
-    <!-- begin remove failure warning alerts -->
-    <uib-alert type="danger" close="closeAlert('removeFailure')">
-      There was an error updating that users conclusion date override field.
+    <uib-alert type="danger">
+      There was an error updating that users conclusion date override field
+    </uib-alert>
+  </div>
+</div>
+
+<div ng-if="!removeFailure" class="row add-top-margin">
+  <div class="col-xs-12">
+    <uib-alert type="success">
+      User X was successfully updated
     </uib-alert>
   </div>
 </div>


### PR DESCRIPTION
[TLT-3189](https://jira.huit.harvard.edu/browse/TLT-3189)

Adds the ability to conclude and unconclude individual enrollments in a course by using a date picker in the 'Conclusion Date Override' column.

Currently deployed on dev
https://canvas.dev.tlt.harvard.edu/accounts/15/external_tools/359
I search using all default filters in GSE and select the first course, which should have a few current enrollments.