### PR TITLE
Cross-listing tool: wider primary / secondary course fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ secure.*
 # files generated via `runserver_plus` CLI command
 *.crt
 *.key
+.python-version

--- a/cross_list_courses/templates/add_new.html
+++ b/cross_list_courses/templates/add_new.html
@@ -41,14 +41,14 @@
                 <label  for="primary-course">
                     Primary Course &nbsp;&nbsp;&nbsp;&nbsp;
                 </label>
-                <input  name="primary_course_input" id="primary-course" style="width: 650px;">
+                <input  name="primary_course_input" id="primary-course" style="width: 850px;">
                 </input>
             </div>
             <div class="panel-body ui-widget">
                 <label for="secondary-course">
                     Secondary Course
                 </label>
-                <input  name="secondary_course_input"  id="secondary-course" style="width: 650px;">
+                <input  name="secondary_course_input"  id="secondary-course" style="width: 850px;">
                 </input>
                 <div class="form-group" style="margin-top: 1em; align:center;">
                     <input type="submit" class="btn btn-primary" value="Pair Courses" />

--- a/cross_list_courses/views.py
+++ b/cross_list_courses/views.py
@@ -6,13 +6,15 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.db.models import Q
 from django.http import HttpResponse
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
+from django.utils.text import Truncator
 from django.views.decorators.http import require_http_methods
-
 from django_auth_lti import const
 from django_auth_lti.decorators import lti_role_required
-from icommons_common.models import XlistMap, CsXlistMapOverview, SimplePerson, CourseInstance
+from icommons_common.models import (CourseInstance, CsXlistMapOverview,
+                                    SimplePerson, XlistMap)
 from lti_permissions.decorators import lti_permission_required
+
 from .utils import create_crosslisting_pair, remove_cross_listing
 
 logger = logging.getLogger(__name__)
@@ -123,11 +125,11 @@ def get_ci_data(request):
             course_json = {}
             course_json['id'] = str(course.course_instance_id)
             course_json['label'] = '{}{} {} [{}, {}]'.format(course.title,
-                                                          ': '+course.sub_title[:40]+'...' if course.sub_title else '',
+                                                          ': ' + Truncator(course.sub_title).chars(75) if course.sub_title else '',
                                                           course.section if course.section else '',
                                                           course.term.school_id.upper(), course.term.display_name)
             course_json['value'] = '{}{}{} [{}, {}]'.format(course.course_instance_id, ': '+course.title,
-                                                            ': '+course.sub_title[:40]+'...' if course.sub_title else '',
+                                                            ': ' + Truncator(course.sub_title).chars(75) if course.sub_title else '',
                                                             course.term.school_id.upper(), course.term.display_name)
 
             results.append(course_json)


### PR DESCRIPTION
This PR increases the width of the primary and secondary course fields on the "add new pair" screen, and increases the truncation length of the sub_title field from 40 to 75 characters. 

The code now uses `django.utils.text.Truncator` to perform the truncation which only includes the ellipsis if the string was actually truncated.

Here are a couple of search strings for some HMS courses with longer sub-titles: `su 600m` , `ob 600`.

Closes TLT-4287. 