### PR TITLE
changes for tlt-4151. Pull in new dccsw

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -32,7 +32,7 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v
 
 hiredis==1.0.0
 kitchen==1.2.4
-psycopg2==2.8.6
+psycopg2-binary==2.8.4
 redis==3.3.8
 
 requests==2.26.0

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -20,7 +20,7 @@ django-rq==2.1.0
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.5#egg=django-icommons-common[async_operations]==2.5
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@task/sapnamysore/tlt-4151/update-xlist-record#egg=django-canvas-course-site-wizard==2.2.4
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v2.2.4#egg=django-canvas-course-site-wizard==2.2.4
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.0.1#egg=django-auth-lti==2.0.1
 

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -20,7 +20,7 @@ django-rq==2.1.0
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.5#egg=django-icommons-common[async_operations]==2.5
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v2.2.3#egg=django-canvas-course-site-wizard==2.2.3
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@task/sapnamysore/tlt-4151/update-xlist-record#egg=django-canvas-course-site-wizard==2.2.4
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.0.1#egg=django-auth-lti==2.0.1
 

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -32,7 +32,7 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v
 
 hiredis==1.0.0
 kitchen==1.2.4
-psycopg2==2.7.4
+psycopg2==2.8.6
 redis==3.3.8
 
 requests==2.26.0


### PR DESCRIPTION
This PR ups the dccsw version. 

Dependent on https://github.com/Harvard-University-iCommons/django-canvas-course-site-wizard/pull/122 being merged and a new release created.  
Will  replace 'task/sapnamysore/tlt-4151/update-xlist-record' with v2.2.4