### PR TITLE
Department/course_group changes for compat. w/REST API changes

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -40,4 +40,4 @@ simplejson==3.17.6
 git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6
 
 splunk_handler==3.0.0
-python-json-logger==2.0.2
+python-json-logger==2.0.4

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -12,7 +12,7 @@ django-proxy==1.2.1
 django-redis-cache==3.0.1
 djangorestframework==3.13.1
 django-storages==1.13.1
-django-allow-cidr==0.5.1
+django-allow-cidr==0.5.0
 django-watchman==1.3.0
 
 rq==1.10.0

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -1,6 +1,6 @@
-Django==3.2.14
+Django==3.2.15
 cx-Oracle==8.3.0
-boto3==1.24.2
+boto3==1.24.66
 
 # NOTE: jasmine testing relies on a checked-in version of the django-angular js.
 # if you bump the version of django-angular, please also download and check in
@@ -11,11 +11,11 @@ django-cached-authentication-middleware==0.2.2
 django-proxy==1.2.1
 django-redis-cache==3.0.1
 djangorestframework==3.13.1
-django-storages==1.12.3
-django-allow-cidr==0.4.1
+django-storages==1.13.1
+django-allow-cidr==0.5.1
 django-watchman==1.3.0
 
-rq==1.10.1
+rq==1.10.0
 django-rq==2.5.1
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v3.0#egg=django-icommons-common==3.0

--- a/canvas_account_admin_tools/settings/local.py
+++ b/canvas_account_admin_tools/settings/local.py
@@ -24,14 +24,16 @@ CANVAS_EMAIL_NOTIFICATION['support_email_address'] = 'tltqaemails@g.harvard.edu'
 
 ALLOWED_HOSTS = ['*']
 INSTALLED_APPS += ['django_extensions']
-# INSTALLED_APPS += ['debug_toolbar']
-# MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
 
-# For Django Debug Toolbar:
+# If you want to use the Django Debug Toolbar, uncomment the following block:
+'''
+INSTALLED_APPS += ['debug_toolbar']
+MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)
 DEBUG_TOOLBAR_CONFIG = {
     'INTERCEPT_REDIRECTS': False,
 }
+'''
 
 # Allows the REST API passthrough to successfully negotiate an SSL session
 # with an unverified certificate, e.g. the one that ships with django-sslserver

--- a/canvas_account_admin_tools/settings/local.py
+++ b/canvas_account_admin_tools/settings/local.py
@@ -134,13 +134,4 @@ SELENIUM_CONFIG = {
    'use_htmlrunner': SECURE_SETTINGS.get('selenium_use_htmlrunner', True),
 }
 
-# Logging
-
-# Log to console instead of a file when running locally
-# LOGGING['handlers']['default'] = {
-#     'level': logging.DEBUG,
-#     'class': 'logging.StreamHandler',
-#     'formatter': 'simple',
-# }
-
 dictConfig(LOGGING)

--- a/canvas_account_admin_tools/settings/local.py
+++ b/canvas_account_admin_tools/settings/local.py
@@ -1,3 +1,12 @@
+import sys
+import oracledb
+oracledb.version = "8.3.0"
+sys.modules["cx_Oracle"] = oracledb
+import cx_Oracle
+
+import urllib3
+urllib3.disable_warnings()
+
 from .base import *
 from logging.config import dictConfig
 
@@ -14,8 +23,9 @@ CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE
 CANVAS_EMAIL_NOTIFICATION['support_email_address'] = 'tltqaemails@g.harvard.edu'
 
 ALLOWED_HOSTS = ['*']
-INSTALLED_APPS += ['debug_toolbar', 'django_extensions']
-MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
+INSTALLED_APPS += ['django_extensions']
+# INSTALLED_APPS += ['debug_toolbar']
+# MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
 
 # For Django Debug Toolbar:
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)
@@ -125,10 +135,10 @@ SELENIUM_CONFIG = {
 # Logging
 
 # Log to console instead of a file when running locally
-LOGGING['handlers']['default'] = {
-    'level': logging.DEBUG,
-    'class': 'logging.StreamHandler',
-    'formatter': 'simple',
-}
+# LOGGING['handlers']['default'] = {
+#     'level': logging.DEBUG,
+#     'class': 'logging.StreamHandler',
+#     'formatter': 'simple',
+# }
 
 dictConfig(LOGGING)

--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -184,4 +184,29 @@ def icommons_rest_api_proxy(request, path):
     url = "{}/{}".format(settings.ICOMMONS_REST_API_HOST, os.path.join(path, ''))
     if settings.ICOMMONS_REST_API_SKIP_CERT_VERIFICATION:
         request_args['verify'] = False
-    return proxy_view(request, url, request_args)
+
+    response = proxy_view(request, url, request_args)
+    try:
+        patch_params = {}
+        if request.method == 'PATCH':
+            patch_params = json.loads(request.body)
+
+        extra = {
+            'user': request.user.username,
+            'path': request.path,
+            'method': request.method,
+            'query_string': request.META.get('QUERY_STRING'),
+            'user_agent': request.META.get('HTTP_USER_AGENT'),
+            'remote_addr': request.META.get('REMOTE_ADDR'),
+            'referrer': request.META.get('HTTP_REFERER'),
+            'status_code': response.status_code,
+            'get_params': request.GET,
+            'post_params': request.POST,
+            'patch_params': patch_params,
+        }
+
+        logger.info(f'User {request.user.username} requesting {request.method} {url}', extra=extra)
+    except Exception:
+        logger.error(f'Error logging request by {request.user.username} to {url}')
+
+    return response

--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -187,9 +187,11 @@ def icommons_rest_api_proxy(request, path):
 
     response = proxy_view(request, url, request_args)
     try:
-        patch_params = {}
+        params = request.GET
         if request.method == 'PATCH':
-            patch_params = json.loads(request.body)
+            params = json.loads(request.body)
+        elif request.method == 'POST':
+            params = json.loads(request.body)
 
         extra = {
             'user': request.user.username,
@@ -200,9 +202,7 @@ def icommons_rest_api_proxy(request, path):
             'remote_addr': request.META.get('REMOTE_ADDR'),
             'referrer': request.META.get('HTTP_REFERER'),
             'status_code': response.status_code,
-            'get_params': request.GET,
-            'post_params': request.POST,
-            'patch_params': patch_params,
+            'params': params,
         }
 
         logger.info(f'User {request.user.username} requesting {request.method} {url}', extra=extra)

--- a/canvas_site_creator/models.py
+++ b/canvas_site_creator/models.py
@@ -14,9 +14,9 @@ def get_course_instance_query_set(sis_term_id, sis_account_id):
     if account_type == 'school':
         filters['course__school'] = account_id
     elif account_type == 'dept':
-        filters['course__departments'] = account_id
+        filters['course__department'] = account_id
     elif account_type == 'coursegroup':
-        filters['course__course_groups'] = account_id
+        filters['course__course_group'] = account_id
 
     return CourseInstance.objects.filter(**filters)
 
@@ -24,33 +24,24 @@ def get_course_instance_query_set(sis_term_id, sis_account_id):
 def get_course_instance_summary_data(query_set):
     total_count = query_set.count()
 
-    # get total count, isites count, and external count for CIs without a Canvas site
+    # get total count and external count for CIs without a Canvas site
     query_set_without_canvas_site = query_set.filter(canvas_course_id__isnull=True)
     total_without_canvas_site_count = query_set_without_canvas_site.count()
-    total_without_canvas_site_with_isites_count = query_set_without_canvas_site.filter(
-        sitemap__course_site__site_type_id='isite'
-    ).count()
     total_without_canvas_site_with_external_count = query_set_without_canvas_site.filter(
         sitemap__course_site__site_type_id='external'
     ).exclude(sitemap__course_site__external_id__icontains=settings.CANVAS_URL).count()
 
-    # get total count, iSites count, and external count for CIs without a Canvas site AND
+    # get total count and external count for CIs without a Canvas site AND
     # with the sync_to_canvas flag set to 0
     query_set_without_canvas_site_and_sync_to_canvas_false = query_set_without_canvas_site.filter(sync_to_canvas=0)
     total_without_canvas_site_and_sync_to_canvas_false_count = query_set_without_canvas_site_and_sync_to_canvas_false.count()
-    total_without_canvas_site_and_sync_to_canvas_false_with_isites_count = query_set_without_canvas_site_and_sync_to_canvas_false.filter(
-    sitemap__course_site__site_type_id='isite'
-    ).count()
     total_without_canvas_site_and_sync_to_canvas_false_with_external_count = query_set_without_canvas_site_and_sync_to_canvas_false.filter(
         sitemap__course_site__site_type_id='external'
     ).exclude(sitemap__course_site__external_id__icontains=settings.CANVAS_URL).count()
 
-    # get total count, isites count, and external count for CIs with a Canvas site
+    # get total count and external count for CIs with a Canvas site
     query_set_with_canvas_site = query_set.filter(canvas_course_id__isnull=False)
     total_with_canvas_site_count = query_set_with_canvas_site.count()
-    total_with_canvas_site_with_isites_count = query_set_with_canvas_site.filter(
-        sitemap__course_site__site_type_id='isite'
-    ).count()
     total_with_canvas_site_with_external_count = query_set_with_canvas_site.filter(
         sitemap__course_site__site_type_id='external'
     ).exclude(sitemap__course_site__external_id__icontains=settings.CANVAS_URL).count()
@@ -59,13 +50,10 @@ def get_course_instance_summary_data(query_set):
         'recordsTotal': total_count,
         'recordsFiltered': total_count,
         'recordsTotalWithoutCanvasSite': total_without_canvas_site_count,
-        'recordsTotalWithoutCanvasSiteWithISite': total_without_canvas_site_with_isites_count,
         'recordsTotalWithoutCanvasSiteWithExternal': total_without_canvas_site_with_external_count,
         'recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse': total_without_canvas_site_and_sync_to_canvas_false_count,
-        'recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithISite': total_without_canvas_site_and_sync_to_canvas_false_with_isites_count,
         'recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithExternal': total_without_canvas_site_and_sync_to_canvas_false_with_external_count,
         'recordsTotalWithCanvasSite': total_with_canvas_site_count,
-        'recordsTotalWithCanvasSiteWithISite': total_with_canvas_site_with_isites_count,
         'recordsTotalWithCanvasSiteWithExternal': total_with_canvas_site_with_external_count,
     }
 

--- a/canvas_site_creator/static/canvas_site_creator/js/controllers/CourseInstanceController.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/controllers/CourseInstanceController.js
@@ -73,8 +73,6 @@
                         $scope.courseInstanceModel.totalCourses = json.recordsTotal;
                         $scope.courseInstanceModel.totalCoursesWithCanvasSite = json.recordsTotalWithCanvasSite;
                         $scope.courseInstanceModel.totalCoursesWithoutCanvasSite = json.recordsTotalWithoutCanvasSite;
-                        $scope.courseInstanceModel.totalCoursesWithISite = json.recordsTotalWithISite;
-                        $scope.courseInstanceModel.totalCoursesWithISiteOfficial = json.recordsTotalWithISiteOfficial;
                         $scope.courseInstanceModel.totalCoursesWithExternalSite = json.recordsTotalExternalSite;
                         $scope.courseInstanceModel.totalCoursesWithExternalSiteOfficial = json.recordsTotalExternalSiteOfficial;
                         $scope.$apply();

--- a/canvas_site_creator/static/canvas_site_creator/js/controllers/CourseInstanceFilterController.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/controllers/CourseInstanceFilterController.js
@@ -22,8 +22,8 @@
                 $scope.courseInstanceFilterModel.filters.department = '';
                 $scope.courseInstanceFilterModel.filters.course_group = '';
                 $scope.courseInstanceFilterModel.terms = [];
-                $scope.courseInstanceFilterModel.departments = [];
-                $scope.courseInstanceFilterModel.course_groups = [];
+                $scope.courseInstanceFilterModel.department = '';
+                $scope.courseInstanceFilterModel.course_group = '';
             }
         };
 

--- a/canvas_site_creator/static/canvas_site_creator/js/models/CourseInstanceModel.js
+++ b/canvas_site_creator/static/canvas_site_creator/js/models/CourseInstanceModel.js
@@ -19,13 +19,10 @@
         self.initSummaryData = function(){
             self.totalCourses= 0;
             self.totalCoursesWithCanvasSite= 0;
-            self.totalCoursesWithCanvasSiteWithISite = 0;
             self.totalCoursesWithCanvasSiteWithExternal = 0;
             self.totalCoursesWithoutCanvasSite= 0;
-            self.totalCoursesWithoutCanvasSiteWithISite = 0;
             self.totalCoursesWithoutCanvasSiteWithExternal = 0;
             self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalse = 0
-            self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithIsite = 0
             self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithExternal = 0
         };
         self.initSummaryData();
@@ -89,13 +86,10 @@
                 self.dataLoaded = true;
                 self.totalCourses = data.recordsTotal;
                 self.totalCoursesWithCanvasSite = data.recordsTotalWithCanvasSite;
-                self.totalCoursesWithCanvasSiteWithISite = data.recordsTotalWithCanvasSiteWithISite;
                 self.totalCoursesWithCanvasSiteWithExternal = data.recordsTotalWithCanvasSiteWithExternal;
                 self.totalCoursesWithoutCanvasSite = data.recordsTotalWithoutCanvasSite;
-                self.totalCoursesWithoutCanvasSiteWithISite = data.recordsTotalWithoutCanvasSiteWithISite;
                 self.totalCoursesWithoutCanvasSiteWithExternal = data.recordsTotalWithoutCanvasSiteWithExternal;
                 self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalse = data.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse;
-                self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithIsite = data.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithISite;
                 self.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithExternal = data.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithExternal;
             }).error(function (data, status, headers, config) {
                 // status == 0 indicates that the request was cancelled,

--- a/canvas_site_creator/templates/canvas_site_creator/course_selection.html
+++ b/canvas_site_creator/templates/canvas_site_creator/course_selection.html
@@ -29,8 +29,7 @@
         <p>
             <strong>
                 <span id="totalCourses">{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse }}</span>
-                course{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse|pluralize }}
-                ({{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithISite }} iSite{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithISite|pluralize }},
+                course{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse|pluralize }},
                 {{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithExternal }} external) without Canvas sites for:
             </strong>
         </p>

--- a/canvas_site_creator/templates/canvas_site_creator/course_selection.html
+++ b/canvas_site_creator/templates/canvas_site_creator/course_selection.html
@@ -29,8 +29,8 @@
         <p>
             <strong>
                 <span id="totalCourses">{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse }}</span>
-                course{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse|pluralize }},
-                {{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithExternal }} external) without Canvas sites for:
+                course{{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalse|pluralize }}
+                ({{ course_instance_summary.recordsTotalWithoutCanvasSiteAndSyncToCanvasFalseWithExternal }} external) without Canvas sites for:
             </strong>
         </p>
         <p>

--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -58,13 +58,8 @@
                                              '1': '1 course with a Canvas site ',
                                              'other': '{} courses with Canvas sites '}">
                             </ng-pluralize>
-                            (<ng-pluralize count="courseInstanceModel.totalCoursesWithCanvasSiteWithISite"
-                                      when="{'0': '0 iSites, ',
-                                             '1': '1 iSites, ',
-                                             'other': '{} iSites, '}">
-                            </ng-pluralize>
                             {% verbatim %}
-                            {{ courseInstanceModel.totalCoursesWithCanvasSiteWithExternal }} external)
+                            ({{ courseInstanceModel.totalCoursesWithCanvasSiteWithExternal }} external)
                             {% endverbatim %}
                         </li>
                         <li>
@@ -73,13 +68,8 @@
                                              '1': '1 course without a Canvas site ',
                                              'other': '{} courses without Canvas sites '}">
                             </ng-pluralize>
-                            (<ng-pluralize count="courseInstanceModel.totalCoursesWithoutCanvasSiteWithISite"
-                                      when="{'0': '0 iSites, ',
-                                             '1': '1 iSites, ',
-                                             'other': '{} iSites, '}">
-                            </ng-pluralize>
                             {% verbatim %}
-                            {{ courseInstanceModel.totalCoursesWithoutCanvasSiteWithExternal }} external)
+                            ({{ courseInstanceModel.totalCoursesWithoutCanvasSiteWithExternal }} external)
                             {% endverbatim %}
                         </li>
                         <li>
@@ -88,13 +78,8 @@
                                              '1': '1 course eligible for site creation via Canvas Site Creator ',
                                              'other': '{} courses eligible for site creation via Canvas Site Creator '}">
                             </ng-pluralize>
-                            (<ng-pluralize count="courseInstanceModel.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithIsite"
-                                      when="{'0': '0 iSites, ',
-                                             '1': '1 iSites, ',
-                                             'other': '{} iSites, '}">
-                            </ng-pluralize>
                             {% verbatim %}
-                            {{ courseInstanceModel.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithExternal }} external)
+                            ({{ courseInstanceModel.totalCoursesWithoutCanvasSiteAndSyncToCanvasFalseWithExternal }} external)
                             {% endverbatim %}
                             <br>
                             <button type="button" class="btn btn-link pull-right" id="createSitesButton" ng-disabled="createDisabled()" ng-click="handleCreate($event)" data-href="{% url 'canvas_site_creator:course_selection' %}">Continue</button>

--- a/course_info/static/course_info/js/controllers/DetailsController.js
+++ b/course_info/static/course_info/js/controllers/DetailsController.js
@@ -102,8 +102,8 @@
                 courseInstance['term_id'] = ci.term.term_id.toString();
                 courseInstance['term_conclude_date'] = $filter('date')(ci.term.conclude_date, 'MM/dd/yyyy', 'Z');
                 courseInstance['year'] = ci.term.academic_year;
-                courseInstance['departments'] = ci.course.departments;
-                courseInstance['course_groups'] = ci.course.course_groups;
+                courseInstance['department'] = ci.course.department ? ci.course.department.name : null;
+                courseInstance['course_group'] = ci.course.course_group ? ci.course.course_group.name : null;
 
                 var registrarCode = ci.course.registrar_code_display
                     ? ci.course.registrar_code_display

--- a/course_info/static/course_info/js/controllers/SitesController.js
+++ b/course_info/static/course_info/js/controllers/SitesController.js
@@ -121,7 +121,7 @@
             });
         };
 
-        // todo: this should be a service that can be reused 
+        // todo: this should be a service that can be reused
         sc.fetchCourseInstanceDetails = function (id) {
 
             var course_url = djangoUrl.reverse(sc.apiProxy,
@@ -156,7 +156,7 @@
         // todo: move this into a service/app.js?
         sc.getCourseDescription = function(course) {
             // If a course's title is [NULL], attempt to display the short title
-            // If the short title is also [NULL], display 'Untitled Course' 
+            // If the short title is also [NULL], display 'Untitled Course'
             if(typeof course.title != "undefined" && course.title.trim().length > 0){
                 return course.title;
             }
@@ -175,8 +175,8 @@
                 courseInstance['school'] = ci.course.school_id.toUpperCase();
                 courseInstance['term'] = ci.term.display_name;
                 courseInstance['year'] = ci.term.academic_year;
-                courseInstance['departments'] = ci.course.departments;
-                courseInstance['course_groups'] = ci.course.course_groups;
+                courseInstance['department'] = ci.course.department ? ci.course.department : null;
+                courseInstance['course_group'] = ci.course.course_group ? ci.course.course_group : null;
 
                 var registrarCode = ci.course.registrar_code_display
                     ? ci.course.registrar_code_display

--- a/course_info/static/course_info/js/controllers/SitesController.js
+++ b/course_info/static/course_info/js/controllers/SitesController.js
@@ -76,6 +76,17 @@
             }
         };
 
+        sc.isCanvasSite = function(siteListIndex) {
+            var rv = false;
+            var s_url = sc.courseInstance.sites[siteListIndex].course_site_url;
+            if (s_url.toLowerCase().includes('canvas.harvard.edu')) {
+                rv = true;
+            } else if (s_url.toLowerCase().includes('harvard.instructure.com')) {
+                rv = true;
+            }
+            return rv;
+        };
+
         sc.dissociateSite = function(siteListIndex) {
             sc.confirmDissociateSiteModalInstance = $uibModal.open({
                 animation: true,

--- a/course_info/templates/course_info/partials/details.html
+++ b/course_info/templates/course_info/partials/details.html
@@ -232,20 +232,20 @@
           label="Meeting time"></hu-editable-input>
 
       <hu-field-label-wrapper
-          is-loading="dc.isUndefined(dc.courseInstance.departments)"
-          field="departments"
-          label="Departments">
-        <div class="row" ng-repeat="dept in dc.courseInstance.departments">
-          <div class="col-sm-12"> {{dept.name}} </div>
+          is-loading="dc.isUndefined(dc.courseInstance.department)"
+          field="department"
+          label="Department">
+        <div class="row">
+          <div class="col-sm-12"> {{dc.courseInstance.department}} </div>
         </div>
       </hu-field-label-wrapper>
 
       <hu-field-label-wrapper
-          is-loading="dc.isUndefined(dc.courseInstance.course_groups)"
-          field="course_groups"
-          label="Course Groups">
-        <div class="row" ng-repeat="group in dc.courseInstance.course_groups">
-          <div class="col-sm-12"> {{group.name}} </div>
+          is-loading="dc.isUndefined(dc.courseInstance.course_group)"
+          field="course_group"
+          label="Course Group">
+        <div class="row">
+          <div class="col-sm-12"> {{dc.courseInstance.course_group}} </div>
         </div>
       </hu-field-label-wrapper>
 

--- a/course_info/templates/course_info/partials/nav-tabs.html
+++ b/course_info/templates/course_info/partials/nav-tabs.html
@@ -229,22 +229,22 @@
 
             <li class="list-group-item">
               <hu-field-label-wrapper
-                  is-loading="dc.isUndefined(dc.courseInstance.departments)"
-                  field="departments"
-                  label="Departments">
-                <div class="row" ng-repeat="dept in dc.courseInstance.departments">
-                  <div class="col-sm-12"> {{dept.name}} </div>
+                  is-loading="dc.isUndefined(dc.courseInstance.department)"
+                  field="department"
+                  label="Department">
+                <div class="row">
+                  <div class="col-sm-12"> {{dc.courseInstance.department.name}} </div>
                 </div>
               </hu-field-label-wrapper>
             </li>
 
             <li class="list-group-item">
               <hu-field-label-wrapper
-                  is-loading="dc.isUndefined(dc.courseInstance.course_groups)"
-                  field="course_groups"
-                  label="Course Groups">
-                <div class="row" ng-repeat="group in dc.courseInstance.course_groups">
-                  <div class="col-sm-12"> {{group.name}} </div>
+                  is-loading="dc.isUndefined(dc.courseInstance.course_group)"
+                  field="course_group"
+                  label="Course Group">
+                <div class="row">
+                  <div class="col-sm-12"> {{dc.courseInstance.course_group.name}} </div>
                 </div>
               </hu-field-label-wrapper>
             </li>

--- a/course_info/templates/course_info/partials/sites.html
+++ b/course_info/templates/course_info/partials/sites.html
@@ -79,7 +79,7 @@
                 {{site.course_site_url}}
               </a>
             </div>
-            <div class="col-sm-3">
+            <div class="col-sm-3" ng-if="!sc.isCanvasSite($index)">
               <button type="button" class="btn btn-default pull-right"
                       ng-click="sc.dissociateSite($index)">
                 <span
@@ -92,6 +92,9 @@
                   Dissociate
                 </span>
               </button>
+            </div>
+            <div class="col-sm-3" ng-if="sc.isCanvasSite($index)">
+              Cannot dissociate a Canvas site - delete it instead.
             </div>
             <hr>
         </div>


### PR DESCRIPTION
This PR includes:
* changes to access course.department rather than course.departments, and course.course_group instead of course.course_groups (to match the way this data is returned by the REST API).
* changes the "departments" course filter to "department" (also to match a change in the API)

This PR also adds detailed logging of the requests that go through the API proxy endpoint. This will create a better record of changes that people make via CAAT tools.

This PR also removes some old  iSites text.