### PR TITLE
Task/sapnamysore/tlt 3713/fix conclude date

### DIFF
--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -334,7 +334,6 @@
                     patchData[field] = dc.formDisplayData[field];
                 }
             });
-            console.log(url);
 
             $http.patch(url, patchData)
                 .then(function finalizeCourseDetailsPatch(response) {

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -321,10 +321,8 @@
                     if (dc.formDisplayData['conclude_date']) {
                         // Validate that the selected date is not in the past before submitting.
                         if (!dc.isSelectedDateInPast(dc.formDisplayData['conclude_date'])) {
-                            var formatted_date = $filter('date')(new Date(dc.formDisplayData['conclude_date']), 'yyyy-MM-dd', 'Z');
-                            formatted_date += 'T05:01:00Z';
+                            var formatted_date = new Date(dc.formDisplayData['conclude_date']+' 00:01:00').toISOString();
                             patchData['conclude_date'] = formatted_date;
-                            console.log(patchData);
                         }
                     } else {
                         // If the conclude date field is left blank, then set the conclude_date to null in the DB.

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -371,7 +371,7 @@
         // Checks if the given date is prior to tomorrow's date(today's date plus 1).
         dc.isSelectedDateInPast = function(selectedDate) {
             // Since the input field is a string representation of a date,
-            // we need to convert today's date to the same format as a string to make the comparison.
+            // we need to convert tomorrow's's date to the same format as a string to make the comparison.
             var today = new Date();
             var tomorrow = new Date();
             tomorrow.setDate(today.getDate() + 1);

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -322,8 +322,9 @@
                         // Validate that the selected date is not in the past before submitting.
                         if (!dc.isSelectedDateInPast(dc.formDisplayData['conclude_date'])) {
                             var formatted_date = $filter('date')(new Date(dc.formDisplayData['conclude_date']), 'yyyy-MM-dd', 'Z');
-                            formatted_date += 'T00:01:00Z';
+                            formatted_date += 'T05:01:00Z';
                             patchData['conclude_date'] = formatted_date;
+                            console.log(patchData);
                         }
                     } else {
                         // If the conclude date field is left blank, then set the conclude_date to null in the DB.
@@ -335,6 +336,8 @@
                     patchData[field] = dc.formDisplayData[field];
                 }
             });
+            console.log(url);
+
             $http.patch(url, patchData)
                 .then(function finalizeCourseDetailsPatch(response) {
                     // update form data so reset button will pick up changes
@@ -365,13 +368,15 @@
 
         dc.init();
 
-        // Checks if the given date is prior to today's date.
+        // Checks if the given date is prior to tomorrow's date(today's date plus 1).
         dc.isSelectedDateInPast = function(selectedDate) {
             // Since the input field is a string representation of a date,
             // we need to convert today's date to the same format as a string to make the comparison.
             var today = new Date();
-            var todayString = (today.getMonth() + 1) + '/' + today.getDate() + '/' +  today.getFullYear();
-            return Date.parse(selectedDate)-Date.parse(todayString)<0;
+            var tomorrow = new Date();
+            tomorrow.setDate(today.getDate() + 1);
+            var tmrwString = (tomorrow.getMonth() + 1) + '/' + tomorrow.getDate() + '/' +  tomorrow.getFullYear();
+            return Date.parse(selectedDate)-Date.parse(tmrwString)<0;
         }
     }
 })();

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -630,7 +630,7 @@
 
                 // Only begin the update call process if the selected date differs from the original value
                 if (selectedDate != previousValue) {
-                    // We only accept dates from today onward
+                    // We only accept dates from tomorrow onward
                     if ($scope.isSelectedDateInPast(selectedDate)) {
                         // Set a .1 second delay before displaying error message.
                         // When the datepicker is closed, it creates a click event which would close this display
@@ -705,18 +705,20 @@
         $scope.formatConcludeDate = function(date) {
             var concludeDate = null;
             if (date) {
-                concludeDate = $filter('date')(new Date(date), 'yyyy-MM-dd', 'Z')+'T00:01:00Z';
+                concludeDate = $filter('date')(new Date(date), 'yyyy-MM-dd', 'Z')+'T05:01:00Z';
             }
             return concludeDate;
         };
 
-        // Checks if the given date is prior to today's date.
+        // Checks if the given date is prior to tomorrow's date(today's date plus 1).
         $scope.isSelectedDateInPast = function(selectedDate) {
             // Since the input field is a string representation of a date,
-            // we need to convert today's date to the same format as a string to make the comparison.
+            // we need to convert tomorrow's date to the same format as a string to make the comparison.
             var today = new Date();
-            var todayString = (today.getMonth() + 1) + '/' + today.getDate() + '/' +  today.getFullYear();
-            return Date.parse(selectedDate)-Date.parse(todayString)<0;
+            var tomorrow = new Date();
+            tomorrow.setDate(today.getDate() + 1);
+            var tmrwString = (tomorrow.getMonth() + 1) + '/' + tomorrow.getDate() + '/' +  tomorrow.getFullYear();
+            return Date.parse(selectedDate)-Date.parse(tmrwString)<0;
         };
 
         // Perform the PATCH with the given user ID, role_id, conclude_date

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -701,11 +701,12 @@
             $('#'+divID).html($compile(angular.element(cal_button))($scope));
         };
 
-        // Converts the mm/dd/yyyy date to a yyyy-MM-ddT00:00:01:00Z format
+        // Converts the mm/dd/yyyy date to a 12:01, ISO format
         $scope.formatConcludeDate = function(date) {
             var concludeDate = null;
             if (date) {
-                concludeDate = $filter('date')(new Date(date), 'yyyy-MM-dd', 'Z')+'T05:01:00Z';
+                date = date+ ' 00:01:00'
+                concludeDate = new Date(date).toISOString();
             }
             return concludeDate;
         };


### PR DESCRIPTION
1. Modified  CAAT's course search screen and the people tab (both of which have conclude date widgets)  to save tomorrow's date and the validation is fixed.
2. Also fixed the formatting in order to save  12:01Am of current date. But this is in UTC(which is correct) , we would also need to modify the DB columns to reflect timezones. Creating a new story to fix the database columns (more info in the Jira ticket) 
[Deployed on qa, testable on canvas.devops]

Depends on: https://github.com/Harvard-University-iCommons/icommons_rest_api/pull/137

