### PR TITLE
Hotfix/v3.1.2

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -37,7 +37,7 @@ redis==3.3.8
 urllib3>=1.26
 requests==2.26.0
 simplejson==3.10.0
-git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.3#egg=django-ssm-parameter-store==0.3
+git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6
 
 splunk_handler==3.0.0
 python-json-logger==2.0.2

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==2.2.24
+Django==2.2.28
 cx-Oracle==7.2.2
 boto3==1.18.54
 

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -32,7 +32,7 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v
 
 hiredis==1.0.0
 kitchen==1.2.4
-psycopg2==2.7.4
+psycopg2==2.8.6
 redis==3.3.8
 
 requests==2.26.0

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -34,7 +34,7 @@ hiredis==1.0.0
 kitchen==1.2.4
 psycopg2==2.8.6
 redis==3.3.8
-
+urllib3>=1.26
 requests==2.26.0
 simplejson==3.10.0
 git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.3#egg=django-ssm-parameter-store==0.3

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -325,52 +325,52 @@ LOGGING = {
         },
         'bulk_utilities': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
         'canvas_account_admin_tools': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
         'canvas_course_site_wizard': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
         'canvas_site_creator': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
         'canvas_site_deletion': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
         'masquerade_tool': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
         'course_info': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
         'cross_list_courses': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
         'publish_courses': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
         'bulk_course_settings': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
         'rq.worker': {
@@ -380,7 +380,12 @@ LOGGING = {
         },
         'canvas_sdk': {
             'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['default'],
+            'handlers': ['console', 'default'],
+            'propagate': False,
+        },
+        'django_auth_lti': {
+            'level': logging.ERROR,
+            'handlers': ['console', 'default'],
             'propagate': False,
         },
 

--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 @require_http_methods(['GET'])
 def tool_config(request):
+    logger.debug("called tool_config()")
     url = "https://{}{}".format(request.get_host(), reverse('lti_launch'))
     url = _url(url)
 

--- a/course_info/views.py
+++ b/course_info/views.py
@@ -56,6 +56,7 @@ def _get_canvas_roles():
     create a list in the format the front end wants.
     :return:
     """
+    logger.debug(f"called _get_canvas_roles()")
     roles = []
     try:
         canvas_roles = canvas_api_helpers_roles.get_roles_for_account_id('self')
@@ -69,12 +70,14 @@ def _get_canvas_roles():
         logger.exception("Unhandled exception in _get_canvas_roles; aborting.")
 
     roles.sort(key=lambda x: x['roleName'])
-
+    logger.debug(f"returning roles: {roles}")
     return json.dumps(roles)
 
 
 def _get_schools_context(canvas_user_id):
+    logger.debug(f"called _get_schools_context({canvas_user_id})")
     accounts = get_administered_school_accounts(canvas_user_id)
+    logger.debug(f"found accounts: {accounts}")
     schools = [{
                     'key': 'school',
                     'value': a['sis_account_id'].split(':')[1],
@@ -83,4 +86,5 @@ def _get_schools_context(canvas_user_id):
                     'text': a['name'] + ' <span class="caret"></span>',
                 } for a in accounts]
     schools = sorted(schools, key=lambda s: s['name'].lower())
+    logger.debug(f"returning schools: {schools}")
     return json.dumps(schools)


### PR DESCRIPTION
This hotfix adds some additional logging and wraps an API call in a try/except so that we can handle certain errors more gracefully. 

When fetching the admins for a sub-account, it will skip sub-accounts with IDs that come from other Trust-connected instances.