### PR TITLE
TLT-4033: Allow Canvas Site Creator to ignore courses that are set to be synced to canvas

### DIFF
--- a/canvas_site_creator/api.py
+++ b/canvas_site_creator/api.py
@@ -352,9 +352,8 @@ def course_instances(request, sis_term_id, sis_account_id):
         order_by_operator = '-' if sort_dir == 'desc' else ''
         query_set = query_set.order_by(order_by_operator + COURSE_INSTANCE_DATA_FIELDS[sort_index])
 
-        # fixes TLT-1570 where courses that already have a Canvas course were showing up
-        # in the create list
-        query_set = query_set.exclude(sync_to_canvas=1)
+        # Exclude courses that are automatically fed to Canvas and already have a Canvas site
+        query_set = query_set.exclude(sync_to_canvas=1).exclude(canvas_course_id__isnull=False)
         result = get_course_instance_summary_data(query_set)
 
         data = []

--- a/canvas_site_creator/api.py
+++ b/canvas_site_creator/api.py
@@ -354,8 +354,7 @@ def course_instances(request, sis_term_id, sis_account_id):
 
         # fixes TLT-1570 where courses that already have a Canvas course were showing up
         # in the create list
-        query_set = query_set.exclude(canvas_course_id__isnull=False)
-
+        query_set = query_set.exclude(sync_to_canvas=1)
         result = get_course_instance_summary_data(query_set)
 
         data = []

--- a/canvas_site_creator/models.py
+++ b/canvas_site_creator/models.py
@@ -24,6 +24,7 @@ def get_course_instance_query_set(sis_term_id, sis_account_id):
 def get_course_instance_summary_data(query_set):
     total_count = query_set.count()
 
+    # get total count, isites count, and external count for CIs without a Canvas site
     query_set_without_canvas_site = query_set.filter(canvas_course_id__isnull=True)
     total_without_canvas_site_count = query_set_without_canvas_site.count()
     total_without_canvas_site_with_isites_count = query_set_without_canvas_site.filter(
@@ -33,6 +34,18 @@ def get_course_instance_summary_data(query_set):
         sitemap__course_site__site_type_id='external'
     ).exclude(sitemap__course_site__external_id__icontains=settings.CANVAS_URL).count()
 
+    # get total count, iSites count, and external count for CIs without a Canvas site AND
+    # with the sync_to_canvas flag set to 0
+    query_set_without_canvas_site_and_sync_to_canvas_false = query_set_without_canvas_site.filter(sync_to_canvas=0)
+    total_without_canvas_site_and_sync_to_canvas_false_count = query_set_without_canvas_site_and_sync_to_canvas_false.count()
+    total_without_canvas_site_and_sync_to_canvas_false_with_isites_count = query_set_without_canvas_site_and_sync_to_canvas_false.filter(
+    sitemap__course_site__site_type_id='isite'
+    ).count()
+    total_without_canvas_site_and_sync_to_canvas_false_with_external_count = query_set_without_canvas_site_and_sync_to_canvas_false.filter(
+        sitemap__course_site__site_type_id='external'
+    ).exclude(sitemap__course_site__external_id__icontains=settings.CANVAS_URL).count()
+
+    # get total count, isites count, and external count for CIs with a Canvas site
     query_set_with_canvas_site = query_set.filter(canvas_course_id__isnull=False)
     total_with_canvas_site_count = query_set_with_canvas_site.count()
     total_with_canvas_site_with_isites_count = query_set_with_canvas_site.filter(
@@ -48,6 +61,9 @@ def get_course_instance_summary_data(query_set):
         'recordsTotalWithoutCanvasSite': total_without_canvas_site_count,
         'recordsTotalWithoutCanvasSiteWithISite': total_without_canvas_site_with_isites_count,
         'recordsTotalWithoutCanvasSiteWithExternal': total_without_canvas_site_with_external_count,
+        'recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse': total_without_canvas_site_and_sync_to_canvas_false_count,
+        'recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithISite': total_without_canvas_site_and_sync_to_canvas_false_with_isites_count,
+        'recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithExternal': total_without_canvas_site_and_sync_to_canvas_false_with_external_count,
         'recordsTotalWithCanvasSite': total_with_canvas_site_count,
         'recordsTotalWithCanvasSiteWithISite': total_with_canvas_site_with_isites_count,
         'recordsTotalWithCanvasSiteWithExternal': total_with_canvas_site_with_external_count,

--- a/canvas_site_creator/static/canvas_site_creator/js/models/CourseInstanceModel.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/models/CourseInstanceModel.js
@@ -24,6 +24,9 @@
             self.totalCoursesWithoutCanvasSite= 0;
             self.totalCoursesWithoutCanvasSiteWithISite = 0;
             self.totalCoursesWithoutCanvasSiteWithExternal = 0;
+            self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalse = 0
+            self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithIsite = 0
+            self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithExternal = 0
         };
         self.initSummaryData();
 
@@ -91,6 +94,9 @@
                 self.totalCoursesWithoutCanvasSite = data.recordsTotalWithoutCanvasSite;
                 self.totalCoursesWithoutCanvasSiteWithISite = data.recordsTotalWithoutCanvasSiteWithISite;
                 self.totalCoursesWithoutCanvasSiteWithExternal = data.recordsTotalWithoutCanvasSiteWithExternal;
+                self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalse = data.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse;
+                self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithIsite = data.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithISite;
+                self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithExternal = data.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithExternal;
             }).error(function (data, status, headers, config) {
                 // status == 0 indicates that the request was cancelled,
                 // which means that (a) the user navigated away from the

--- a/canvas_site_creator/templates/canvas_site_creator/course_selection.html
+++ b/canvas_site_creator/templates/canvas_site_creator/course_selection.html
@@ -28,10 +28,10 @@
     <main ng-controller="CourseSelectionController">
         <p>
             <strong>
-                <span id="totalCourses">{{ course_instance_summary.recordsTotalWithoutCanvasSite }}</span>
-                course{{ course_instance_summary.recordsTotalWithoutCanvasSite|pluralize }}
-                ({{ course_instance_summary.recordsTotalWithoutCanvasSiteWithISite }} iSite{{ course_instance_summary.recordsTotalWithoutCanvasSiteWithISite|pluralize }},
-                {{ course_instance_summary.recordsTotalWithoutCanvasSiteWithExternal }} external) without Canvas sites for:
+                <span id="totalCourses">{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse }}</span>
+                course{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse|pluralize }}
+                ({{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithISite }} iSite{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithISite|pluralize }},
+                {{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithExternal }} external) without Canvas sites for:
             </strong>
         </p>
         <p>
@@ -51,7 +51,7 @@
             <form id="createForm" action="{% url 'canvas_site_creator:create_job' %}" method="POST">{% csrf_token %}
                 <h2>
                     <span ng-hide="courseInstanceModel.getSelectedCourseIdsCount()">
-                        {{ course_instance_summary.recordsTotalWithoutCanvasSite }} course{{ course_instance_summary.recordsTotalWithoutCanvasSite|pluralize }}
+                        {{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse }} course{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse|pluralize }}
                     </span>
                     <ng-pluralize count="courseInstanceModel.getSelectedCourseIdsCount()"
                                   when="{'0': '',

--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -81,6 +81,23 @@
                             {% verbatim %}
                             {{ courseInstanceModel.totalCoursesWithoutCanvasSiteWithExternal }} external)
                             {% endverbatim %}
+                            {% comment %} <br>
+                            <button type="button" class="btn btn-link pull-right" id="createSitesButton" ng-disabled="createDisabled()" ng-click="handleCreate($event)" data-href="{% url 'canvas_site_creator:course_selection' %}">Continue</button> {% endcomment %}
+                        </li>
+                        <li>
+                            <ng-pluralize count="courseInstanceModel.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalse"
+                                      when="{'0': '0 courses eligible for creation via Canvas Site Creator ',
+                                             '1': '1 course eligible for creation via Canvas Site Creator ',
+                                             'other': '{} courses eligible for creation via Canvas Site Creator '}">
+                            </ng-pluralize>
+                            (<ng-pluralize count="courseInstanceModel.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithIsite"
+                                      when="{'0': '0 iSites, ',
+                                             '1': '1 iSites, ',
+                                             'other': '{} iSites, '}">
+                            </ng-pluralize>
+                            {% verbatim %}
+                            {{ courseInstanceModel.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithExternal }} external)
+                            {% endverbatim %}
                             <br>
                             <button type="button" class="btn btn-link pull-right" id="createSitesButton" ng-disabled="createDisabled()" ng-click="handleCreate($event)" data-href="{% url 'canvas_site_creator:course_selection' %}">Continue</button>
                         </li>

--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -81,14 +81,12 @@
                             {% verbatim %}
                             {{ courseInstanceModel.totalCoursesWithoutCanvasSiteWithExternal }} external)
                             {% endverbatim %}
-                            {% comment %} <br>
-                            <button type="button" class="btn btn-link pull-right" id="createSitesButton" ng-disabled="createDisabled()" ng-click="handleCreate($event)" data-href="{% url 'canvas_site_creator:course_selection' %}">Continue</button> {% endcomment %}
                         </li>
                         <li>
                             <ng-pluralize count="courseInstanceModel.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalse"
-                                      when="{'0': '0 courses eligible for creation via Canvas Site Creator ',
-                                             '1': '1 course eligible for creation via Canvas Site Creator ',
-                                             'other': '{} courses eligible for creation via Canvas Site Creator '}">
+                                      when="{'0': '0 courses eligible for site creation via Canvas Site Creator ',
+                                             '1': '1 course eligible for site creation via Canvas Site Creator ',
+                                             'other': '{} courses eligible for site creation via Canvas Site Creator '}">
                             </ng-pluralize>
                             (<ng-pluralize count="courseInstanceModel.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithIsite"
                                       when="{'0': '0 iSites, ',

--- a/canvas_site_creator/views.py
+++ b/canvas_site_creator/views.py
@@ -318,8 +318,10 @@ def create_job(request):
         else:
             account = filters['school']
 
-        # Retrieve all course instances for the given term and account that do not have Canvas course sites.
-        ci_query_set_without_canvas = get_course_instance_query_set(term, account).filter(canvas_course_id__isnull=True)
+        # Retrieve all course instances for the given term and account that do not have Canvas course sites
+        # nor are set to be fed into Canvas via the automated feed
+        ci_query_set_without_canvas = get_course_instance_query_set(term, account).filter(
+            canvas_course_id__isnull=True, sync_to_canvas=0)
 
         # Iterate through the query set to build a list of all the course instance id's
         # for a school/course_group/department, which course sites will be created for.


### PR DESCRIPTION
This PR works to resolve a bug where creating a course via Canvas Site Creator (within CAAT) could occasionally return an unexpected error due to potential clashing with the background async Canvas feed process. A more detailed description of this bug can be found in the associated [JIRA ticket](https://jira.huit.harvard.edu/browse/TLT-4033).

To resolve this issue, the following updates were made:

- Set the `create_job` view to exclude courses from its query where `sync_to_canvas=1` in the case that "Create All" is `True` (i.e. the user has not selected specific courses from the selection menu; they want sites created for all listed courses)(9342bbc). The logic associated with the other scenario (i.e. the user selects just a subset of listed courses) did not need updating.
- Ensure that the courses listed in the course selection menu are only those that are not set to be synced to Canvas (db query update in 87c52ae; template update in 22e4309)
- Within the `index` template, add an additional bullet that lists how many courses without a Canvas site are eligible for site creation via Canvas Site Creator (e.g. "7 courses eligible for site creation via Canvas Site Creator (0 iSites, 0 external)") (template update in 22e4309; Django model update in e45a056; Angular CourseInstanceModel update in a1f05e7).

I tested these changes locally within QA using [this sub-account](https://canvas.qa.tlt.harvard.edu/accounts/11) (nothing special here; it was a fairly arbitrary choice to use this sub-account). Most recent courses already have Canvas sites (as expected), so you'll need to set "Academic Term" to an earlier date to find courses without sites (I generally used "2020 Fall / Full Term").