### PR TITLE
Feature/crosslisting v2 add term info

### DIFF
--- a/cross_list_courses/templates/list.html
+++ b/cross_list_courses/templates/list.html
@@ -8,6 +8,11 @@
         Cross Listings
     </h3>
     </nav>
+     <div class="row">
+        <div class="col-xs-12">
+            <h4 class="modal-title bottom-spacing">Cross-listed courses in current terms</h4>
+        </div>
+     </div>
 
     <div class="container-fluid">
         <div class="row" style="margin-top: 1em;">

--- a/cross_list_courses/templates/list.html
+++ b/cross_list_courses/templates/list.html
@@ -8,14 +8,12 @@
         Cross Listings
     </h3>
     </nav>
-     <div class="row">
-        <div class="col-xs-12">
-            <h4 class="modal-title bottom-spacing">Cross-listed courses in current terms</h4>
-        </div>
-     </div>
 
     <div class="container-fluid">
         <div class="row" style="margin-top: 1em;">
+            <div class="col-xs-6">
+                <h4 class="modal-title bottom-spacing">Cross-listed courses in current terms</h4>
+            </div>
             <a href="{% url 'cross_list_courses:add_new_pair' %}" class="btn btn-primary pull-right">Add New Pair</a>
         </div>
             {% for message in messages %}

--- a/cross_list_courses/templates/list.html
+++ b/cross_list_courses/templates/list.html
@@ -45,7 +45,7 @@
                             {{ xlist_map.primary_course_instance.short_title }}
                             {{ xlist_map.primary_course_instance.course_instance_id }}
                             <br>
-                            {{ xlist_map.primary_course_instance.title }}
+                            {{ xlist_map.primary_course_instance.title }}/ {{ xlist_map.primary_course_instance.term.display_name}}
                         </td>
                         <td>
                             {{ xlist_map.secondary_course_instance.course.school_id | upper }}
@@ -53,7 +53,7 @@
                             {{ xlist_map.secondary_course_instance.short_title }}
                             {{ xlist_map.secondary_course_instance.course_instance_id }}
                             <br>
-                            {{ xlist_map.secondary_course_instance.title }}
+                            {{ xlist_map.secondary_course_instance.title }}/ {{ xlist_map.secondary_course_instance.term.display_name}}
                         </td>
                         <td>{{ xlist_map.last_modified_by_full_name }}</td>
                         <td>

--- a/cross_list_courses/views.py
+++ b/cross_list_courses/views.py
@@ -32,9 +32,10 @@ def index(request):
     xlist_maps = XlistMap.objects.filter(Q(primary_course_instance__term__end_date__gte=today) |
                                         Q(secondary_course_instance__term__end_date__gte=today)).filter(
                                         Q(primary_course_instance__course__school=tool_launch_school) |
-                                        Q(secondary_course_instance__course__school=tool_launch_school)).select_related('primary_course_instance__course',
-                                                                                                                        'secondary_course_instance__course',
-                                                                                                                        )
+                                        Q(secondary_course_instance__course__school=tool_launch_school)).select_related(
+                                                                                'primary_course_instance__course', 'primary_course_instance__term',
+                                                                                'secondary_course_instance__course', 'secondary_course_instance__term'
+                                                                                )
     updater_ids = Set()
     for xm in xlist_maps:
         updater_ids.add(xm.last_modified_by)


### PR DESCRIPTION
This PR contains changes for TLT-3776 and 3677. Adds Term information to the crosslisting entries for better clarity. Also adds a title to the initial screen. 

This branch is deployed on dev : https://canvas.dev.tlt.harvard.edu/accounts/10/external_tools/359