### PR TITLE
TLT-3681 and TLT-3699 Swap courses in cross listing and cosmetic changes

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -12,7 +12,8 @@ django-redis-cache==1.7.1
 djangorestframework==3.5.3
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.13#egg=django-canvas-course-site-wizard==1.3.13
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.3.0#egg=django-auth-lti==1.3.0
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.49#egg=django-icommons-common[async]==1.49
+#git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.51#egg=django-icommons-common[async]==1.51
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@task/thornton/tlt-3699/update_CsXlistMapOverview#egg=django-icommons-common[async]==task/thornton/tlt-3699/update_CsXlistMapOverview
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.5.3#egg=django-icommons-ui==1.5.3
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.11#egg=canvas-python-sdk==0.11
 git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v1.0#egg=django-harvardkey-cas==1.0

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -12,8 +12,7 @@ django-redis-cache==1.7.1
 djangorestframework==3.5.3
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.13#egg=django-canvas-course-site-wizard==1.3.13
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.3.0#egg=django-auth-lti==1.3.0
-#git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.51#egg=django-icommons-common[async]==1.51
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@task/thornton/tlt-3699/update_CsXlistMapOverview#egg=django-icommons-common[async]==task/thornton/tlt-3699/update_CsXlistMapOverview
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.51#egg=django-icommons-common[async]==1.51
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.5.3#egg=django-icommons-ui==1.5.3
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.11#egg=canvas-python-sdk==0.11
 git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v1.0#egg=django-harvardkey-cas==1.0

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -12,7 +12,7 @@ django-redis-cache==1.7.1
 djangorestframework==3.5.3
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.13#egg=django-canvas-course-site-wizard==1.3.13
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.3.0#egg=django-auth-lti==1.3.0
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.51#egg=django-icommons-common[async]==1.51
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.52.1#egg=django-icommons-common[async]==1.52.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.5.3#egg=django-icommons-ui==1.5.3
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.11#egg=canvas-python-sdk==0.11
 git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v1.0#egg=django-harvardkey-cas==1.0

--- a/cross_list_courses/templates/add_new.html
+++ b/cross_list_courses/templates/add_new.html
@@ -59,7 +59,7 @@
 
     <div class="container-fluid">
         <div class="row" style="margin-top: .25em;">
-            <div style="margin-bottom: -20px; padding-top: 50px;"><h4><u>Potential Cross Listings</u></h4></div>
+            <div style="margin-bottom: -20px; padding-top: 50px;"><h4>Potential Cross Listings</h4></div>
             <table class="datatable table display no-footer">
                 <thead>
                     <th>Primary Course</th>

--- a/cross_list_courses/templates/add_new.html
+++ b/cross_list_courses/templates/add_new.html
@@ -57,9 +57,9 @@
         </div>
     </div>
 
-    <div><h4>Potential Cross Listings </h4></div>
     <div class="container-fluid">
         <div class="row" style="margin-top: .25em;">
+            <div style="margin-bottom: -20px; padding-top: 50px;"><h4><u>Potential Cross Listings</u></h4></div>
             <table class="datatable table display no-footer">
                 <thead>
                     <th>Primary Course</th>
@@ -70,14 +70,40 @@
                 <tbody>
                 {% for mapping in potential_mappings %}
                     <tr>
-                        <td>{{ mapping.primary_school_id | upper }}: {{ mapping.primary_short_title }} :{{ mapping.primary_course_instance_id }}
+                        <td>
+                            {{ mapping.primary_school_id | upper }}
                             <br>
-                            {{ mapping.primary_sub_title }}
+                            {% if mapping.primary_school_id == 'hls' or mapping.primary_school_id == 'ext' %}
+                                {{ mapping.primary_course_instance.course.registrar_code }}
+                            {% else %}
+                                {{ mapping.primary_short_title }}
+                            {% endif %}
+                            {{ mapping.term_id }}
+                            (course instance ID {{ mapping.primary_course_instance_id }})
+                            <br>
+                            {% if mapping.primary_school_id == 'hls' or mapping.primary_school_id == 'ext' %}
+                                {{ mapping.primary_short_title }}
+                            {% else %}
+                                {{ mapping.primary_sub_title }}
+                            {% endif %}
                         </td>
                         <td><i class="fa fa-exchange fa-2x btn btn-primary" onclick="swapCourses(this);" aria-hidden="true"></i></td>
-                        <td>{{ mapping.secondary_school_id | upper }}: {{ mapping.secondary_short_title }} : {{ mapping.secondary_course_instance_id }}
+                        <td>
+                            {{ mapping.secondary_school_id | upper }}
                             <br>
-                            {{ mapping.secondary_sub_title }}
+                            {% if mapping.seondary_school_id == 'hls' or mapping.secondary_school_id == 'ext' %}
+                                {{ mapping.secondarycourse_instance.course.registrar_code }}
+                            {% else %}
+                                {{ mapping.secondary_short_title }}
+                            {% endif %}
+                            {{ mapping.term_id }}
+                            (course instance ID {{ mapping.secondary_course_instance_id }})
+                            <br>
+                            {% if mapping.secondary_school_id == 'hls' or mapping.secondary_school_id == 'ext' %}
+                                {{ mapping.secondary_short_title }}
+                            {% else %}
+                                {{ mapping.secondary_sub_title }}
+                            {% endif %}
                         </td>
                         <td>
                             <a href="{% url 'cross_list_courses:create_new_pair' %}&primary_course_input={{ mapping.primary_course_instance_id }}&secondary_course_input={{ mapping.secondary_course_instance_id }}" class="btn btn-primary pull-right">Pair Courses</a>
@@ -98,7 +124,7 @@
             "bInfo" : false,
             "aoColumnDefs": [ { "orderable": false, "targets": [1,3] } ],
             "oLanguage": {
-              "sSearch": "Filter"
+              "sSearch": "Filter the list below"
             }
         });
     });

--- a/cross_list_courses/templates/add_new.html
+++ b/cross_list_courses/templates/add_new.html
@@ -78,7 +78,7 @@
                             {% else %}
                                 {{ mapping.primary_short_title }}
                             {% endif %}
-                            {{ mapping.term_display_name }}
+                            {{ mapping.primary_term_display_name }}
                             (course instance ID {{ mapping.primary_course_instance_id }})
                             <br>
                             {% if mapping.primary_school_id == 'hls' or mapping.primary_school_id == 'ext' %}
@@ -96,7 +96,7 @@
                             {% else %}
                                 {{ mapping.secondary_short_title }}
                             {% endif %}
-                            {{ mapping.term_display_name }}
+                            {{ mapping.secondary_term_display_name }}
                             (course instance ID {{ mapping.secondary_course_instance_id }})
                             <br>
                             {% if mapping.secondary_school_id == 'hls' or mapping.secondary_school_id == 'ext' %}

--- a/cross_list_courses/templates/add_new.html
+++ b/cross_list_courses/templates/add_new.html
@@ -6,9 +6,9 @@
     <h3>
         <a href="{% url 'dashboard_account' %}">Admin Console</a>
         <small><i class="fa fa-chevron-right"></i></small>
-        <a href="{% url 'cross_list_courses:index' %}">Cross Listings</a>
+        <a href="{% url 'cross_list_courses:index' %}">Cross-Listings</a>
         <small><i class="fa fa-chevron-right"></i></small>
-        Add Cross Listings
+        Add Cross-Listings
     </h3>
 </nav>
 <br>
@@ -36,7 +36,7 @@
         {% endfor %}
 
         <div class="panel panel-default">
-            <div class="panel-heading"><h4>Create a New Cross Listing Pair</h4></div>
+            <div class="panel-heading"><h4>Create a New Cross-Listing Pair</h4></div>
             <div class="panel-body ui-widget">
                 <label  for="primary-course">
                     Primary Course &nbsp;&nbsp;&nbsp;&nbsp;
@@ -59,7 +59,7 @@
 
     <div class="container-fluid">
         <div class="row" style="margin-top: .25em;">
-            <div style="margin-bottom: -20px; padding-top: 50px;"><h4>Potential Cross Listings</h4></div>
+            <div style="margin-bottom: -20px; padding-top: 50px;"><h4>Potential Cross-Listings:</h4></div>
             <table class="datatable table display no-footer">
                 <thead>
                     <th>Primary Course</th>
@@ -72,12 +72,14 @@
                     <tr>
                         <td>
                             {{ mapping.primary_school_id | upper }}
-                            <br>
+                            <b>
                             {% if mapping.primary_school_id == 'hls' or mapping.primary_school_id == 'ext' %}
                                 {{ mapping.primary_registrar_code }}
                             {% else %}
                                 {{ mapping.primary_short_title }}
                             {% endif %}
+                            </b>
+                            <br>
                             {{ mapping.primary_term_display_name }}
                             (course instance ID {{ mapping.primary_course_instance_id }})
                             <br>
@@ -87,15 +89,17 @@
                                 {{ mapping.primary_sub_title }}
                             {% endif %}
                         </td>
-                        <td><i class="fa fa-exchange fa-2x btn btn-primary" onclick="swapCourses(this);" aria-hidden="true"></i></td>
+                        <td><i class="fa fa-exchange fa-2x btn btn-info" onclick="swapCourses(this);" aria-hidden="true"></i></td>
                         <td>
                             {{ mapping.secondary_school_id | upper }}
-                            <br>
+                            <b>
                             {% if mapping.seondary_school_id == 'hls' or mapping.secondary_school_id == 'ext' %}
                                 {{ mapping.secondary_registrar_code }}
                             {% else %}
                                 {{ mapping.secondary_short_title }}
                             {% endif %}
+                            </b>
+                            <br>
                             {{ mapping.secondary_term_display_name }}
                             (course instance ID {{ mapping.secondary_course_instance_id }})
                             <br>

--- a/cross_list_courses/templates/add_new.html
+++ b/cross_list_courses/templates/add_new.html
@@ -2,22 +2,19 @@
 {% block body %}
 {% load static %}
 
-
 <nav>
-  <h3>
-    <a href="{% url 'dashboard_account' %}">Admin Console</a>
-    <small><i class="fa fa-chevron-right"></i></small>
-    <a href="{% url 'cross_list_courses:index' %}">Cross Listings</a>
-    <small><i class="fa fa-chevron-right"></i></small>
-    Add Cross Listings
-  </h3>
+    <h3>
+        <a href="{% url 'dashboard_account' %}">Admin Console</a>
+        <small><i class="fa fa-chevron-right"></i></small>
+        <a href="{% url 'cross_list_courses:index' %}">Cross Listings</a>
+        <small><i class="fa fa-chevron-right"></i></small>
+        Add Cross Listings
+    </h3>
 </nav>
 <br>
 <body role="application">
 <form action="{% url 'cross_list_courses:create_new_pair' %}" method="post">{% csrf_token %}
     <input type="hidden" name="school_id" value="{{ school_id }}" />
-
-
     <div class="container-fluid">
         {% for message in messages %}
             {% if message.level_tag == "success" %}
@@ -38,57 +35,52 @@
             {% endif %}
         {% endfor %}
 
-          <div class="panel panel-default">
-              <div class="panel-heading"><h4>Create a New Cross Listing Pair</h4></div>
-              <div class="panel-body ui-widget">
-                  <label  for="primary-course">
-                       Primary Course &nbsp;&nbsp;&nbsp;&nbsp;
-                  </label>
-                  <input  name="primary_course_input" id="primary-course" style="width: 650px;">
-                    </input>
-              </div>
-              <div class="panel-body ui-widget">
-
-                  <label for="secondary-course">
-                      Secondary Course
-                  </label>
-                  <input  name="secondary_course_input"  id="secondary-course" style="width: 650px;">
-                  </input>
-                  <div class="form-group" style="margin-top: 1em; align:center;">
-
-                      <input type="submit" class="btn btn-primary" value="Pair Courses" />
-                  </div>
-
-              </div>
-          </div>
-
+        <div class="panel panel-default">
+            <div class="panel-heading"><h4>Create a New Cross Listing Pair</h4></div>
+            <div class="panel-body ui-widget">
+                <label  for="primary-course">
+                    Primary Course &nbsp;&nbsp;&nbsp;&nbsp;
+                </label>
+                <input  name="primary_course_input" id="primary-course" style="width: 650px;">
+                </input>
+            </div>
+            <div class="panel-body ui-widget">
+                <label for="secondary-course">
+                    Secondary Course
+                </label>
+                <input  name="secondary_course_input"  id="secondary-course" style="width: 650px;">
+                </input>
+                <div class="form-group" style="margin-top: 1em; align:center;">
+                    <input type="submit" class="btn btn-primary" value="Pair Courses" />
+                </div>
+            </div>
+        </div>
     </div>
 
-
-    <div> <h4>Potential Cross Listings </h4></div>
+    <div><h4>Potential Cross Listings </h4></div>
     <div class="container-fluid">
         <div class="row" style="margin-top: .25em;">
-
             <table class="datatable table display no-footer">
                 <thead>
                     <th>Primary Course</th>
+                    <th></th>
                     <th>Secondary Course</th>
                     <th></th>
-
                 </thead>
                 <tbody>
                 {% for mapping in potential_mappings %}
                     <tr>
                         <td>{{ mapping.primary_school_id | upper }}: {{ mapping.primary_short_title }} :{{ mapping.primary_course_instance_id }}
-                             <br>
+                            <br>
                             {{ mapping.primary_sub_title }}
                         </td>
+                        <td><i class="fa fa-exchange fa-2x btn btn-primary" onclick="swapCourses(this);" aria-hidden="true"></i></td>
                         <td>{{ mapping.secondary_school_id | upper }}: {{ mapping.secondary_short_title }} : {{ mapping.secondary_course_instance_id }}
-                                <br>
+                            <br>
                             {{ mapping.secondary_sub_title }}
                         </td>
-                         <td>
-                             <a href="{% url 'cross_list_courses:create_new_pair' %}&primary_course_input={{ mapping.primary_course_instance_id }}&secondary_course_input={{ mapping.secondary_course_instance_id }}" class="btn btn-primary pull-right">Pair Courses</a>
+                        <td>
+                            <a href="{% url 'cross_list_courses:create_new_pair' %}&primary_course_input={{ mapping.primary_course_instance_id }}&secondary_course_input={{ mapping.secondary_course_instance_id }}" class="btn btn-primary pull-right">Pair Courses</a>
                         </td>
                     </tr>
                 {% endfor %}
@@ -96,7 +88,6 @@
             </table>
         </div>
     </div>
-
 </form>
 </body>
 
@@ -105,37 +96,68 @@
         $('.datatable').dataTable( {
             paging: false,
             "bInfo" : false,
-            "aoColumnDefs": [ { "orderable": false, "targets": 2 } ],
+            "aoColumnDefs": [ { "orderable": false, "targets": [1,3] } ],
             "oLanguage": {
               "sSearch": "Filter"
             }
         });
     });
 
+    $(document).ready(function(){
+        var location_input=$('input[id="primary-course"]');
+        location_input.autocomplete({
+            source: "get_ci_data",
+            minLength: 2
+        });
+    });
+
+    // keeps same width as box
+    jQuery.ui.autocomplete.prototype._resizeMenu = function () {
+        var ul = this.menu.element;
+        ul.outerWidth(this.element.outerWidth());
+    };
 
     $(document).ready(function(){
-            var location_input=$('input[id="primary-course"]');
-            location_input.autocomplete({
-                source: "get_ci_data",
-              minLength: 2
-            });
-          } );
+        var location_input=$('input[id="secondary-course"]');
+        location_input.autocomplete({
+            source: "get_ci_data",
+            minLength: 2
+        });
+    });
 
-    //   keeps same width as box
-      jQuery.ui.autocomplete.prototype._resizeMenu = function () {
-          var ul = this.menu.element;
-          ul.outerWidth(this.element.outerWidth());
+    function swapCourses(element) {
+        // Swap the primary and secondary course cells
+        let tdArray = $(element).parent().parent().find('td');
+        let primaryCourseCell = tdArray[0];
+        let primaryHTML = primaryCourseCell.innerHTML;
+        let secondaryCourseCell = tdArray[2];
+        let secondaryHTML = secondaryCourseCell.innerHTML;
+        primaryCourseCell.innerHTML = secondaryHTML;
+        secondaryCourseCell.innerHTML = primaryHTML;
+
+        // Swap the primary and secondary course instance ids stored in the "Pair Courses" url
+        let pairCoursesButton = $(tdArray[3]).find('a');
+        let buttonHref = pairCoursesButton.attr('href');
+        let primaryCourseInstance = getUrlParameter('primary_course_input', buttonHref);
+        let secondaryCourseInstance = getUrlParameter('secondary_course_input', buttonHref);
+        buttonHref = buttonHref.replace('primary_course_input='+primaryCourseInstance, 'primary_course_input='+secondaryCourseInstance);
+        buttonHref = buttonHref.replace('secondary_course_input='+secondaryCourseInstance, 'secondary_course_input='+primaryCourseInstance);
+        $(pairCoursesButton).attr('href', buttonHref);
+    }
+
+    function getUrlParameter(sParam, url) {
+        let sURLVariables = url.split('&'),
+            sParameterName,
+            i;
+
+        for (i = 0; i < sURLVariables.length; i++) {
+            sParameterName = sURLVariables[i].split('=');
+
+            if (sParameterName[0] === sParam) {
+                return sParameterName[1] === undefined ? true : decodeURIComponent(sParameterName[1]);
+            }
         }
-
-    $(document).ready(function(){
-            var location_input=$('input[id="secondary-course"]');
-            location_input.autocomplete({
-                source: "get_ci_data",
-              minLength: 2
-            });
-    } );
-
-
+    }
 </script>
 
 {% endblock %}

--- a/cross_list_courses/templates/add_new.html
+++ b/cross_list_courses/templates/add_new.html
@@ -83,11 +83,13 @@
                             {{ mapping.primary_term_display_name }}
                             (course instance ID {{ mapping.primary_course_instance_id }})
                             <br>
+                            <i>
                             {% if mapping.primary_school_id == 'hls' or mapping.primary_school_id == 'ext' %}
                                 {{ mapping.primary_title }}
                             {% else %}
                                 {{ mapping.primary_sub_title }}
                             {% endif %}
+                            </i>
                         </td>
                         <td><i class="fa fa-exchange fa-2x btn btn-info" onclick="swapCourses(this);" aria-hidden="true"></i></td>
                         <td>
@@ -103,11 +105,13 @@
                             {{ mapping.secondary_term_display_name }}
                             (course instance ID {{ mapping.secondary_course_instance_id }})
                             <br>
+                            <i>
                             {% if mapping.secondary_school_id == 'hls' or mapping.secondary_school_id == 'ext' %}
                                 {{ mapping.secondary_title }}
                             {% else %}
                                 {{ mapping.secondary_sub_title }}
                             {% endif %}
+                            </i>
                         </td>
                         <td>
                             <a href="{% url 'cross_list_courses:create_new_pair' %}&primary_course_input={{ mapping.primary_course_instance_id }}&secondary_course_input={{ mapping.secondary_course_instance_id }}" class="btn btn-primary pull-right">Pair Courses</a>

--- a/cross_list_courses/templates/add_new.html
+++ b/cross_list_courses/templates/add_new.html
@@ -74,15 +74,15 @@
                             {{ mapping.primary_school_id | upper }}
                             <br>
                             {% if mapping.primary_school_id == 'hls' or mapping.primary_school_id == 'ext' %}
-                                {{ mapping.primary_course_instance.course.registrar_code }}
+                                {{ mapping.primary_registrar_code }}
                             {% else %}
                                 {{ mapping.primary_short_title }}
                             {% endif %}
-                            {{ mapping.term_id }}
+                            {{ mapping.term_display_name }}
                             (course instance ID {{ mapping.primary_course_instance_id }})
                             <br>
                             {% if mapping.primary_school_id == 'hls' or mapping.primary_school_id == 'ext' %}
-                                {{ mapping.primary_short_title }}
+                                {{ mapping.primary_title }}
                             {% else %}
                                 {{ mapping.primary_sub_title }}
                             {% endif %}
@@ -92,15 +92,15 @@
                             {{ mapping.secondary_school_id | upper }}
                             <br>
                             {% if mapping.seondary_school_id == 'hls' or mapping.secondary_school_id == 'ext' %}
-                                {{ mapping.secondarycourse_instance.course.registrar_code }}
+                                {{ mapping.secondary_registrar_code }}
                             {% else %}
                                 {{ mapping.secondary_short_title }}
                             {% endif %}
-                            {{ mapping.term_id }}
+                            {{ mapping.term_display_name }}
                             (course instance ID {{ mapping.secondary_course_instance_id }})
                             <br>
                             {% if mapping.secondary_school_id == 'hls' or mapping.secondary_school_id == 'ext' %}
-                                {{ mapping.secondary_short_title }}
+                                {{ mapping.secondary_title }}
                             {% else %}
                                 {{ mapping.secondary_sub_title }}
                             {% endif %}

--- a/cross_list_courses/templates/list.html
+++ b/cross_list_courses/templates/list.html
@@ -10,12 +10,6 @@
     </nav>
 
     <div class="container-fluid">
-        <div class="row" style="margin-top: 1em;">
-            <div class="col-xs-6">
-                <h4 class="modal-title bottom-spacing">Cross-listed courses in current terms</h4>
-            </div>
-            <a href="{% url 'cross_list_courses:add_new_pair' %}" class="btn btn-primary pull-right">Add New Pair</a>
-        </div>
             {% for message in messages %}
             <div class="row">
                     {% if message.level_tag == "success" %}
@@ -31,7 +25,13 @@
                 {% endif %}
             </div>
         {% endfor %}
+        <div class="row" style="margin-top: 1em;">
+            <a href="{% url 'cross_list_courses:add_new_pair' %}" class="btn btn-primary pull-right">Add New Pair</a>
+        </div>
         <div class="row" style="margin-top: .25em;">
+            <div style="margin-bottom: -20px; padding-top: 50px;">
+                <h4 class="modal-title bottom-spacing"><u>Cross-listed Courses in Current Terms</u></h4>
+            </div>
             <table class="datatable table display no-footer">
                 <thead>
                     <th>Primary</th>
@@ -44,19 +44,37 @@
                     <tr>
                         <td>
                             {{ xlist_map.primary_course_instance.course.school_id | upper }}
-                            {{ xlist_map.primary_course_instance.course.registrar_code }}
-                            {{ xlist_map.primary_course_instance.short_title }}
-                            {{ xlist_map.primary_course_instance.course_instance_id }}
                             <br>
-                            {{ xlist_map.primary_course_instance.title }}/ {{ xlist_map.primary_course_instance.term.display_name}}
+                            {% if xlist_map.primary_course_instance.course.school_id == 'hls' or xlist_map.primary_course_instance.course.school_id == 'ext'%}
+                                {{ xlist_map.primary_course_instance.course.registrar_code }}
+                            {% else %}
+                                {{ xlist_map.primary_course_instance.short_title }}
+                            {% endif %}
+                            {{ xlist_map.primary_course_instance.term.display_name}}
+                            (course instance ID {{ xlist_map.primary_course_instance.course_instance_id }})
+                            <br>
+                            {% if xlist_map.primary_course_instance.course.school_id == 'hls' or xlist_map.primary_course_instance.course.school_id == 'ext'%}
+                                {{ xlist_map.primary_course_instance.title }}
+                            {% else %}
+                                {{ xlist_map.primary_course_instance.sub_title }}
+                            {% endif %}
                         </td>
                         <td>
                             {{ xlist_map.secondary_course_instance.course.school_id | upper }}
-                            {{ xlist_map.secondary_course_instance.course.registrar_code }}
-                            {{ xlist_map.secondary_course_instance.short_title }}
-                            {{ xlist_map.secondary_course_instance.course_instance_id }}
                             <br>
-                            {{ xlist_map.secondary_course_instance.title }}/ {{ xlist_map.secondary_course_instance.term.display_name}}
+                            {% if xlist_map.secondary_course_instance.course.school_id == 'hls' or xlist_map.secondary_course_instance.course.school_id == 'ext'%}
+                                {{ xlist_map.secondary_course_instance.course.registrar_code }}
+                            {% else %}
+                                {{ xlist_map.secondary_course_instance.short_title }}
+                            {% endif %}
+                            {{ xlist_map.secondary_course_instance.term.display_name}}
+                            (course instance ID {{ xlist_map.secondary_course_instance.course_instance_id }})
+                            <br>
+                            {% if xlist_map.secondary_course_instance.course.school_id == 'hls' or xlist_map.secondary_course_instance.course.school_id == 'ext'%}
+                                {{ xlist_map.secondary_course_instance.title }}
+                            {% else %}
+                                {{ xlist_map.secondary_course_instance.sub_title }}
+                            {% endif %}
                         </td>
                         <td>{{ xlist_map.last_modified_by_full_name }}</td>
                         <td>
@@ -76,7 +94,7 @@
             "bInfo" : false,
             "aoColumnDefs": [ { "orderable": false, "targets": 3 } ],
             "oLanguage": {
-              "sSearch": "Search"
+              "sSearch": "Filter the list below"
             }
         });
     });

--- a/cross_list_courses/templates/list.html
+++ b/cross_list_courses/templates/list.html
@@ -47,8 +47,14 @@
                             <b>
                             {% if xlist_map.primary_course_instance.course.school_id == 'hls' or xlist_map.primary_course_instance.course.school_id == 'ext'%}
                                 {{ xlist_map.primary_course_instance.course.registrar_code }}
-                            {% else %}
+                            {% elif xlist_map.primary_course_instance.short_title %}
                                 {{ xlist_map.primary_course_instance.short_title }}
+                            {% elif xlist_map.primary_course_instance.course.registrar_code_display %}
+                                {{ xlist_map.primary_course_instance.course.registrar_code_display }}
+                            {% elif xlist_map.primary_course_instance.course.registrar_code %}
+                                {{ xlist_map.primary_course_instance.course.registrar_code }}
+                            {% else %}
+                                No course code; course ID {{ xlist_map.primary_course_instance.course.course_id }}
                             {% endif %}
                             </b>
                             <br>
@@ -66,8 +72,14 @@
                             <b>
                             {% if xlist_map.secondary_course_instance.course.school_id == 'hls' or xlist_map.secondary_course_instance.course.school_id == 'ext'%}
                                 {{ xlist_map.secondary_course_instance.course.registrar_code }}
-                            {% else %}
+                            {% elif xlist_map.secondary_course_instance.short_title %}
                                 {{ xlist_map.secondary_course_instance.short_title }}
+                            {% elif xlist_map.secondary_course_instance.course.registrar_code_display %}
+                                {{ xlist_map.secondary_course_instance.course.registrar_code_display }}
+                            {% elif xlist_map.secondary_course_instance.course.registrar_code %}
+                                {{ xlist_map.secondary_course_instance.course.registrar_code }}
+                            {% else %}
+                                No course code; course ID {{ xlist_map.secondary_course_instance.course.course_id }}
                             {% endif %}
                             </b>
                             <br>

--- a/cross_list_courses/templates/list.html
+++ b/cross_list_courses/templates/list.html
@@ -30,7 +30,7 @@
         </div>
         <div class="row" style="margin-top: .25em;">
             <div style="margin-bottom: -20px; padding-top: 50px;">
-                <h4 class="modal-title bottom-spacing"><u>Cross-listed Courses in Current Terms</u></h4>
+                <h4 class="modal-title bottom-spacing">Cross-listed Courses in Current Terms</h4>
             </div>
             <table class="datatable table display no-footer">
                 <thead>

--- a/cross_list_courses/templates/list.html
+++ b/cross_list_courses/templates/list.html
@@ -5,7 +5,7 @@
     <h3>
         <a href="{% url 'dashboard_account' %}">Admin Console</a>
         <small><i class="fa fa-chevron-right"></i></small>
-        Cross Listings
+        Cross-Listings
     </h3>
     </nav>
 
@@ -30,7 +30,7 @@
         </div>
         <div class="row" style="margin-top: .25em;">
             <div style="margin-bottom: -20px; padding-top: 50px;">
-                <h4 class="modal-title bottom-spacing">Cross-listed Courses in Current Terms</h4>
+                <h4 class="modal-title bottom-spacing">Cross-Listed Courses in Current Terms:</h4>
             </div>
             <table class="datatable table display no-footer">
                 <thead>
@@ -44,12 +44,14 @@
                     <tr>
                         <td>
                             {{ xlist_map.primary_course_instance.course.school_id | upper }}
-                            <br>
+                            <b>
                             {% if xlist_map.primary_course_instance.course.school_id == 'hls' or xlist_map.primary_course_instance.course.school_id == 'ext'%}
                                 {{ xlist_map.primary_course_instance.course.registrar_code }}
                             {% else %}
                                 {{ xlist_map.primary_course_instance.short_title }}
                             {% endif %}
+                            </b>
+                            <br>
                             {{ xlist_map.primary_course_instance.term.display_name}}
                             (course instance ID {{ xlist_map.primary_course_instance.course_instance_id }})
                             <br>
@@ -61,12 +63,14 @@
                         </td>
                         <td>
                             {{ xlist_map.secondary_course_instance.course.school_id | upper }}
-                            <br>
+                            <b>
                             {% if xlist_map.secondary_course_instance.course.school_id == 'hls' or xlist_map.secondary_course_instance.course.school_id == 'ext'%}
                                 {{ xlist_map.secondary_course_instance.course.registrar_code }}
                             {% else %}
                                 {{ xlist_map.secondary_course_instance.short_title }}
                             {% endif %}
+                            </b>
+                            <br>
                             {{ xlist_map.secondary_course_instance.term.display_name}}
                             (course instance ID {{ xlist_map.secondary_course_instance.course_instance_id }})
                             <br>

--- a/cross_list_courses/templates/list.html
+++ b/cross_list_courses/templates/list.html
@@ -61,11 +61,13 @@
                             {{ xlist_map.primary_course_instance.term.display_name}}
                             (course instance ID {{ xlist_map.primary_course_instance.course_instance_id }})
                             <br>
+                            <i>
                             {% if xlist_map.primary_course_instance.course.school_id == 'hls' or xlist_map.primary_course_instance.course.school_id == 'ext'%}
                                 {{ xlist_map.primary_course_instance.title }}
                             {% else %}
                                 {{ xlist_map.primary_course_instance.sub_title }}
                             {% endif %}
+                            </i>
                         </td>
                         <td>
                             {{ xlist_map.secondary_course_instance.course.school_id | upper }}
@@ -86,11 +88,13 @@
                             {{ xlist_map.secondary_course_instance.term.display_name}}
                             (course instance ID {{ xlist_map.secondary_course_instance.course_instance_id }})
                             <br>
+                            <i>
                             {% if xlist_map.secondary_course_instance.course.school_id == 'hls' or xlist_map.secondary_course_instance.course.school_id == 'ext'%}
                                 {{ xlist_map.secondary_course_instance.title }}
                             {% else %}
                                 {{ xlist_map.secondary_course_instance.sub_title }}
                             {% endif %}
+                            </i>
                         </td>
                         <td>{{ xlist_map.last_modified_by_full_name }}</td>
                         <td>

--- a/cross_list_courses/utils.py
+++ b/cross_list_courses/utils.py
@@ -128,8 +128,7 @@ def _get_canvas_course(course_sis_id, request):
         return canvas_get_course(SDK_CONTEXT, course_id).json()
     except:
         msg = 'Canvas course {} unavailable.'.format(course_id)
-        logger.exception('Error during cross-listing: ' + msg)
-        messages.warning(request, msg)
+        logger.info('Error during cross-listing: ' + msg)
     return None
 
 

--- a/cross_list_courses/views.py
+++ b/cross_list_courses/views.py
@@ -1,7 +1,6 @@
 from sets import Set
 import logging
 from datetime import datetime, timedelta
-from django.utils import timezone
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -21,7 +20,6 @@ import json
 
 
 logger = logging.getLogger(__name__)
-
 
 
 @login_required
@@ -57,6 +55,7 @@ def index(request):
     }
     return render(request, 'list.html', context=context)
 
+
 @lti_role_required(const.ADMINISTRATOR)
 @lti_permission_required(settings.PERMISSION_XLIST_TOOL)
 @require_http_methods(['GET'])
@@ -70,7 +69,8 @@ def add_new_pair(request):
     #  Possibly add a column in the view to do so
 
     potential_mappings = CsXlistMapOverview.objects.filter(Q(primary_school_id=school_id)).filter(
-        Q(term_end_date__gte=today) | Q(term_end_date__isnull=True)).filter(
+        Q(primary_term_end_date__gte=today) | Q(primary_term_end_date__isnull=True) |
+        Q(secondary_term_end_date__gte=today) | Q(secondary_term_end_date__isnull=True)).filter(
         Q(existing_mapping__isnull=True)).filter(
         Q(existing_reverse_mapping__isnull=True))
 
@@ -80,6 +80,7 @@ def add_new_pair(request):
     }
 
     return render(request, 'add_new.html', context=context)
+
 
 @lti_role_required(const.ADMINISTRATOR)
 @lti_permission_required(settings.PERMISSION_XLIST_TOOL)
@@ -97,6 +98,7 @@ def create_new_pair(request):
         create_crosslisting_pair(primary_id, secondary_id,request)
 
     return redirect('cross_list_courses:add_new_pair')
+
 
 @login_required
 @lti_role_required(const.ADMINISTRATOR)


### PR DESCRIPTION
https://jira.huit.harvard.edu/browse/TLT-3681
Adds the ability to swap the primary and secondary courses in the "Add New Pair" page.

https://jira.huit.harvard.edu/browse/TLT-3699
Cosmetic changes outlined in the story. Since we are not referencing FK's in the model, the second page still needs another round of consideration.