### PR TITLE
Task/sapnamysore/tlt 3517/configure timeout

### DIFF
--- a/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
+++ b/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
@@ -16,7 +16,7 @@ from icommons_common.models import Term
 
 logger = logging.getLogger(__name__)
 # set to 60 seconds
-VISIBILITY_TIMEOUT = 60
+VISIBILITY_TIMEOUT = 120
 
 
 class Command(BaseCommand):

--- a/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
+++ b/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
@@ -72,6 +72,7 @@ class Command(BaseCommand):
     @staticmethod
     def handle_message(message):
         start_time = time.time()
+        logger.info(" START TIME =", str(time.ctime(int(start_time))))
         try:
             bulk_settings_id = message.message_attributes['bulk_settings_id']['StringValue']
 
@@ -100,7 +101,8 @@ class Command(BaseCommand):
                             message.change_visibility(VisibilityTimeout=VISIBILITY_TIMEOUT)
                             start_time = time.time()
                             # todo: change debug  to info after testing
-                            logger.debug("Extended message visibility to %d and reset start time to  %d", VISIBILITY_TIMEOUT, start_time)
+                            logger.debug("Extended message visibility to %d and reset start time to  %d, detail.id= %d",
+                                         VISIBILITY_TIMEOUT, str(time.ctime(int(start_time))), detail.id)
 
                         # Check to see if the course originally had a None value for the setting to be modified,
                         # Use false as the update arg value in the reversion call.
@@ -120,11 +122,13 @@ class Command(BaseCommand):
                         if (time.time() - start_time) < VISIBILITY_TIMEOUT-15:
                             message.change_visibility(VisibilityTimeout=VISIBILITY_TIMEOUT)
                             start_time = time.time()
-                            logger.debug("Extended message visibility to %d and reset start time to  %d", VISIBILITY_TIMEOUT, start_time)
+                            logger.debug("Extended message visibility to %d and reset start time to %d, canvas id= %s",
+                                         VISIBILITY_TIMEOUT, str(time.ctime(int(start_time))), course['id'])
                         utils.check_and_update_course(course, job)
 
                 logger.info('Message has been processed , deleting from sqs...')
                 message.delete()
+                logger.info(" END TIME =", str(time.ctime(int(time.time()))))
 
             except Exception as e:
                 # Put the message back on the queue

--- a/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
+++ b/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
@@ -99,7 +99,8 @@ class Command(BaseCommand):
                         if (time.time() - start_time) < VISIBILITY_TIMEOUT-15:
                             message.change_visibility(VisibilityTimeout=VISIBILITY_TIMEOUT)
                             start_time = time.time()
-                            logger.info("Extended message visibility to %d and reset start time to  %d", VISIBILITY_TIMEOUT, start_time)
+                            # todo: change debug  to info after testing
+                            logger.debug("Extended message visibility to %d and reset start time to  %d", VISIBILITY_TIMEOUT, start_time)
 
                         # Check to see if the course originally had a None value for the setting to be modified,
                         # Use false as the update arg value in the reversion call.
@@ -119,7 +120,7 @@ class Command(BaseCommand):
                         if (time.time() - start_time) < VISIBILITY_TIMEOUT-15:
                             message.change_visibility(VisibilityTimeout=VISIBILITY_TIMEOUT)
                             start_time = time.time()
-                            logger.info("Extended message visibility to %d and reset start time to  %d", VISIBILITY_TIMEOUT, start_time)
+                            logger.debug("Extended message visibility to %d and reset start time to  %d", VISIBILITY_TIMEOUT, start_time)
                         utils.check_and_update_course(course, job)
 
                 logger.info('Message has been processed , deleting from sqs...')

--- a/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
+++ b/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
@@ -15,7 +15,7 @@ from bulk_course_settings.models import Job, Details
 from icommons_common.models import Term
 
 logger = logging.getLogger(__name__)
-# set to 60 seconds
+# set to 120 seconds
 VISIBILITY_TIMEOUT = 120
 
 

--- a/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
+++ b/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
@@ -15,7 +15,8 @@ from bulk_course_settings.models import Job, Details
 from icommons_common.models import Term
 
 logger = logging.getLogger(__name__)
-VISIBILITY_TIMEOUT = 20
+# set to 60 seconds
+VISIBILITY_TIMEOUT = 60
 
 
 class Command(BaseCommand):

--- a/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
+++ b/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
@@ -3,8 +3,6 @@ import logging
 import signal
 import time
 from datetime import datetime
-from time import strftime
-
 
 from botocore.exceptions import ClientError
 from django.core.management.base import BaseCommand

--- a/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
+++ b/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
@@ -59,7 +59,6 @@ class Command(BaseCommand):
 
                         # Check to see if the job had any errors and update the workflow appropriately
                         bulk_settings_id = message.message_attributes['bulk_settings_id']['StringValue']
-                        print "bulk_settings_id=", bulk_settings_id
                         job = Job.objects.get(id=bulk_settings_id)
                         failed = Details.objects.filter(parent_job=bulk_settings_id, workflow_status=constants.FAILED)
                         if failed:

--- a/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
+++ b/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
@@ -103,9 +103,10 @@ class Command(BaseCommand):
                         # VISIBILITY_TIMEOUT settings and reset start_time
                         if (time.time() - start_time) > VISIBILITY_TIMEOUT-15:
                             message.change_visibility(VisibilityTimeout=VISIBILITY_TIMEOUT)
-                            start_date = datetime.utcfromtimestamp(time.time()).strftime('%Y-%m-%dT%H:%M:%S')
+                            start_time = time.time()
                             logger.info("Extended message visibility to %d and reset start time to %s, detail.id= %d",
-                                        VISIBILITY_TIMEOUT, start_date, detail.id)
+                                        VISIBILITY_TIMEOUT,
+                                        datetime.utcfromtimestamp(start_time).strftime('%Y-%m-%dT%H:%M:%S'), detail.id)
 
                         # Check to see if the course originally had a None value for the setting to be modified,
                         # Use false as the update arg value in the reversion call.
@@ -124,9 +125,10 @@ class Command(BaseCommand):
                         # VISIBILITY_TIMEOUT settings and reset start_time
                         if (time.time() - start_time) > VISIBILITY_TIMEOUT-15:
                             message.change_visibility(VisibilityTimeout=VISIBILITY_TIMEOUT)
-                            start_date = datetime.utcfromtimestamp(time.time()).strftime('%Y-%m-%dT%H:%M:%S')
+                            start_time = time.time()
                             logger.info("Extended message visibility to %d and reset start time to %s, canvas id= %s",
-                                        VISIBILITY_TIMEOUT, start_date, course['id'])
+                                        VISIBILITY_TIMEOUT,
+                                        datetime.utcfromtimestamp(start_time).strftime('%Y-%m-%dT%H:%M:%S'), course['id'])
                         utils.check_and_update_course(course, job)
 
                 logger.info('Message has been processed , deleting from sqs...')

--- a/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
+++ b/bulk_course_settings/management/commands/process_bulk_course_settings_jobs.py
@@ -13,8 +13,7 @@ from bulk_course_settings.models import Job, Details
 from icommons_common.models import Term
 
 logger = logging.getLogger(__name__)
-# set to 120 seconds
-VISIBILITY_TIMEOUT = 120
+VISIBILITY_TIMEOUT = utils.VISIBILITY_TIMEOUT
 
 
 class Command(BaseCommand):
@@ -45,10 +44,11 @@ class Command(BaseCommand):
             else:
                 # Use long polling (wait up to 20 seconds) to reduce the number of receive_messages requests we make
                 messages = self.queue.receive_messages(
-                    MaxNumberOfMessages=10,
+                    MaxNumberOfMessages=1,
                     MessageAttributeNames=['All'],
                     AttributeNames=['All'],
                     WaitTimeSeconds=20,
+                    VisibilityTimeout=VISIBILITY_TIMEOUT
                 )
 
                 if messages:

--- a/bulk_course_settings/utils.py
+++ b/bulk_course_settings/utils.py
@@ -85,9 +85,9 @@ def get_term_data_for_school(school_sis_account_id):
 
 def queue_bulk_settings_job(bulk_settings_id, school_id, term_id, setting_to_be_modified, desired_setting, queue_name=QUEUE_NAME):
     """Adds a message to the SQS queue using the given parameters """
-    logger.debug("queue_bulk_settings_job:  bulk_settings_id=%s, school_id=%s, term_id=%s, setting_to_be_modified=%s ,"
-                 "desired_setting=%s"
-                 % (bulk_settings_id, school_id, term_id, setting_to_be_modified, desired_setting))
+    logger.debug("queue_bulk_settings_job:  bulk_settings_id={}, school_id={}, term_id={}, setting_to_be_modified={} , "
+                 "desired_setting={}"
+                 .format(bulk_settings_id, school_id, term_id, setting_to_be_modified, desired_setting))
     queue = SQS.get_queue_by_name(QueueName=queue_name)
     message = queue.send_message(
         MessageBody='_'.join(['msg_body', str(bulk_settings_id)]),

--- a/bulk_course_settings/utils.py
+++ b/bulk_course_settings/utils.py
@@ -24,6 +24,7 @@ AWS_REGION_NAME = settings.BULK_COURSE_SETTINGS['aws_region_name']
 AWS_ACCESS_KEY_ID = settings.BULK_COURSE_SETTINGS['aws_access_key_id']
 AWS_SECRET_ACCESS_KEY = settings.BULK_COURSE_SETTINGS['aws_secret_access_key']
 QUEUE_NAME = settings.BULK_COURSE_SETTINGS['job_queue_name']
+VISIBILITY_TIMEOUT = settings.BULK_COURSE_SETTINGS['visibility_timeout']
 
 KW = {
     'aws_access_key_id': AWS_ACCESS_KEY_ID,

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -282,22 +282,22 @@ LOGGING = {
     'loggers': {
         'bulk_utilities': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['console', 'default'],
+            'handlers': ['default'],
             'propagate': False,
         },
         'canvas_account_admin_tools': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['console', 'default'],
+            'handlers': ['default'],
             'propagate': False,
         },
         'canvas_course_site_wizard': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['console', 'default'],
+            'handlers': ['default'],
             'propagate': False,
         },
         'canvas_site_creator': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['console', 'default'],
+            'handlers': ['default'],
             'propagate': False,
         },
         'course_info': {
@@ -312,12 +312,12 @@ LOGGING = {
         },
         'publish_courses': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['console', 'default'],
+            'handlers': ['default'],
             'propagate': False,
         },
         'bulk_course_settings': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['console', 'default'],
+            'handlers': ['default'],
             'propagate': False,
         },
         'rq.worker': {

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -405,6 +405,7 @@ BULK_COURSE_SETTINGS = {
     'aws_access_key_id': SECURE_SETTINGS.get('aws_access_key_id'),
     'aws_secret_access_key': SECURE_SETTINGS.get('aws_secret_access_key'),
     'job_queue_name': SECURE_SETTINGS.get('job_queue_name'),
+    'visibility_timeout': SECURE_SETTINGS.get('visibility_timeout', 120),
 
 }
 


### PR DESCRIPTION
Modified the logic so that the app will dynamically increase the visibility timeout when 15 seconds are left.


**Notes**:

1. Modified the dev/qa sqs settings to be 2 minutes(previously set to 15 mins)
https://github.huit.harvard.edu/HUIT/at-cfn-templates/commit/605caf8ff4bf3bb08d8f381ee9289d2ef36dee65

2. Testing: Used https://canvas.devops.tlt.harvard.edu/accounts/14/external_tools/5 to test with large courses
One test case is job 18, that took around 18-19 minutes to complete. Starting with an initial 2 minute timeout, it was extended 10 times by a 2 minute extension. 
[https://splunk-60ox.noc.harvard.edu/en-US/app/search/search?dispatch.sample_ratio=1&display.page.search.mode=verbose&q=search%20app%3Dbulk_course_settings%20host%3D%22qa-djangoapp-tlt-10.39.83.106%22%20%22extended%22&earliest=1539786256.216&latest=now&sid=1539801236.4420139]
 Please test on dev/qa




