### PR TITLE
TLT-3878 If course group does not exist when creating a course, create course group

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -17,7 +17,7 @@ django-storages==1.7.2
 rq==1.1.0
 django-rq==2.1.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v2.1#egg=django-canvas-course-site-wizard==2.1
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@task/thornton/tlt-3878/create_coursegroup_if_dne#egg=django-canvas-course-site-wizard==ask/thornton/tlt-3878/create_coursegroup_if_dne
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.0.1#egg=django-auth-lti==2.0.1
 

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -17,7 +17,7 @@ django-storages==1.7.2
 rq==1.1.0
 django-rq==2.1.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@task/thornton/tlt-3878/create_coursegroup_if_dne#egg=django-canvas-course-site-wizard==ask/thornton/tlt-3878/create_coursegroup_if_dne
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v2.2#egg=django-canvas-course-site-wizard==2.2
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.0.1#egg=django-auth-lti==2.0.1
 


### PR DESCRIPTION
TLT-3878
When creating a course site via the admin console, this check will see if a course group exists and if not, create it prior to creating the course