### PR TITLE
For Bulk Site Creator, exclude any course instances that have a paren…

### DIFF
--- a/canvas_site_creator/models.py
+++ b/canvas_site_creator/models.py
@@ -6,7 +6,9 @@ from canvas_course_site_wizard.models import CanvasCourseGenerationJob
 
 
 def get_course_instance_query_set(sis_term_id, sis_account_id):
-    filters = {'exclude_from_isites': 0, 'term_id': sis_term_id}
+    # Exclude records that have parent_course_instance_id  set(TLT-3558) as we don't want to create sites for the
+    # children; they will be associated with the parent site
+    filters = {'exclude_from_isites': 0, 'term_id': sis_term_id, 'parent_course_instance_id__isnull': True}
 
     (account_type, account_id) = sis_account_id.split(':')
     if account_type == 'school':


### PR DESCRIPTION
…t_course_instance_id populated.

Deployed on dev: https://canvas.dev.tlt.harvard.edu/accounts/5/external_tools/359
 Tested with **Divinity school, Spring 2016-17**, it was rendering 118 courses before the change, now has 117 after I explicitly set one of the courses parent value(course_instance_id=379439)