### PR TITLE
Upgrade to Django 3.2 and bump base image to v3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ parameters.*
 secure.*
 .venv/
 .vscode/
+# files generated via `runserver_plus` CLI command
+*.crt
+*.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:experimental
 
-FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-build:v0.5 as build
+FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-build:v3.10 as build
 COPY canvas_account_admin_tools/requirements/*.txt /code/
-RUN --mount=type=ssh,id=build_ssh_key ./python_venv/bin/pip3 install gunicorn && ./python_venv/bin/pip3 install -r aws.txt
+RUN --mount=type=ssh,id=build_ssh_key ./python_venv/bin/pip install gunicorn && ./python_venv/bin/pip install -r aws.txt
 COPY . /code/
 RUN chmod a+x /code/docker-entrypoint.sh
 
-FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-base:v0.5
+FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-base:v3.10
 COPY --from=build /code /code/
 ENV PYTHONUNBUFFERED 1
 WORKDIR /code

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -18,7 +18,7 @@ django-watchman==1.3.0
 rq==1.10.1
 django-rq==2.5.1
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@patricktonne/django-3.2-upgrade
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v3.0#egg=django-icommons-common==3.0
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v3.0#egg=django-canvas-course-site-wizard==3.0
 

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -1,42 +1,42 @@
-Django==2.2.28
-cx-Oracle==7.2.2
-boto3==1.18.54
+Django==3.2.13
+cx-Oracle==8.3.0
+boto3==1.24.2
 
 # NOTE: jasmine testing relies on a checked-in version of the django-angular js.
 # if you bump the version of django-angular, please also download and check in
 # new copies of django-angular[.min].js.
-django-angular==2.2.1
+django-angular==2.3
 django-cached-authentication-middleware==0.2.2
 
 django-proxy==1.2.1
-django-redis-cache==2.0.0
-djangorestframework==3.11.2
-django-storages==1.7.2
-django-allow-cidr==0.3.1
-django-watchman==1.2.0
+django-redis-cache==3.0.1
+djangorestframework==3.13.1
+django-storages==1.12.3
+django-allow-cidr==0.4.1
+django-watchman==1.3.0
 
-rq==1.1.0
-django-rq==2.1.0
+rq==1.10.1
+django-rq==2.5.1
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.5#egg=django-icommons-common[async_operations]==2.5
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@patricktonne/django-3.2-upgrade
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v2.2.4#egg=django-canvas-course-site-wizard==2.2.4
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v3.0#egg=django-canvas-course-site-wizard==3.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.0.1#egg=django-auth-lti==2.0.1
+git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.0#egg=django-icommons-ui==2.0
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
 
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v1.2.0#egg=canvas-python-sdk==1.2.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v2.0#egg=django-harvardkey-cas==v2.0
+git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0#egg=django-harvardkey-cas==3.0
 
-hiredis==1.0.0
-kitchen==1.2.4
-psycopg2==2.8.6
-redis==3.3.8
+hiredis==2.0.0
+kitchen==1.2.6
+psycopg2==2.9.3
+redis==3.5.3
 urllib3>=1.26
-requests==2.26.0
-simplejson==3.10.0
+requests==2.28.0
+simplejson==3.17.6
 git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6
 
 splunk_handler==3.0.0

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -5,7 +5,7 @@ boto3==1.24.2
 # NOTE: jasmine testing relies on a checked-in version of the django-angular js.
 # if you bump the version of django-angular, please also download and check in
 # new copies of django-angular[.min].js.
-django-angular==2.3
+git+ssh://git@github.com/Harvard-University-iCommons/django-angular.git@v2.3#egg=django-angular==2.3
 django-cached-authentication-middleware==0.2.2
 
 django-proxy==1.2.1

--- a/canvas_account_admin_tools/requirements/local.txt
+++ b/canvas_account_admin_tools/requirements/local.txt
@@ -1,16 +1,17 @@
 # local environment requirements
 
 #includes the base.txt requirements needed in all environments
--r base.txt 
- 
+-r base.txt
+
 # below are requirements specific to the local environment
 
-ddt==1.1.1
-django-debug-toolbar==1.9
-django-sslserver==0.21
+ddt==1.5.0
+django-extensions==3.1.5 # provides `runserver_plus` local dev server
+pyOpenSSL==22.0.0 # dependency for django-extensions
+Werkzeug==2.0.3 # dependency for django-extensions
 
 mock==2.0.0
-pyvirtualdisplay==0.2.1
+pyvirtualdisplay==3.0
 selenium==2.53.0
 xlrd==1.0.0
 

--- a/canvas_account_admin_tools/requirements/local.txt
+++ b/canvas_account_admin_tools/requirements/local.txt
@@ -5,6 +5,7 @@
 
 # below are requirements specific to the local environment
 
+django-debug-toolbar==3.5.0
 ddt==1.5.0
 django-extensions==3.1.5 # provides `runserver_plus` local dev server
 pyOpenSSL==22.0.0 # dependency for django-extensions

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -99,8 +99,6 @@ MIDDLEWARE = [
     'allow_cidr.middleware.AllowCIDRMiddleware'
 ]
 
-FORM_RENDERER = 'djng.forms.renderers.DjangoAngularBootstrap3Templates'
-
 AUTHENTICATION_BACKENDS = [
     'django_auth_lti.backends.LTIAuthBackend',
     'django.contrib.auth.backends.ModelBackend',

--- a/canvas_account_admin_tools/settings/local.py
+++ b/canvas_account_admin_tools/settings/local.py
@@ -14,8 +14,7 @@ CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE
 CANVAS_EMAIL_NOTIFICATION['support_email_address'] = 'tltqaemails@g.harvard.edu'
 
 ALLOWED_HOSTS = ['*']
-INSTALLED_APPS += ['debug_toolbar', 'sslserver']
-MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
+INSTALLED_APPS += ['django_extensions']
 
 # For Django Debug Toolbar:
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)

--- a/canvas_account_admin_tools/settings/local.py
+++ b/canvas_account_admin_tools/settings/local.py
@@ -14,7 +14,8 @@ CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE
 CANVAS_EMAIL_NOTIFICATION['support_email_address'] = 'tltqaemails@g.harvard.edu'
 
 ALLOWED_HOSTS = ['*']
-INSTALLED_APPS += ['django_extensions']
+INSTALLED_APPS += ['debug_toolbar', 'django_extensions']
+MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
 
 # For Django Debug Toolbar:
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-./python_venv/bin/python3 manage.py migrate                  # Apply database migrations
-./python_venv/bin/python3 manage.py collectstatic --noinput  # Collect static files
+./python_venv/bin/python manage.py migrate                  # Apply database migrations
+./python_venv/bin/python manage.py collectstatic --noinput  # Collect static files
 
 # Start Gunicorn processes
 echo Starting Gunicorn.


### PR DESCRIPTION
Resolves [TLT-4240](https://jira.huit.harvard.edu/browse/TLT-4240) and [TLT-4260](https://jira.huit.harvard.edu/browse/TLT-4260).

Depends on https://github.com/Harvard-University-iCommons/django-icommons-common/pull/216.

## Summary
This PR:
- Upgrades the app to Django 3.2.
- Updates the Dockerfile to use `v3.10` of the build and base images.
- Replaces `django-sslserver` with `django-extensions` since the former is incompatible with Django 3.x.
- Uses an updated branch of [django-icommons-common](https://github.com/Harvard-University-iCommons/django-icommons-common/pull/216) that includes minor updates to maintain compatibility with Django 3.2.
- Uses a forked version of [django-angular](https://github.com/Harvard-University-iCommons/django-angular) (for reasons explained below).
- Removes use of `debug_toolbar` from `local.py` (for reasons explained below).

## Resolving incompatibilities with `django-angular` and Django 3.2
After some research, it seems that [django-angular](https://pypi.org/project/django-angular/) does not officially support Django 3.2 (more specifically, any version of Django >3.0). According to [an issue](https://github.com/jrief/django-angular/issues/357#issuecomment-1017560567) on the project's GitHub repo (which I came upon after running into the listed error during the upgrade), this appears to be because the primary project maintainer (and creator?) has since developed a different library ([django-formset](https://github.com/jrief/django-formset)) to serve a similar purpose and [no longer maintains the django-angular project](https://github.com/jrief/django-angular/issues/357#issuecomment-1018053768).

Since the project's no longer maintained, there was an initial goal to find a way to remove uses of this library from the application. While this initially seemed promising, it was later discovered that CAAT's AngularJS frontend relies heavily on the library's middleware component for reversing URLs (e.g. `var URL_LISTS = djangoUrl.reverse('mailing_list:api_lists');`).

So, for now at least, we still need this library to keep things functioning. The next step was to determine if there's a way to continue using this library despite its incompatibility with Django 3.2. Through trial and error, two primary errors were addressed:
- Running the tool locally, `django-angular` raised an error on startup when attempting to render a form by request from `debug_toolbar.middleware.DebugToolbarMiddleware` (see the issue mentioned earlier: https://github.com/jrief/django-angular/issues/357). Stopping use of `debug_toolbar` resolved the error.
- Using the Bulk Course Settings component of CAAT, clicking "Create New Job" raised the same form error as above. To resolve this, I found that removing `FORM_RENDERER = 'djng.forms.renderers.DjangoAngularBootstrap3Templates'` from `base.py` fixed the issue. Note that removing this setting bypasses `django-angular`'s form renderer (which is not compatible with Django 3.2) in favor of Django's default form renderer (note that overriding Django's form renderer is a listed step on the library's [installation guide](https://django-angular.readthedocs.io/en/latest/installation.html#django-1-11)).

The two fixes above (removing `debug_toolbar` to resolve issues when running locally and removing the `FORM_RENDERER` override from `base.py` to resolve the failed rendering of a "Create New Job" form) ultimately resolved all errors.

Note that there was some experimentation to update the forked `django-angular` library itself to determine how easy it would be to resolve some of the Django incompatibilities. Long story short, barring additional time and research, the only clear fix here is to bypass the library's incompatible form renderer via the method above.


### Forking the repo
On a separate note, It was determined in a meeting with Chris that forking the repo would be a good way to ensure we always have a local copy of the code (lest something happens to the original repo), so this particular branch is pointed to a newly-tagged version of the forked repo (`v2.3`). This tag points to the merge commit for `release/2.3` (commit in original source repo here: https://github.com/Harvard-University-iCommons/django-angular/commit/b825b8098863506d34b70ac44d0aebbbc7d1355a).

Oddly enough, the `django-angular` repo did not receive a `2.3` tag (the latest tagged version in the source repo is `2.2.4`: https://github.com/jrief/django-angular/tags), yet PyPI provides a `2.3` version of the library (https://pypi.org/project/django-angular/), presumably containing the changes merged in by the `release/2.3` branch. I'm not sure of the reason for this discrepancy (maybe the maintainer just got lazy near the end?), but it's an interesting thing to note.

## Testing
This branch is currently running on QA. Testing was performed via manual use of each of the project's apps (Search Courses, Search People, etc.).

Example sub-account in QA for testing: https://canvas.qa.tlt.harvard.edu/accounts/11/external_tools/3.


