### PR TITLE
TLT-2848 Remove Associated Site and Site Status Columns and Calls

### DIFF
--- a/canvas_site_creator/api.py
+++ b/canvas_site_creator/api.py
@@ -339,9 +339,6 @@ def course_instances(request, sis_term_id, sis_account_id):
 
         query_set = get_course_instance_query_set(sis_term_id, sis_account_id)
         query_set = query_set.select_related('course')
-        # Added prefetch_related here to reduce hitting the database again later
-        # when we query for the associated iSites.
-        query_set = query_set.prefetch_related('sites')
 
         # Apply text search filter
         if search:
@@ -363,9 +360,6 @@ def course_instances(request, sis_term_id, sis_account_id):
 
         data = []
         for ci in query_set[start:(start + limit)]:
-            # Get associated iSites keywords and external URL if present(TLT-1578)
-            sites = [site.external_id for site in ci.sites.all() if site.site_type_id in ['isite', 'external']]
-            official = [site_map.map_type_id for site_map in ci.sitemap_set.all()]
             data.append({
                 'id': ci.course_instance_id,
                 'registrar_code': ci.course.registrar_code_display or
@@ -373,8 +367,6 @@ def course_instances(request, sis_term_id, sis_account_id):
                 'title': ci.title,
                 'course_section': ci.section,
                 'has_canvas_site': ci.canvas_course_id is not None,
-                'associated_sites': ', '.join(sites),
-                'site_status': ', '.join(official),
             })
 
         result['data'] = data

--- a/canvas_site_creator/static/canvas_site_creator/js/controllers/CourseInstanceController.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/controllers/CourseInstanceController.js
@@ -88,8 +88,6 @@
                     {data: 'registrar_code'},
                     {data: 'title'},
                     {data: 'course_section', className: 'col-align-center'},
-                    {data: 'associated_sites', orderable: false},
-                    {data: 'site_status', orderable: false},
                 ],
                 preDrawCallback: function(){
                     $scope.courseInstanceModel.dataLoading = true;

--- a/canvas_site_creator/static/canvas_site_creator/js/controllers/CourseSelectionTableController.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/controllers/CourseSelectionTableController.js
@@ -42,8 +42,6 @@
                     {data: 'registrar_code'},
                     {data: 'title'},
                     {data: 'course_section', className: 'col-align-center'},
-                    {data: 'associated_sites'},
-                    {data: 'site_status'}
                 ],
                 preDrawCallback: function(){
                     $('#courseSelectionDT .remove-selection').off('click', $scope.handleRemoveSelection);

--- a/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
@@ -336,14 +336,6 @@
             );
         };
 
-         $scope.renderAssociatedSite = function(){
-             //update the associated site column in the UI
-             $scope.newCourseInstance.canvas_course_id = $scope.canvasCourse.id;
-             $scope.newCourseInstance.canvas_course_url =
-                 window.globals.CANVAS_URL + '/courses/'
-                 + $scope.canvasCourse.id;
-         };
-
         $scope.postCourseSiteAndMap = function(){
             var url = djangoUrl.reverse('icommons_rest_api_proxy',
                 ['api/course/v2/course_sites/']);
@@ -374,18 +366,7 @@
                 course_site : $scope.newCourseInstance.course_site_id,
                 map_type : 'official'
             };
-            $http.post(url, data).then(
-                function updateSiteMapAndFinish(){
-                    // if everything is successful, then update the canvas site
-                    // link in the UI
-                    $scope.renderAssociatedSite();
-                    $scope.courseCreationSuccessful = true;
-                    $scope.courseCreationInProgress = false;
-                },function handleError(response) {
-                    $scope.handleAjaxErrorWithMessage(response,
-                        "There was a problem updating the Site Map Table. ");
-                }
-            );
+            $http.post(url, data);
         };
 
         $scope.handleAjaxErrorResponse = function(response) {

--- a/canvas_site_creator/templates/canvas_site_creator/views/_course_instance_table_header.html
+++ b/canvas_site_creator/templates/canvas_site_creator/views/_course_instance_table_header.html
@@ -4,6 +4,4 @@
     <th>Course Code</th>
     <th>Course Title</th>
     <th>Course Section</th>
-    <th>Associated Sites</th>
-    <th>Associated Sites Status</th>
 </tr>

--- a/canvas_site_creator/templates/canvas_site_creator/views/_course_selection_table_header.html
+++ b/canvas_site_creator/templates/canvas_site_creator/views/_course_selection_table_header.html
@@ -4,6 +4,4 @@
     <th>Course Code</th>
     <th>Course Title</th>
     <th>Course Section</th>
-    <th>Associated Sites</th>
-    <th>Status</th>
 </tr>

--- a/canvas_site_creator/tests/jasmine/controllers/CreateNewCourseControllerSpec.js
+++ b/canvas_site_creator/tests/jasmine/controllers/CreateNewCourseControllerSpec.js
@@ -453,19 +453,6 @@ describe('Unit testing CreateNewCourseController', function() {
         });
     });
 
-    describe('renderAssociatedSite', function(){
-        it('should set the correct values', function(){
-            scope.canvasCourse = {
-                id: 12345
-            };
-            window.globals.CANVAS_URL = 'someurl';
-            scope.newCourseInstance = {};
-            scope.renderAssociatedSite();
-            expect(scope.newCourseInstance.canvas_course_id).toBe(scope.canvasCourse.id);
-            expect(scope.newCourseInstance.canvas_course_url).toBe('someurl/courses/' +scope.canvasCourse.id);
-        });
-    });
-
     describe('postCourseSiteAndMap', function(){
         it('should create a site map with the right course information and ' +
             'set site_map_id on scope when finished', function () {
@@ -539,13 +526,11 @@ describe('Unit testing CreateNewCourseController', function() {
                 map_type : 'official'
             };
             spyOn(scope, 'handleAjaxErrorWithMessage');
-            spyOn(scope, 'renderAssociatedSite');
             scope.postSiteMap();
 
             $httpBackend.expectPOST(api.urls.site_maps, expectedPostData)
                 .respond(201, JSON.stringify(api.data.site_maps_post));
             $httpBackend.flush(1);
-            expect(scope.renderAssociatedSite).toHaveBeenCalled();
             expect(scope.courseCreationSuccessful).toBe(true);
             expect(scope.courseCreationInProgress).toBe(false);
             expect(scope.handleAjaxErrorWithMessage)

--- a/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
+++ b/course_info/tests/jasmine/controllers/PeopleControllerSpec.js
@@ -747,7 +747,7 @@ describe('Unit testing PeopleController', function() {
                 }];
             var result = scope.getMembersByUserId(memberList);
             var memberWithFixedRole = angular.copy(memberList[0]);
-            memberWithFixedRole.role.role_name = 'TA';
+            memberWithFixedRole.role.role_name = 'Teaching Fellow';
             expect(result).toEqual({
                 12345678: [memberWithFixedRole],
                 87654321: [memberList[1]]


### PR DESCRIPTION
Removed associated site and site status columns from the CSC table and the confirmation modal. Also removed the calls that populated that data