### PR TITLE
Added search_courses permission

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==2.2.14
+Django==2.2.20
 cx-Oracle==7.2.2
 boto== 2.49.0
 boto3==1.9.210
@@ -11,7 +11,7 @@ django-cached-authentication-middleware==0.2.2
 
 django-proxy==1.2.1
 django-redis-cache==2.0.0
-djangorestframework==3.10.2
+djangorestframework==3.11.2
 django-storages==1.7.2
 
 rq==1.1.0

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -396,15 +396,14 @@ ICOMMONS_REST_API_TOKEN = SECURE_SETTINGS.get('icommons_rest_api_token')
 ICOMMONS_REST_API_SKIP_CERT_VERIFICATION = False
 
 PERMISSION_ACCOUNT_ADMIN_TOOLS = 'account_admin_tools'
+PERMISSION_SEARCH_COURSES = 'search_courses'  # aka course_info
 PERMISSION_PEOPLE_TOOL = 'people_tool'
 PERMISSION_XLIST_TOOL = 'cross_listing'
 PERMISSION_SITE_CREATOR = 'manage_courses'
 PERMISSION_PUBLISH_COURSES = 'publish_courses'
 PERMISSION_BULK_COURSE_SETTING = 'bulk_course_settings'
 PERMISSION_CANVAS_SITE_DELETION = 'canvas_site_deletion'
-PERMISSION_MASQUERADE_TOOL='masquerade_tool'
-
-
+PERMISSION_MASQUERADE_TOOL = 'masquerade_tool'
 
 # in search courses, when you add a person to a course. This list
 # controls which roles show up in the drop down. The list contains
@@ -438,22 +437,22 @@ CANVAS_EMAIL_NOTIFICATION = {
     'from_email_address': 'icommons-bounces@harvard.edu',
     'support_email_address': 'tlt_support@harvard.edu',
     'course_migration_success_subject': 'Course site is ready',
-    'course_migration_success_body': 'Success! \nYour new Canvas course site has been created and is ready for you at:\n'+
+    'course_migration_success_body': 'Success! \nYour new Canvas course site has been created and is ready for you at:\n' +
             ' {0} \n\n Here are some resources for getting started with your site:\n http://tlt.harvard.edu/getting-started#teachingstaff',
 
     'course_migration_failure_subject': 'Course site not created',
-    'course_migration_failure_body': 'There was a problem creating your course site in Canvas.\n'+
-            'Your local academic support staff has been notified and will be in touch with you.\n\n'+
-            'If you have questions please contact them at:\n'+
-            ' FAS: atg@fas.harvard.edu\n'+
-            ' DCE/Summer: AcademicTechnology@dce.harvard.edu\n'+
+    'course_migration_failure_body': 'There was a problem creating your course site in Canvas.\n' +
+            'Your local academic support staff has been notified and will be in touch with you.\n\n' +
+            'If you have questions please contact them at:\n' +
+            ' FAS: atg@fas.harvard.edu\n' +
+            ' DCE/Summer: AcademicTechnology@dce.harvard.edu\n' +
             ' (Let them know that course site creation failed for sis_course_id: {0} ',
 
     'support_email_subject_on_failure': 'Course site not created',
-    'support_email_body_on_failure': 'There was a problem creating a course site in Canvas via the wizard.\n\n'+
-            'Course site creation failed for sis_course_id: {0}\n'+
-            'User: {1}\n'+
-            '{2}\n'+
+    'support_email_body_on_failure': 'There was a problem creating a course site in Canvas via the wizard.\n\n' +
+            'Course site creation failed for sis_course_id: {0}\n' +
+            'User: {1}\n' +
+            '{2}\n' +
             'Environment: {3}\n',
     'environment': ENV_NAME.capitalize(),
 }

--- a/canvas_account_admin_tools/templates/canvas_account_admin_tools/dashboard_account.html
+++ b/canvas_account_admin_tools/templates/canvas_account_admin_tools/dashboard_account.html
@@ -40,7 +40,7 @@
           </div>
         </a>
       </div>
-    {% endif search_courses_allowed %}
+    {% endif %}
 
     {% if people_tool_allowed %}
         <div class="card card_color">

--- a/canvas_account_admin_tools/templates/canvas_account_admin_tools/dashboard_account.html
+++ b/canvas_account_admin_tools/templates/canvas_account_admin_tools/dashboard_account.html
@@ -14,31 +14,33 @@
       </nav>
     </header>
 
-    <div class="card card_color">
-      <a href="{% url 'course_info:index' %}" id="course-roster">
-        <div class="card-body">
-          <div class="card-header card-header_color5">
-          </div>
-          <div class="card-content card-content_normal">
-            <div class="card-content-width">
-              <div class="card-content-icon">
-                <i class="fa fa-search icon-size"></i>
-              </div>
-              <div class="card-content-data">
-                <h2 class="card-content-title ellipsis" title="Search Courses">
-                  <span class="content-link">
-                    Search Courses
-                  </span>
-                </h2>
-                <p title="Search Courses">
-                  Find courses in order to add people or edit course details
-                </p>
+    {% if search_courses_allowed %}
+      <div class="card card_color">
+        <a href="{% url 'course_info:index' %}" id="course-info">
+          <div class="card-body">
+            <div class="card-header card-header_color5">
+            </div>
+            <div class="card-content card-content_normal">
+              <div class="card-content-width">
+                <div class="card-content-icon">
+                  <i class="fa fa-search icon-size"></i>
+                </div>
+                <div class="card-content-data">
+                  <h2 class="card-content-title ellipsis" title="Search Courses">
+                    <span class="content-link">
+                      Search Courses
+                    </span>
+                  </h2>
+                  <p title="Search Courses">
+                    Find courses in order to add people or edit course details
+                  </p>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </a>
-    </div>
+        </a>
+      </div>
+    {% endif search_courses_allowed %}
 
     {% if people_tool_allowed %}
         <div class="card card_color">
@@ -220,5 +222,3 @@
     {% endif %}
 
 {% endblock content %}
-
-

--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -1,23 +1,23 @@
 import json
 import logging
 import os
-import urllib.request, urllib.parse, urllib.error
+import urllib.error
 import urllib.parse
+import urllib.request
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.urls import reverse
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
+from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
-from lti import ToolConfig
-from proxy.views import proxy_view
-
 from django_auth_lti import const
 from django_auth_lti.decorators import lti_role_required
+from lti import ToolConfig
 from lti_permissions.decorators import lti_permission_required
 from lti_permissions.verification import is_allowed
+from proxy.views import proxy_view
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +88,16 @@ def dashboard_account(request):
     custom_canvas_membership_roles = request.LTI['custom_canvas_membership_roles']
 
     """
-    Verify that the curernt user has permission to see the cross listing button
+    Verify that the current user has permission to see the Search Courses (aka course_info) tool
+    """
+    search_courses_allowed = is_allowed(
+        custom_canvas_membership_roles,
+        settings.PERMISSION_SEARCH_COURSES,
+        canvas_account_sis_id=custom_canvas_account_sis_id
+    )
+
+    """
+    Verify that the current user has permission to see the cross listing button
     on the dashboard TLT-2569
     """
     cross_listing_is_allowed = is_allowed(custom_canvas_membership_roles,
@@ -133,18 +142,18 @@ def dashboard_account(request):
         verify that user has permissions to view the masquerade tool
         """
     masquerade_tool_is_allowed = is_allowed(custom_canvas_membership_roles,
-                                                 settings.PERMISSION_MASQUERADE_TOOL,
-                                                 canvas_account_sis_id=custom_canvas_account_sis_id)
+                                            settings.PERMISSION_MASQUERADE_TOOL,
+                                            canvas_account_sis_id=custom_canvas_account_sis_id)
 
     return render(request, 'canvas_account_admin_tools/dashboard_account.html', {
+        'search_courses_allowed': search_courses_allowed,
         'cross_listing_allowed': cross_listing_is_allowed,
         'people_tool_allowed': people_tool_is_allowed,
-        'site_creator_is_allowed':site_creator_is_allowed,
-        'publish_courses_allowed':publish_courses_allowed,
+        'site_creator_is_allowed': site_creator_is_allowed,
+        'publish_courses_allowed': publish_courses_allowed,
         'bulk_course_settings_is_allowed': bulk_course_settings_is_allowed,
         'canvas_site_deletion_is_allowed': canvas_site_deletion_is_allowed,
         'masquerade_tool_is_allowed': masquerade_tool_is_allowed,
-
     })
 
 

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @login_required
 @lti_role_required(const.ADMINISTRATOR)
-@lti_permission_required(settings.PERMISSION_ACCOUNT_ADMIN_TOOLS)
+@lti_permission_required(settings.PERMISSION_SEARCH_COURSES)
 @require_http_methods(['GET'])
 def index(request):
     canvas_user_id = request.LTI['custom_canvas_user_id']
@@ -36,7 +36,7 @@ def index(request):
 
 @login_required
 @lti_role_required(const.ADMINISTRATOR)
-@lti_permission_required(settings.PERMISSION_ACCOUNT_ADMIN_TOOLS)
+@lti_permission_required(settings.PERMISSION_SEARCH_COURSES)
 @require_http_methods(['GET'])
 def partials(request, path):
     return render(request, 'course_info/partials/' + path, {})
@@ -44,7 +44,7 @@ def partials(request, path):
 
 @login_required
 @lti_role_required(const.ADMINISTRATOR)
-@lti_permission_required(settings.PERMISSION_ACCOUNT_ADMIN_TOOLS)
+@lti_permission_required(settings.PERMISSION_SEARCH_COURSES)
 @require_http_methods(['GET'])
 def clear_sis_id(request, canvas_course_id):
     return HttpResponse(clear_course_sis_id(canvas_course_id))
@@ -62,10 +62,10 @@ def _get_canvas_roles():
         user_roles = UserRole.objects.filter(pk__in=settings.ADD_PEOPLE_TO_COURSE_ALLOWED_ROLES_LIST)
         for role in user_roles:
             label = canvas_roles[role.canvas_role_id]['label']
-            roles.append({'roleId': role.role_id,'roleName': label})
+            roles.append({'roleId': role.role_id, 'roleName': label})
     except CanvasAPIError:
         logger.exception("Failed to retrieve roles for the root account from Canvas API")
-    except:
+    except Exception:
         logger.exception("Unhandled exception in _get_canvas_roles; aborting.")
 
     roles.sort(key=lambda x: x['roleName'])


### PR DESCRIPTION
This PR adds a custom permission setting `search_courses` to control visibility of the Search Courses dashboard card, and to control access to the views in the `course_info` tool. 

This enables us to grant access to the dashboard itself without also granting access to any specific tools. 

Resolves TLT-4000. 