### PR TITLE
TLT-3570 Clears the SIS ID when a site is disassociated

### DIFF
--- a/course_info/static/course_info/js/controllers/SitesController.js
+++ b/course_info/static/course_info/js/controllers/SitesController.js
@@ -97,10 +97,14 @@
                 function modalConfirmed() {
                     var delete_course_site_url = djangoUrl.reverse(sc.apiProxy,
                         [sc.apiBase + sc.courseInstance.course_instance_id + '/sites/' + sc.courseInstance.sites[siteListIndex].site_map_id + '/']);
+                    // Get the Canvas course ID that is at the end of the site URL
+                    var canvas_course_id = sc.courseInstance.sites[siteListIndex]['course_site_url'].match(/\d+/)[0];
                     $http.delete(delete_course_site_url)
                         .then(function(response){
                             sc.dissociateSiteInProgressIndex = siteListIndex;
                             sc.courseInstance.sites.splice(siteListIndex, 1);
+                            var clear_sis_url = djangoUrl.reverse('course_info:clear_sis_id', [canvas_course_id]);
+                            $http.get(clear_sis_url)
                         }, function(response){
                             sc.handleAjaxErrorResponse(response);
                             sc.alerts.form.siteOperationFailed = {

--- a/course_info/static/course_info/js/controllers/SitesController.js
+++ b/course_info/static/course_info/js/controllers/SitesController.js
@@ -98,13 +98,17 @@
                     var delete_course_site_url = djangoUrl.reverse(sc.apiProxy,
                         [sc.apiBase + sc.courseInstance.course_instance_id + '/sites/' + sc.courseInstance.sites[siteListIndex].site_map_id + '/']);
                     // Get the Canvas course ID that is at the end of the site URL
-                    var canvas_course_id = sc.courseInstance.sites[siteListIndex]['course_site_url'].match(/\d+/)[0];
+                    var canvas_course_id = sc.courseInstance.sites[siteListIndex]['course_site_url'].match(/\d+/);
                     $http.delete(delete_course_site_url)
                         .then(function(response){
                             sc.dissociateSiteInProgressIndex = siteListIndex;
-                            sc.courseInstance.sites.splice(siteListIndex, 1);
-                            var clear_sis_url = djangoUrl.reverse('course_info:clear_sis_id', [canvas_course_id]);
-                            $http.get(clear_sis_url)
+                                sc.courseInstance.sites.splice(siteListIndex, 1);
+                            if (canvas_course_id) {
+                                // Match returns an array, get the first item which is the actual ID
+                                canvas_course_id = canvas_course_id[0];
+                                var clear_sis_url = djangoUrl.reverse('course_info:clear_sis_id', [canvas_course_id]);
+                                $http.get(clear_sis_url)
+                            }
                         }, function(response){
                             sc.handleAjaxErrorResponse(response);
                             sc.alerts.form.siteOperationFailed = {

--- a/course_info/urls.py
+++ b/course_info/urls.py
@@ -5,4 +5,5 @@ from course_info import views
 urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^partials/(?P<path>.+)$', views.partials, name='partials'),
+    url(r'^clear_sis_id/(?P<canvas_course_id>\d+)/$', views.clear_sis_id, name='clear_sis_id')
 ]

--- a/course_info/utils.py
+++ b/course_info/utils.py
@@ -1,0 +1,15 @@
+import logging
+
+from django.conf import settings
+
+from canvas_sdk.methods.courses import update_course as canvas_update_course
+from icommons_common.canvas_utils import SessionInactivityExpirationRC
+
+SDK_CONTEXT = SessionInactivityExpirationRC(**settings.CANVAS_SDK_SETTINGS)
+logger = logging.getLogger(__name__)
+
+
+def clear_course_sis_id(canvas_course_id):
+    """ Makes a Canvas SDK call to set the SIS ID to an empty string for the given Canvas course ID """
+    return canvas_update_course(SDK_CONTEXT, canvas_course_id, course_sis_course_id='')
+

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -13,6 +13,8 @@ from django_auth_lti.decorators import lti_role_required
 from icommons_common.canvas_api.helpers import roles as canvas_api_helpers_roles
 from icommons_common.models import UserRole
 from canvas_sdk.exceptions import CanvasAPIError
+from utils import clear_course_sis_id
+from django.http import HttpResponse
 logger = logging.getLogger(__name__)
 
 
@@ -38,6 +40,14 @@ def index(request):
 @require_http_methods(['GET'])
 def partials(request, path):
     return render(request, 'course_info/partials/' + path, {})
+
+
+@login_required
+@lti_role_required(const.ADMINISTRATOR)
+@lti_permission_required(settings.PERMISSION_ACCOUNT_ADMIN_TOOLS)
+@require_http_methods(['GET'])
+def clear_sis_id(request, canvas_course_id):
+    return HttpResponse(clear_course_sis_id(canvas_course_id))
 
 
 def _get_canvas_roles():


### PR DESCRIPTION
When a course site is disassociated, we now clear the SIS ID of the Canvas course

https://jira.huit.harvard.edu/browse/TLT-3570

I used the COLGSAS course 354849 to test this.
Open that course instance and then click on associated sites tab.
Open one of the associated sites in a new tab and go to the settings page.
On the previous tab, select "Disassociate site".
You should see one less associated site.
On the other tab, refresh the page and you should see that the SIS ID field is cleared out