### PR TITLE
TLT-4093 (fix) Log masquerade tool errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ selenium_tests/reports/
 sqlnet.log
 parameters.*
 secure.*
+.venv/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-build:v0.3 as build
+FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-build:v0.4 as build
 COPY canvas_account_admin_tools/requirements/*.txt /code/
 RUN --mount=type=ssh,id=build_ssh_key ./python_venv/bin/pip3 install gunicorn && ./python_venv/bin/pip3 install -r aws.txt
 COPY . /code/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Canvas Account Admin Tools
 
-This project provides a collection of tools used to administer Harvard TLT's instance of Canvas at the account level.
+This project provides a collection of tools used to administer courses, users, and other resources in Harvard Academic Technology's instance of Canvas at the sub-account level.
+
+
+# Releasing
+
+1. **Container Image:** Ensure there is an image in [tlt-nonprod ECR](https://console.aws.amazon.com/ecr/repositories/private/482956169056/uw/canvas-account-admin?region=us-east-1) for the version you want to deploy (e.g. `latest`, commit, branch, tag).
+
+    If the image doesn't already exist, you can kick off a build like so (in tlt-nonprod account):
+    ```sh
+    aws codebuild start-build --project-name uw-canvas-account-admin-image-build --source-version <git-ref>
+    ```
+
+2. **ECS Service:** Deploy the [SSO ECS service stack](https://console.aws.amazon.com/cloudformation/#/stacks?filteringStatus=active&filteringText=uw-canvas-account-admin-tools-ecs-service&viewNested=true&hideStacks=false) with the latest version of [at-cfn-templates/at-generic-django-docker-ecs-service.yaml](https://github.huit.harvard.edu/HUIT/at-cfn-templates/blob/master/at-generic-django-docker-ecs-service.yaml)
+    * `ImageTagParameter` should be the version you want to deploy (see Container Image step, above)
+    * `WeekdayScheduleParameter` should be `true` for non-prod environments, or `false` (default) for prod


### PR DESCRIPTION
Improves error handling for the temporary masquerade tool so that users see our user-facing error page and more information is logged about the cause of the error.

# Original issue

During the initial deploy of CAAT as an ECS service we noticed that there were permissions missing, but our logs were not showing the expect log messages. This was due to the following issue, where the lookup of “status” in the payload fails but we were running into another error in the exception handler:

```
/code/masquerade_tool/views.py in add_role
    line 57: status = response_payload["status"]

During handling of the above exception ('status'), another exception occurred:

/code/masquerade_tool/views.py in add_role
    line 67: format(request.get('lis_person_name_full', '(list_person_name_full missing from LTI context)')))

AttributeError at /masquerade_tool/add_role/
'WSGIRequest' object has no attribute 'get'
```

# Fixes

- If, as observed in our first prod deployment, there is a problem accessing the lambda, such as an IAM permission failure, the user will now see the error page and we'll log the issue ([example logs](https://harvard.splunkcloud.com/en-US/app/at_general/search?q=search%20source%3D%22django-canvas_account_admin_tools%22%20%7C%20spath%20env%20%7C%20search%20env%3D%22qa%22%20%7C%20spath%20pathname%20%7C%20search%20pathname%3D%22%2Fcode%2Fmasquerade_tool%2Fviews.py%22&earliest=1637695994.565&latest=1637696004.566&display.page.search.mode=fast&dispatch.sample_ratio=1&sid=1637696072.185268_C792FD5F-93AD-498E-9E97-43080375E59C)). (This was tested by temporarily removing the [uw-lambda-masquerade-execute-policy policy](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::482956169056:policy/uw-lambda-masquerade-execute-policy) from the [uw-canvas-account-admin-ecs-task-role-qa role](https://console.aws.amazon.com/iam/home#/roles/uw-canvas-account-admin-ecs-task-role-qa).)
- If there is an error that is handled by the lambda and it returns a 200 OK with a response payload that contains no status, like in the case of the temporary masquerade function getting a 403 VPN-only when attempting to contact canvas.qa.tlt.harvard.edu (because it was not originally connected to our VPC), the user will now see the error page and we'll log the issue ([example logs](https://harvard.splunkcloud.com/en-US/app/at_general/search?q=search%20source%3D%22django-canvas_account_admin_tools%22%20%7C%20spath%20env%20%7C%20search%20env%3D%22qa%22%20%7C%20spath%20pathname%20%7C%20search%20pathname%3D%22%2Fcode%2Fmasquerade_tool%2Fviews.py%22&earliest=1637693311.973&latest=1637693321.974&display.page.search.mode=fast&dispatch.sample_ratio=1&sid=1637693978.185020_C792FD5F-93AD-498E-9E97-43080375E59C)). (For an example of this behavior on the temporary masquerade function side, see [example lambda logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Ftemporary-masquerade-qa-TemporaryMasqueradeFunctio-SJ32BO731B2Q/log-events/2021$252F11$252F23$252F$255B$2524LATEST$255Dd383fca284d64450845e9b3d87cad2e5).)

