### PR TITLE
TLT-3609: Disable ability to associate sites with secondarily-crosslisted courses

### DIFF
--- a/course_info/static/course_info/js/controllers/SitesController.js
+++ b/course_info/static/course_info/js/controllers/SitesController.js
@@ -244,6 +244,11 @@
             sc.courseInstance['members'] = response.data.count;
         };
 
+        sc.isPrimaryCourse = function() {
+            return (sc.courseInstance.xlist_status &&
+                sc.courseInstance.xlist_status === 'Primary')
+        }
+
         sc.isCourseInstanceEditable = function(courseRegistrarCode) {
             // TLT-2376: sandbox and ILE courses are editable, and are
             // identified by their course (registrar) code

--- a/course_info/templates/course_info/partials/sites.html
+++ b/course_info/templates/course_info/partials/sites.html
@@ -95,7 +95,7 @@
             </div>
             <hr>
         </div>
-        <div class="form-group">
+        <div class="form-group" ng-if="sc.isPrimaryCourse()">
           <div class="col-sm-8 col-sm-offset-1">
             <label class="sr-only" for="newAssociatedCourseURL">
               New associated course URL
@@ -124,6 +124,11 @@
               </span>
             </button>
           </div>
+        </div>
+        <div ng-if="!sc.isPrimaryCourse()">
+          <span>
+            <strong>Sites cannot be associated with secondarily-crosslisted courses.</strong>
+          </span>
         </div>
         <div class="form-group"
              ng-if="sc.alertPresent('form', 'siteOperationFailed')">


### PR DESCRIPTION
Resolves [TLT-3609](https://jira.huit.harvard.edu/browse/TLT-3609).

This has been deployed to dev and can be tested by searching for any primary/secondary crosslisted course within the Search Courses tool and clicking the "Associated Site" tab for a given course. See [this](https://canvas-account-admin-tools.dev.tlt.harvard.edu/course_info/?resource_link_id=ca122ea3b565b2faf8882c3e1da0ddf02973672a#/sites/424656) for an example of a primary crosslisted course (the option to associate a site with the course is still there) and [this](https://canvas-account-admin-tools.dev.tlt.harvard.edu/course_info/?resource_link_id=ca122ea3b565b2faf8882c3e1da0ddf02973672a#/sites/442354) for a secondary crosslisted course (users can no longer associate a new site).