### PR TITLE
TLT-3591 Angular reverse issue fix

### DIFF
--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -13,8 +13,6 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 import logging
-# Need to import patch_reverse here to override the loading order of Django's reverse function.
-from django_auth_lti import patch_reverse
 from django.core.urlresolvers import reverse_lazy
 from .secure import SECURE_SETTINGS
 
@@ -79,8 +77,6 @@ INSTALLED_APPS = [
 
 
 MIDDLEWARE = [
-    # NOTE - djng needs to be the first item in this list
-    'djng.middleware.AngularUrlMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'cached_auth.Middleware',
@@ -90,6 +86,8 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    # NOTE - djng needs to be the last item in this list
+    'djng.middleware.AngularUrlMiddleware',
 ]
 
 FORM_RENDERER = 'djng.forms.renderers.DjangoAngularBootstrap3Templates'

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -76,7 +76,9 @@ INSTALLED_APPS = [
 ]
 
 
-MIDDLEWARE = [
+MIDDLEWARE_CLASSES = [
+    # NOTE - djng needs to be the first item in this list
+    'djng.middleware.AngularUrlMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'cached_auth.Middleware',
@@ -86,8 +88,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    # NOTE - djng needs to be the last item in this list
-    'djng.middleware.AngularUrlMiddleware',
+
 ]
 
 FORM_RENDERER = 'djng.forms.renderers.DjangoAngularBootstrap3Templates'

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -88,7 +88,6 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-
 ]
 
 FORM_RENDERER = 'djng.forms.renderers.DjangoAngularBootstrap3Templates'

--- a/canvas_account_admin_tools/settings/local.py
+++ b/canvas_account_admin_tools/settings/local.py
@@ -15,7 +15,7 @@ CANVAS_EMAIL_NOTIFICATION['support_email_address'] = 'tltqaemails@g.harvard.edu'
 
 
 INSTALLED_APPS += ['debug_toolbar', 'sslserver']
-MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
+MIDDLEWARE_CLASSES += ['debug_toolbar.middleware.DebugToolbarMiddleware']
 
 # For Django Debug Toolbar:
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)


### PR DESCRIPTION
This installation of CAAT, currently deployed on dev, uses the XML from this branch's tool config
https://canvas.dev.tlt.harvard.edu/accounts/10/external_tools/521

Fixes issue where there was an error in the site creator during a Angular reverse call