### PR TITLE
TLT-4291: Associated sites cross-listing bug fix

### DIFF
--- a/course_info/static/course_info/js/controllers/SitesController.js
+++ b/course_info/static/course_info/js/controllers/SitesController.js
@@ -121,7 +121,7 @@
             });
         };
 
-        // todo: this should be a service that can be reused 
+        // todo: this should be a service that can be reused
         sc.fetchCourseInstanceDetails = function (id) {
 
             var course_url = djangoUrl.reverse(sc.apiProxy,
@@ -156,7 +156,7 @@
         // todo: move this into a service/app.js?
         sc.getCourseDescription = function(course) {
             // If a course's title is [NULL], attempt to display the short title
-            // If the short title is also [NULL], display 'Untitled Course' 
+            // If the short title is also [NULL], display 'Untitled Course'
             if(typeof course.title != "undefined" && course.title.trim().length > 0){
                 return course.title;
             }
@@ -244,9 +244,12 @@
             sc.courseInstance['members'] = response.data.count;
         };
 
+        sc.isCrosslisted= function() {
+            return sc.courseInstance.xlist_status !== 'N/A'
+        };
+
         sc.isPrimaryCourse = function() {
-            return (sc.courseInstance.xlist_status &&
-                sc.courseInstance.xlist_status === 'Primary')
+            return sc.courseInstance.xlist_status === 'Primary';
         }
 
         sc.isCourseInstanceEditable = function(courseRegistrarCode) {

--- a/course_info/templates/course_info/partials/sites.html
+++ b/course_info/templates/course_info/partials/sites.html
@@ -95,7 +95,7 @@
             </div>
             <hr>
         </div>
-        <div class="form-group" ng-if="sc.isPrimaryCourse()">
+        <div class="form-group" ng-if="!sc.isCrosslisted() || (sc.isCrosslisted() && sc.isPrimaryCourse())">
           <div class="col-sm-8 col-sm-offset-1">
             <label class="sr-only" for="newAssociatedCourseURL">
               New associated course URL
@@ -125,7 +125,7 @@
             </button>
           </div>
         </div>
-        <div ng-if="!sc.isPrimaryCourse()">
+        <div ng-if="sc.isCrosslisted() && !sc.isPrimaryCourse()">
           <span>
             <strong>Sites cannot be associated with secondarily-crosslisted courses.</strong>
           </span>


### PR DESCRIPTION
Resolves [TLT-4291](https://jira.huit.harvard.edu/browse/TLT-4291).

This PR:
- Fixes an issue where the "Associated Sites" tab on the detail page for non-cross-listed courses would incorrectly read "**Sites cannot be associated with secondarily-crosslisted courses**" and prevent users from cross-listing the course.

### Testing:

This branch has been deployed to QA.

Courses for testing:
- Example QA [non-cross-listed course](https://canvas-account-admin-tools.qa.tlt.harvard.edu/course_info/?resource_link_id=7843b6954605aa973870683495ce30bcf3af7985#/sites/327398) (correctly allows user to cross-list course)
- Example QA [primary course](https://canvas-account-admin-tools.qa.tlt.harvard.edu/course_info/?resource_link_id=7843b6954605aa973870683495ce30bcf3af7985#/sites/424656) (correctly allows user to further cross-list course)
- Example QA [secondary course](https://canvas-account-admin-tools.qa.tlt.harvard.edu/course_info/?resource_link_id=7843b6954605aa973870683495ce30bcf3af7985#/sites/442354) (correctly prevents user from cross-listing course and displays corresponding message)