### PR TITLE
TLT-3595 Added parent_course_instance to patch data in CreateNewCourseController

### DIFF
--- a/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/controllers/CreateNewCourseController.js
@@ -323,6 +323,7 @@
             var data = {
                 canvas_course_id: $scope.canvasCourse.id,
                 sync_to_canvas: 1,
+                parent_course_instance: null
             };
 
             $http.patch(url, data).then(


### PR DESCRIPTION
The serializer that validates patch calls for a course instance requires parent_course_instance to be included in the call. The CreateNewCourseController is the only spot requiring this update as we already pass this value in the course info controller.