### PR TITLE
Adjust the course code element width

### DIFF
--- a/canvas_site_creator/static/canvas_site_creator/css/app.css
+++ b/canvas_site_creator/static/canvas_site_creator/css/app.css
@@ -28,7 +28,7 @@
    combines with #course-code-type to form an input group inside
    #course-code-input-group container */
 #course-code {
-    width: 88%;
+    width: 82%;
 }
 
 /* container for #course-code and #course-code-type to form an input group */
@@ -40,7 +40,7 @@
    combines with #course-code to form an input group inside
    #course-code-input-group container */
 #course-code-type {
-    width: 12%;
+    width: 18%;
 }
 
 #courseSelectionDT .remove-selection {


### PR DESCRIPTION
Adjusted so that the issue in https://jira.huit.harvard.edu/browse/TLT-3884 is not happening when window size is small
![image](https://user-images.githubusercontent.com/1084105/90926495-3a07bb80-e3c1-11ea-949e-dd91110e7f35.png)


Deployed on dev and tested on Chrome, Safari and FF:
https://canvas.dev.tlt.harvard.edu/accounts/10/external_tools/2
