### PR TITLE
Added editable parent CI ID field to course info

### DIFF
--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -281,7 +281,11 @@
                     dc.showNewGlobalAlert('updateSucceeded');
                 }, function cleanUpFailedCourseDetailsPatch(response) {
                     dc.handleAjaxErrorResponse(response);
-                    dc.showNewGlobalAlert('updateFailed', response.statusText);
+                    // Show the status text by default, ie: 'Bad Request'
+                    // If we have a validation error from the REST API, display the message from the serializer
+                    var errorMessage = response.statusText;
+                    if (response.data["non_field_errors"]) {errorMessage=response.data["non_field_errors"][0]}
+                    dc.showNewGlobalAlert('updateFailed', errorMessage);
                 })
                 .finally( function courseDetailsUpdateNoLongerInProgress() {
                     // leaves 'edit' mode, re-enables edit button

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -125,6 +125,7 @@
                 courseInstance['exclude_from_isites'] = ci.exclude_from_isites;
                 courseInstance['exclude_from_catalog'] = ci.exclude_from_catalog;
                 courseInstance['section'] = ci.section ? ci.section : '';
+                courseInstance['parent_course_instance'] = ci.parent_course_instance ? ci.parent_course_instance : '';
 
                 if (ci.secondary_xlist_instances &&
                     ci.secondary_xlist_instances.length > 0) {
@@ -251,7 +252,8 @@
                 'exclude_from_isites',
                 'exclude_from_catalog',
                 'section',
-                'conclude_date'
+                'conclude_date',
+                'parent_course_instance'
             ];
             fields.forEach(function(field) {
                 if (field == 'conclude_date') {

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -240,6 +240,7 @@
                 [dc.apiBase + dc.courseInstanceId + '/']);
             // we could also get these from editable properties on the DOM
             var fields = [
+                'course_instance_id',
                 'description',
                 'instructors_display',
                 'location',
@@ -284,7 +285,12 @@
                     // Show the status text by default, ie: 'Bad Request'
                     // If we have a validation error from the REST API, display the message from the serializer
                     var errorMessage = response.statusText;
-                    if (response.data["non_field_errors"]) {errorMessage=response.data["non_field_errors"][0]}
+                    if (Object.keys(response.data).length != 0) {
+                        errorMessage = '';
+                        for (var key in response.data) {
+                            errorMessage += response.data[key][0];
+                        }
+                    }
                     dc.showNewGlobalAlert('updateFailed', errorMessage);
                 })
                 .finally( function courseDetailsUpdateNoLongerInProgress() {

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -126,6 +126,15 @@
           field="section"
           label="Course Section"></hu-editable-input>
 
+      <hu-editable-input
+          editable="dc.editInProgress"
+          is-loading="dc.isUndefined(dc.courseInstance.parent_course_instance)"
+          form-value="dc.formDisplayData.parent_course_instance"
+          model-value="dc.courseInstance.parent_course_instance"
+          maxlength="50"
+          field="parent_course_instance"
+          label="Parent Course Instance ID"></hu-editable-input>
+
       <hu-field-label-wrapper
         field="xlist_status"
         is-loading="dc.isUndefined(dc.courseInstance.xlist_status)"


### PR DESCRIPTION
Requires changing the parent_course_instance field in the CourseInstanceDetail serializer in the REST API for this to work. I made those changes on a separate branch and deployed both to dev