### PR TITLE
Task/sapnamysore/tlt 4277/self enrollment ile

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -32,8 +32,7 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v
 
 hiredis==2.0.0
 kitchen==1.2.6
-#psycopg2==2.9.3
-psycopg2-binary==2.9.3
+psycopg2==2.9.3
 redis==3.5.3
 urllib3>=1.26
 requests==2.28.0

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -32,7 +32,8 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v
 
 hiredis==2.0.0
 kitchen==1.2.6
-psycopg2==2.9.3
+#psycopg2==2.9.3
+psycopg2-binary==2.9.3
 redis==3.5.3
 urllib3>=1.26
 requests==2.28.0

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -508,10 +508,6 @@ MASQUERADE_TOOL_SETTINGS = {
     'masquerade_session_minutes': SECURE_SETTINGS.get('masquerade_session_minutes', 60),
 }
 
-SELF_ENROLLMENT_TOOL_RSETTINGS = {
-    'self_enrolment_tool_url' :  SECURE_SETTINGS.get('self_enrolment_tool_url', 'https://canvas.instructure.com')
-
-}
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -454,7 +454,7 @@ PERMISSION_MASQUERADE_TOOL = 'masquerade_tool'
 ADD_PEOPLE_TO_COURSE_ALLOWED_ROLES_LIST = [0, 1, 2, 5, 6, 7, 9, 10, 11, 12, 14, 15, 16, 18, 19,
                                            20, 22, 23, 24, 25, 26, 27, 28, 400, 401]
 
-SELF_ENROLLMENT_TOOL_ROLES_LIST = SECURE_SETTINGS.get('self_enrollment_roles', ['Student', 'Guest'])
+SELF_ENROLLMENT_TOOL_ROLES_LIST = SECURE_SETTINGS.get('self_enrollment_roles', [0,10,14])
 
 BULK_COURSE_CREATION = {
     'log_long_running_jobs': True,

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -79,6 +79,7 @@ INSTALLED_APPS = [
     'bulk_course_settings',
     'canvas_site_deletion',
     'masquerade_tool',
+    'self_enrollment_tool',
     'rest_framework',
     'watchman'
 ]
@@ -354,6 +355,11 @@ LOGGING = {
             'handlers': ['console', 'default'],
             'propagate': False,
         },
+        'self_enrollment_tool': {
+            'level': _DEFAULT_LOG_LEVEL,
+            'handlers': ['console', 'default'],
+            'propagate': False,
+        },
         'course_info': {
             'level': _DEFAULT_LOG_LEVEL,
             'handlers': ['console', 'default'],
@@ -439,6 +445,7 @@ PERMISSION_SITE_CREATOR = 'manage_courses'
 PERMISSION_PUBLISH_COURSES = 'publish_courses'
 PERMISSION_BULK_COURSE_SETTING = 'bulk_course_settings'
 PERMISSION_CANVAS_SITE_DELETION = 'canvas_site_deletion'
+PERMISSION_SELF_ENROLLMENT_TOOL = 'canvas_site_deletion' # ToDo: fix this by PR to 'self_enrollment_tool'
 PERMISSION_MASQUERADE_TOOL = 'masquerade_tool'
 
 # in search courses, when you add a person to a course. This list
@@ -446,6 +453,8 @@ PERMISSION_MASQUERADE_TOOL = 'masquerade_tool'
 # user role id's from the course manager database
 ADD_PEOPLE_TO_COURSE_ALLOWED_ROLES_LIST = [0, 1, 2, 5, 6, 7, 9, 10, 11, 12, 14, 15, 16, 18, 19,
                                            20, 22, 23, 24, 25, 26, 27, 28, 400, 401]
+
+SELF_ENROLLMENT_TOOL_ROLES_LIST = SECURE_SETTINGS.get('self_enrollment_roles', ['Student', 'Guest'])
 
 BULK_COURSE_CREATION = {
     'log_long_running_jobs': True,

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -445,7 +445,7 @@ PERMISSION_SITE_CREATOR = 'manage_courses'
 PERMISSION_PUBLISH_COURSES = 'publish_courses'
 PERMISSION_BULK_COURSE_SETTING = 'bulk_course_settings'
 PERMISSION_CANVAS_SITE_DELETION = 'canvas_site_deletion'
-PERMISSION_SELF_ENROLLMENT_TOOL = 'canvas_site_deletion' # ToDo: fix this by PR to 'self_enrollment_tool'
+PERMISSION_SELF_ENROLLMENT_TOOL = 'self_enrollment_tool'
 PERMISSION_MASQUERADE_TOOL = 'masquerade_tool'
 
 # in search courses, when you add a person to a course. This list
@@ -506,6 +506,11 @@ MASQUERADE_TOOL_SETTINGS = {
     'aws_region_name':  SECURE_SETTINGS.get('aws_region_name', 'us-east-1'),
     'temporary_masquerade_function_arn': SECURE_SETTINGS.get('temporary_masquerade_function_arn'),
     'masquerade_session_minutes': SECURE_SETTINGS.get('masquerade_session_minutes', 60),
+}
+
+SELF_ENROLLMENT_TOOL_RSETTINGS = {
+    'self_enrolment_tool_url' :  SECURE_SETTINGS.get('self_enrolment_tool_url', 'https://canvas.instructure.com')
+
 }
 
 REST_FRAMEWORK = {

--- a/canvas_account_admin_tools/templates/canvas_account_admin_tools/dashboard_account.html
+++ b/canvas_account_admin_tools/templates/canvas_account_admin_tools/dashboard_account.html
@@ -221,4 +221,31 @@
         </div>
     {% endif %}
 
+    {% if self_enrollment_tool_is_allowed%}
+        <div class="card card_color">
+            <a href="{% url 'self_enrollment_tool:index' %}" id="canvas_site_deletion">
+              <div class="card-body">
+              <div class="card-header card-header_color5">
+              </div>
+              <div class="card-content card-content_normal">
+                <div class="card-content-width">
+                  <div class="card-content-icon">
+                    <i class="fa fa-user-plus icon-size"></i>
+                  </div>
+                  <div class="card-content-data">
+                    <h2 class="card-content-title ellipsis" title="Self Enrollment Tool">
+                      <span class="content-link">
+                        Self Enrollment Tool
+                      </span>
+                    </h2>
+                    <p title="Self Enrolmnet Tool"> Enable Self Enrollment for ILE courses</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </a>
+        </div>
+    {% endif %}
+
+
 {% endblock content %}

--- a/canvas_account_admin_tools/urls.py
+++ b/canvas_account_admin_tools/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     path('bulk_course_settings/', include(('bulk_course_settings.urls', 'bulk_course_settings'), namespace='bulk_course_settings')),
     path('canvas_site_deletion/', include(('canvas_site_deletion.urls', 'canvas_site_deletion'), namespace='canvas_site_deletion')),
     path('masquerade_tool/', include(('masquerade_tool.urls', 'masquerade_tool'), namespace='masquerade_tool')),
+    path('self_enrollment_tool/', include(('self_enrollment_tool.urls', 'self_enrollment_tool'), namespace='self_enrollment_tool')),
     path('tool_config/', views.tool_config, name='tool_config'),
     path('w/', include('watchman.urls')),
     re_path(r'^status/?$', watchman.views.bare_status),

--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -140,6 +140,14 @@ def dashboard_account(request):
     canvas_site_deletion_is_allowed = is_allowed(custom_canvas_membership_roles,
                                                  settings.PERMISSION_CANVAS_SITE_DELETION,
                                                  canvas_account_sis_id=custom_canvas_account_sis_id)
+
+    """
+           verify that user has permissions to view the Canvas Site deletion tool
+           """
+    self_enrollment_tool_is_allowed = is_allowed(custom_canvas_membership_roles,
+                                                 settings.PERMISSION_SELF_ENROLLMENT_TOOL,
+                                                 canvas_account_sis_id=custom_canvas_account_sis_id)
+
     """
         verify that user has permissions to view the masquerade tool
         """
@@ -156,6 +164,8 @@ def dashboard_account(request):
         'bulk_course_settings_is_allowed': bulk_course_settings_is_allowed,
         'canvas_site_deletion_is_allowed': canvas_site_deletion_is_allowed,
         'masquerade_tool_is_allowed': masquerade_tool_is_allowed,
+        'self_enrollment_tool_is_allowed': self_enrollment_tool_is_allowed,
+
         'build_info': build_info
     })
 

--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -142,8 +142,8 @@ def dashboard_account(request):
                                                  canvas_account_sis_id=custom_canvas_account_sis_id)
 
     """
-           verify that user has permissions to view the Canvas Site deletion tool
-           """
+       verify that user has permissions to view the Canvas Site deletion tool
+    """
     self_enrollment_tool_is_allowed = is_allowed(custom_canvas_membership_roles,
                                                  settings.PERMISSION_SELF_ENROLLMENT_TOOL,
                                                  canvas_account_sis_id=custom_canvas_account_sis_id)

--- a/self_enrollment_tool/admin.py
+++ b/self_enrollment_tool/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/self_enrollment_tool/admin.py
+++ b/self_enrollment_tool/admin.py
@@ -1,3 +1,2 @@
-from django.contrib import admin
 
 # Register your models here.

--- a/self_enrollment_tool/apps.py
+++ b/self_enrollment_tool/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class SelfEnrollmentToolConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'self_enrollment_tool'

--- a/self_enrollment_tool/migrations/0001_initial.py
+++ b/self_enrollment_tool/migrations/0001_initial.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+         ('lti_permissions', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="INSERT INTO lti_permissions_ltipermission "
+                  "(permission, school_id, canvas_role, allow) "
+                  "VALUES ('self_enrollment_tool', '*', 'AccountAdmin', '1'),"
+                  "('self_enrollment_tool', '*', 'Account admin', '1'),"
+                  "('self_enrollment_tool', '*', 'Account Admin', '1'),"
+                  "('self_enrollment_tool', '*', 'SchoolLiaison', '1');",
+            reverse_sql="delete from lti_permissions_ltipermission where permission='self_enrollment_tool';",
+        ),
+    ]
+

--- a/self_enrollment_tool/migrations/0002_add_self_enrollment.py
+++ b/self_enrollment_tool/migrations/0002_add_self_enrollment.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        ('self_enrollment_tool', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SelfEnrollmentCourse',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('course_instance_id', models.IntegerField(blank=True, null=True)),
+                ('role_id', models.CharField(blank=True, max_length=20, null=True)),
+                ('updated_by', models.CharField(max_length=15)),
+                ('last_updated', models.DateTimeField(auto_now_add=True)),
+            ],
+        )
+    ]

--- a/self_enrollment_tool/migrations/0002_add_self_enrollment.py
+++ b/self_enrollment_tool/migrations/0002_add_self_enrollment.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from django.db import migrations, models
-import django.db.models.deletion
-
 
 class Migration(migrations.Migration):
     initial = True

--- a/self_enrollment_tool/models.py
+++ b/self_enrollment_tool/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/self_enrollment_tool/models.py
+++ b/self_enrollment_tool/models.py
@@ -7,3 +7,6 @@ class SelfEnrollmentCourse(models.Model):
     role_id = models.IntegerField()
     updated_by = models.CharField(max_length=15)
     last_updated = models.DateTimeField(auto_now_add=True)
+    class Meta:
+        db_table = 'self_enrollment_course'
+        

--- a/self_enrollment_tool/models.py
+++ b/self_enrollment_tool/models.py
@@ -1,3 +1,9 @@
 from django.db import models
 
-# Create your models here.
+
+class SelfEnrollmentCourse(models.Model):
+
+    course_instance_id = models.IntegerField(unique=True)
+    role_id = models.IntegerField()
+    updated_by = models.CharField(max_length=15)
+    last_updated = models.DateTimeField(auto_now_add=True)

--- a/self_enrollment_tool/templates/self_enrollment_tool/add_new.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/add_new.html
@@ -61,7 +61,6 @@
                     <tr><th>Subtitle</th><td>{{ course_instance.sub_title }}</td></tr>
                 {% endif %}
                 <tr> <th>Course instance ID</th><td>{{course_instance.course_instance_id}}</td></tr>
-{#                <tr> <th>Sync to Canvas</th><td>{{course_instance.sync_to_canvas}}</td></tr>#}
                 <tr> <th>Term</th><td>{{course_instance.term.display_name}}</td></tr>
             </table>
         <br>

--- a/self_enrollment_tool/templates/self_enrollment_tool/add_new.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/add_new.html
@@ -1,0 +1,93 @@
+{% extends 'self_enrollment_tool/base.html' %}
+
+{% block body %}
+
+<nav>
+  <h3>
+    <a href="{% url 'dashboard_account' %}">Admin Console</a>
+    <small><i class="fa fa-chevron-right"></i></small>
+      <a href="{% url 'self_enrollment_tool:index' %}">Enable Self Enrollment</a>
+      <small><i class="fa fa-chevron-right"></i></small>
+      Add New
+  </h3>
+</nav>
+
+<body role="application">
+    <div class="container-fluid">
+        {% for message in messages %}
+            {% if message.level_tag == "success" %}
+                <div class="alert alert-success" role="alert">
+                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                    {{ message }}
+                </div>
+            {% elif message.level_tag == "error" %}
+                <div class="alert alert-danger" role="alert">
+                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                    {{ message }}
+                </div>
+            {% endif %}
+        {% endfor %}
+    <br><br>
+       <div class="row">
+        <div class="col-sm-6">
+            <b>Enter an SIS Course Id to lookup the ILE course:</b>
+        </div>
+    </div>
+    <br>
+    <div class="row">
+        <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:lookup' %}">{% csrf_token %}
+            <div class="form-group col-sm-3">
+                <label class="sr-only" for="course_search_term"> Enter Course Instance ID</label>
+                <input type="search" name="course_search_term" class="form-control" id="course_search_term" placeholder="Enter Course Instance ID" style="width: 100%"/>
+            </div>
+            <div class="col-sm-3">
+                <button type="submit" name="Search" id="course_search_button" class="btn btn-primary" data-loading-text="<i class='fa fa-spinner fa-spin'></i> Searching...">
+                <i class="fa fa-search"></i> Find Course</button>
+            </div>
+        </form>
+    </div>
+    <br>
+    <div>
+    {% if course_instance and abort is False %}
+        <h4>Course Details:</h4>
+            <table class="table table-striped table-hover">
+                <tr> <th>Canvas course ID</th><td><a href="{{ canvas_url }}/courses/{{ course_instance.canvas_course_id}}" target="_new">{{course_instance.canvas_course_id}}</a></td></tr>
+                <tr> <th>School</th><td>{{course_instance.term.school.school_id|upper }}</td></tr>
+                <tr> <th>Title</th><td>{{course_instance.title}}</td></tr>
+                {% if course_instance.short_title %}
+                    <tr> <th>Short title</th><td>{{course_instance.short_title}}</td></tr>
+                {% endif %}
+                {% if course_instance.sub_title %}
+                    <tr><th>Subtitle</th><td>{{ course_instance.sub_title }}</td></tr>
+                {% endif %}
+                <tr> <th>Course instance ID</th><td>{{course_instance.course_instance_id}}</td></tr>
+{#                <tr> <th>Sync to Canvas</th><td>{{course_instance.sync_to_canvas}}</td></tr>#}
+                <tr> <th>Term</th><td>{{course_instance.term.display_name}}</td></tr>
+            </table>
+        <br>
+        <div class="row">
+        <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:enable' course_instance_id=course_instance.course_instance_id %}">{% csrf_token %}
+            <h4>Please Choose the role the enrollees should have in the  course:</h4>
+
+            <div class="form-group col-sm-3" >
+                <label for="course_enroll"> Role</label>
+                    <select name="role_id" id="role_id" class="form-control">
+                        {% for role in roles %}
+                            <option value="{{ role}}">{{role}}</option>1
+                        {% endfor %}
+                    </select>
+            </div>
+            <div class="col-sm-3">
+                <button type="submit" name="Enable " id="course_enroll_button" class="btn btn-primary"
+                        data-loading-text=" Processing...">Enable Self Enrollment</button>
+            </div>
+        </form>
+        </div>
+    </div>
+    {% endif %}
+
+</div>
+</body>
+
+
+{% endblock %}

--- a/self_enrollment_tool/templates/self_enrollment_tool/base.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/base.html
@@ -1,0 +1,43 @@
+{% load collections %}
+{% load django_helpers %}
+{% load static %}
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1, user-scalable=no">
+    <link href="https://static.tlt.harvard.edu/shared/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="stylesheet" type="text/css"
+          href="https://static.tlt.harvard.edu/shared/font-awesome-4.5.0/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css"
+          href="https://static.tlt.harvard.edu/shared/bootstrap-3.3.6/dist/css/bootstrap.min.css"
+          media="screen"/>
+    <link rel="stylesheet" type="text/css"
+          href="https://static.tlt.harvard.edu/shared/datatables-1.10.15/media/css/jquery.dataTables.min.css"
+          media="screen"/>
+
+
+    <script src="https://static.tlt.harvard.edu/shared/jquery-2.2.2/jquery-2.2.2.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/datatables-1.10.15/media/js/jquery.dataTables.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/bootstrap-3.3.6/dist/js/bootstrap.js"></script>
+
+    {% include 'django_auth_lti/resource_link_id.html' %}
+
+    {# fixes safari autocomplete issue #}
+    {# (see https://github.com/angular/angular.js/issues/1460) #}
+    <script src="{% static 'course_info/js/polyfills/autofill-event.js' %}"></script>
+
+    <script>
+      window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';
+    </script>
+
+    <title>Canvas Site Deletion</title>
+  </head>
+
+
+  <body class="lti-tool" role="application">
+    {% block body %}
+    {% endblock %}
+  </body>
+</html>

--- a/self_enrollment_tool/templates/self_enrollment_tool/base.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/base.html
@@ -32,7 +32,7 @@
       window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';
     </script>
 
-    <title>Canvas Site Deletion</title>
+    <title>Self Enrollment Tool</title>
   </head>
 
 

--- a/self_enrollment_tool/templates/self_enrollment_tool/enable_enrollment.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/enable_enrollment.html
@@ -32,7 +32,6 @@
     <div>
         <h4> Distributable link :</h4>
         {{ enrollment_url }}:enrollment_url
-{#         {{ request.get_full_path }}"/self_enrollment_tool/enable"#}
         {{ request.path }}"/self_enrollment_tool/enable"
 
         <a href=" ">

--- a/self_enrollment_tool/templates/self_enrollment_tool/enable_enrollment.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/enable_enrollment.html
@@ -6,7 +6,9 @@
   <h3>
     <a href="{% url 'dashboard_account' %}">Admin Console</a>
     <small><i class="fa fa-chevron-right"></i></small>
-    Enable Self Enrollment
+      <a href="{% url 'self_enrollment_tool:index' %}">Enable Self Enrollment</a>
+      <small><i class="fa fa-chevron-right"></i></small>
+      Add New
   </h3>
 </nav>
 

--- a/self_enrollment_tool/templates/self_enrollment_tool/enable_enrollment.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/enable_enrollment.html
@@ -1,0 +1,45 @@
+{% extends 'self_enrollment_tool/base.html' %}
+
+{% block body %}
+
+<nav>
+  <h3>
+    <a href="{% url 'dashboard_account' %}">Admin Console</a>
+    <small><i class="fa fa-chevron-right"></i></small>
+    Enable Self Enrollment
+  </h3>
+</nav>
+
+<body role="application">
+    <div class="container-fluid">
+        {% for message in messages %}
+            {% if message.level_tag == "success" %}
+                <div class="alert alert-success" role="alert">
+                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                    {{ message }}
+
+                </div>
+            {% elif message.level_tag == "error" %}
+                <div class="alert alert-danger" role="alert">
+                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                    {{ message }}
+                </div>
+            {% endif %}
+        {% endfor %}
+    <br><br>
+    <div>
+        <h4> Distributable link :</h4>
+        {{ enrollment_url }}:enrollment_url
+{#         {{ request.get_full_path }}"/self_enrollment_tool/enable"#}
+        {{ request.path }}"/self_enrollment_tool/enable"
+
+        <a href=" ">
+             {% url 'self_enrollment_tool:enable'  course_instance_id=course_instance_id  %}
+         </a>
+    </div>
+
+</div>
+</body>
+
+
+{% endblock %}

--- a/self_enrollment_tool/templates/self_enrollment_tool/index.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/index.html
@@ -64,8 +64,8 @@
             </table>
         <br>
         <div class="row">
-        <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:enroll' %}">{% csrf_token %}
-            <h4>Please Choose the the role the enrollees should have in the  course:</h4>
+        <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:enable' %}">{% csrf_token %}
+            <h4>Please Choose the role the enrollees should have in the  course:</h4>
 
             <div class="form-group col-sm-3" >
                 <label for="course_enroll"> Role</label>
@@ -76,8 +76,8 @@
                     </select>
             </div>
             <div class="col-sm-3">
-                <button type="submit" name="Enroll" id="course_enrollb_utton" class="btn btn-primary"
-                        data-loading-text=" Processing...">Enroll</button>
+                <button type="submit" name="Enable " id="course_enrollb_utton" class="btn btn-primary"
+                        data-loading-text=" Processing...">Enable Self Enrollment</button>
             </div>
         </form>
         </div>

--- a/self_enrollment_tool/templates/self_enrollment_tool/index.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/index.html
@@ -64,19 +64,19 @@
             </table>
         <br>
         <div class="row">
-        <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:enable' %}">{% csrf_token %}
+        <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:enable' course_instance_id=course_instance.course_instance_id %}">{% csrf_token %}
             <h4>Please Choose the role the enrollees should have in the  course:</h4>
 
             <div class="form-group col-sm-3" >
                 <label for="course_enroll"> Role</label>
-                    <select name="role_name" id="role_name" class="form-control">
+                    <select name="role_id" id="role_id" class="form-control">
                         {% for role in roles %}
                             <option value="{{ role}}">{{role}}</option>1
                         {% endfor %}
                     </select>
             </div>
             <div class="col-sm-3">
-                <button type="submit" name="Enable " id="course_enrollb_utton" class="btn btn-primary"
+                <button type="submit" name="Enable " id="course_enroll_button" class="btn btn-primary"
                         data-loading-text=" Processing...">Enable Self Enrollment</button>
             </div>
         </form>

--- a/self_enrollment_tool/templates/self_enrollment_tool/index.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/index.html
@@ -26,64 +26,10 @@
             {% endif %}
         {% endfor %}
     <br><br>
-       <div class="row">
-        <div class="col-sm-6">
-            <b>Enter an SIS Course Id to lookup the ILE course:</b>
-        </div>
+    <div class="row" style="margin-top: 1em;">
+            <a href="{% url 'self_enrollment_tool:add_new' %}" class="btn btn-primary pull-right">Add New</a>
     </div>
-    <br>
-    <div class="row">
-        <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:lookup' %}">{% csrf_token %}
-            <div class="form-group col-sm-3">
-                <label class="sr-only" for="course_search_term"> Enter Course Instance ID</label>
-                <input type="search" name="course_search_term" class="form-control" id="course_search_term" placeholder="Enter Course Instance ID" style="width: 100%"/>
-            </div>
-            <div class="col-sm-3">
-                <button type="submit" name="Search" id="course_search_button" class="btn btn-primary" data-loading-text="<i class='fa fa-spinner fa-spin'></i> Searching...">
-                <i class="fa fa-search"></i> Find Course</button>
-            </div>
-        </form>
-    </div>
-    <br>
-    <div>
-    {% if course_instance and abort is False %}
-        <h4>Course Details:</h4>
-            <table class="table table-striped table-hover">
-                <tr> <th>Canvas course ID</th><td><a href="{{ canvas_url }}/courses/{{ course_instance.canvas_course_id}}" target="_new">{{course_instance.canvas_course_id}}</a></td></tr>
-                <tr> <th>School</th><td>{{course_instance.term.school.school_id|upper }}</td></tr>
-                <tr> <th>Title</th><td>{{course_instance.title}}</td></tr>
-                {% if course_instance.short_title %}
-                    <tr> <th>Short title</th><td>{{course_instance.short_title}}</td></tr>
-                {% endif %}
-                {% if course_instance.sub_title %}
-                    <tr><th>Subtitle</th><td>{{ course_instance.sub_title }}</td></tr>
-                {% endif %}
-                <tr> <th>Course instance ID</th><td>{{course_instance.course_instance_id}}</td></tr>
-{#                <tr> <th>Sync to Canvas</th><td>{{course_instance.sync_to_canvas}}</td></tr>#}
-                <tr> <th>Term</th><td>{{course_instance.term.display_name}}</td></tr>
-            </table>
-        <br>
-        <div class="row">
-        <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:enable' course_instance_id=course_instance.course_instance_id %}">{% csrf_token %}
-            <h4>Please Choose the role the enrollees should have in the  course:</h4>
-
-            <div class="form-group col-sm-3" >
-                <label for="course_enroll"> Role</label>
-                    <select name="role_id" id="role_id" class="form-control">
-                        {% for role in roles %}
-                            <option value="{{ role}}">{{role}}</option>1
-                        {% endfor %}
-                    </select>
-            </div>
-            <div class="col-sm-3">
-                <button type="submit" name="Enable " id="course_enroll_button" class="btn btn-primary"
-                        data-loading-text=" Processing...">Enable Self Enrollment</button>
-            </div>
-        </form>
-        </div>
-    </div>
-    {% endif %}
-
+    <p><i>This is the placeholder for the list view</i></p>
 </div>
 </body>
 

--- a/self_enrollment_tool/templates/self_enrollment_tool/index.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/index.html
@@ -1,0 +1,91 @@
+{% extends 'self_enrollment_tool/base.html' %}
+
+{% block body %}
+
+<nav>
+  <h3>
+    <a href="{% url 'dashboard_account' %}">Admin Console</a>
+    <small><i class="fa fa-chevron-right"></i></small>
+    Enable Self Enrollment
+  </h3>
+</nav>
+
+<body role="application">
+    <div class="container-fluid">
+        {% for message in messages %}
+            {% if message.level_tag == "success" %}
+                <div class="alert alert-success" role="alert">
+                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                    {{ message }}
+                </div>
+            {% elif message.level_tag == "error" %}
+                <div class="alert alert-danger" role="alert">
+                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                    {{ message }}
+                </div>
+            {% endif %}
+        {% endfor %}
+    <br><br>
+       <div class="row">
+        <div class="col-sm-6">
+            <b>Enter an SIS Course Id to lookup the ILE course:</b>
+        </div>
+    </div>
+    <br>
+    <div class="row">
+        <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:lookup' %}">{% csrf_token %}
+            <div class="form-group col-sm-3">
+                <label class="sr-only" for="course_search_term"> Enter Course Instance ID</label>
+                <input type="search" name="course_search_term" class="form-control" id="course_search_term" placeholder="Enter Course Instance ID" style="width: 100%"/>
+            </div>
+            <div class="col-sm-3">
+                <button type="submit" name="Search" id="course_search_button" class="btn btn-primary" data-loading-text="<i class='fa fa-spinner fa-spin'></i> Searching...">
+                <i class="fa fa-search"></i> Find Course</button>
+            </div>
+        </form>
+    </div>
+    <br>
+    <div>
+    {% if course_instance and abort is False %}
+        <h4>Course Details:</h4>
+            <table class="table table-striped table-hover">
+                <tr> <th>Canvas course ID</th><td><a href="{{ canvas_url }}/courses/{{ course_instance.canvas_course_id}}" target="_new">{{course_instance.canvas_course_id}}</a></td></tr>
+                <tr> <th>School</th><td>{{course_instance.term.school.school_id|upper }}</td></tr>
+                <tr> <th>Title</th><td>{{course_instance.title}}</td></tr>
+                {% if course_instance.short_title %}
+                    <tr> <th>Short title</th><td>{{course_instance.short_title}}</td></tr>
+                {% endif %}
+                {% if course_instance.sub_title %}
+                    <tr><th>Subtitle</th><td>{{ course_instance.sub_title }}</td></tr>
+                {% endif %}
+                <tr> <th>Course instance ID</th><td>{{course_instance.course_instance_id}}</td></tr>
+{#                <tr> <th>Sync to Canvas</th><td>{{course_instance.sync_to_canvas}}</td></tr>#}
+                <tr> <th>Term</th><td>{{course_instance.term.display_name}}</td></tr>
+            </table>
+        <br>
+        <div class="row">
+        <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:enroll' %}">{% csrf_token %}
+            <h4>Please Choose the the role the enrollees should have in the  course:</h4>
+
+            <div class="form-group col-sm-3" >
+                <label for="course_enroll"> Role</label>
+                    <select name="role_name" id="role_name" class="form-control">
+                        {% for role in roles %}
+                            <option value="{{ role}}">{{role}}</option>1
+                        {% endfor %}
+                    </select>
+            </div>
+            <div class="col-sm-3">
+                <button type="submit" name="Enroll" id="course_enrollb_utton" class="btn btn-primary"
+                        data-loading-text=" Processing...">Enroll</button>
+            </div>
+        </form>
+        </div>
+    </div>
+    {% endif %}
+
+</div>
+</body>
+
+
+{% endblock %}

--- a/self_enrollment_tool/tests.py
+++ b/self_enrollment_tool/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/self_enrollment_tool/urls.py
+++ b/self_enrollment_tool/urls.py
@@ -4,6 +4,7 @@ from self_enrollment_tool import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('add_new/', views.add_new, name='add_new'),
     path('lookup/', views.lookup, name='lookup'),
     path('enable/(?P<course_instance_id>\d+)$', views.enable,  name='enable'),
     path('enroll/(?P<course_instance_id>\d+)$', views.enroll, name='enroll'),

--- a/self_enrollment_tool/urls.py
+++ b/self_enrollment_tool/urls.py
@@ -5,7 +5,7 @@ from self_enrollment_tool import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('lookup/', views.lookup, name='lookup'),
-    path('enable/', views.lookup, name='enable'),
-    path('enroll/', views.lookup, name='enroll'),
+    path('enable/(?P<course_instance_id>\d+)$', views.enable,  name='enable'),
+    path('enroll/(?P<course_instance_id>\d+)$', views.enroll, name='enroll'),
 
 ]

--- a/self_enrollment_tool/urls.py
+++ b/self_enrollment_tool/urls.py
@@ -5,6 +5,7 @@ from self_enrollment_tool import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('lookup/', views.lookup, name='lookup'),
+    path('enable/', views.lookup, name='enable'),
     path('enroll/', views.lookup, name='enroll'),
 
 ]

--- a/self_enrollment_tool/urls.py
+++ b/self_enrollment_tool/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path, re_path
+
+from self_enrollment_tool import views
+
+urlpatterns = [
+    path('', views.index, name='index'),
+    path('lookup/', views.lookup, name='lookup'),
+    path('enroll/', views.lookup, name='enroll'),
+
+]

--- a/self_enrollment_tool/views.py
+++ b/self_enrollment_tool/views.py
@@ -14,6 +14,8 @@ from django_auth_lti.decorators import lti_role_required
 from icommons_common.canvas_utils import SessionInactivityExpirationRC
 from icommons_common.models import CourseInstance
 from lti_permissions.decorators import lti_permission_required
+from self_enrollment_tool.models import SelfEnrollmentCourse
+
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +89,10 @@ def lookup(request):
 
     # fetch the roles for the dropdown
     roles = settings.SELF_ENROLLMENT_TOOL_ROLES_LIST
+
     if roles:
+        # todo : Get role names from role table and display role names in dropdown (currently role_ids are being shown)
+
         context['roles'] = roles
 
     return render(request, 'self_enrollment_tool/index.html', context)
@@ -96,47 +101,62 @@ def lookup(request):
 @lti_role_required(const.ADMINISTRATOR)
 @lti_permission_required(settings.PERMISSION_CANVAS_SITE_DELETION)
 @require_http_methods(['GET', 'POST'])
-def enable(request):
+def enable (request, course_instance_id):
     """
     Enable Self enrollment for the Course with the chosen role
     """
-    course_search_term = request.POST.get('course_search_term')
-    course_search_term = course_search_term.strip()
+    logger.debug(request)
+    role_id = request.POST.get('role_id')
+
+    # todo: retrive role name
+    role_name = request.POST.get('role_id')
+    logger.debug(f'Selected Role_id {role_id} for Self Enrollment in  course {course_instance_id}')
+
     context = {
         'canvas_url': settings.CANVAS_URL,
+        'course_instance_id' : course_instance_id,
+        'role_id':role_id,
+        'role_name': role_name,
         'abort': False,
     }
+    try:
+        if role_id and course_instance_id:
 
-    if course_search_term.isnumeric():
-        try:
-            ci = CourseInstance.objects.get(course_instance_id=course_search_term)
-            context['course_instance'] = ci
-
-            if ci.canvas_course_id:
-                # get the Canvas course and make sure that the SIS ID matches
-                response = courses.get_single_course_courses(SDK_CONTEXT, id=ci.canvas_course_id)
-                if response.status_code == 200:
-                    cc = response.json()
-                else:
-                    logger.error(f'Could not retrieve Canvas course {ci.canvas_course_id}')
-                    messages.error(request, f'Could not find Canvas course {ci.canvas_course_id}')
-                    context['abort'] = True
-
-          
-
-        except CourseInstance.DoesNotExist:
-            logger.exception('Could not determine the course instance for Canvas '
-                             'course instance id %s' % course_search_term)
-            messages.error(request, 'Could not find a Course Instance from search term')
-            context['abort'] = True
-        except CanvasAPIError:
-            logger.exception(f'Could not find Canvas course {ci.canvas_course_id} via Canvas API')
-            messages.error(request, f'Could not find Canvas course {ci.canvas_course_id}. Aborting.')
-            context['abort'] = True
-    else:
-        messages.error(request, 'Search term must be populated and may only be numbers')
+            # todo: add validation to check if self enrollment si already enabled for this course
+            exists  = SelfEnrollmentCourse.objects.filter(course_instance_id=course_instance_id).exists()
+            if exists :
+                logger.error(f'Self Enrollment is already enabled for this course  {course_instance_id} ')
+                messages.error(request, f'Self Enrollment is already enabled for this course {course_instance_id} ')
+                context['abort'] = True
+            else:
+                new_selfE_enrollment_course = SelfEnrollmentCourse.objects.create(course_instance_id=course_instance_id,
+                                              role_id=role_id,
+                                              updated_by=str(request.user))
+                logger.debug(f'Successfully saved Role_id {role_id} for Self Enrollment in course {course_instance_id}')
+                messages.success(request, f"Successfully enabled Self Enrollment for SIS Course Id"
+                                          f" {course_instance_id} for role {role_name}")
+                # todo : add the Distributable Self reg link On eoption, for example:
+                # https://icommons-tools.tlt.harvard.edu/shopping/course_selfreg/103686
+                enrollment_url = 'canvas_account_admin_tools/self_enrollment_tool/enroll/' + course_instance_id;
+                context['enrollment_url'] = enrollment_url
+    except Exception as e:
+        message = 'Error creating self enrollment record  for course {} with role {} error details={}' \
+            .format(course_instance_id, role_id, e)
+        logger.exception(message)
+        context['abort'] = True
 
 
-    return render(request, 'self_enrollment_tool/index.html', context)
+    return render(request, 'self_enrollment_tool/enable_enrollment.html', context)
 
 
+@login_required
+@lti_role_required(const.ADMINISTRATOR)
+@lti_permission_required(settings.PERMISSION_CANVAS_SITE_DELETION)
+@require_http_methods(['GET', 'POST'])
+def enroll (request, course_instance_id):
+    context = {
+        'canvas_url': settings.CANVAS_URL,
+        'course_instance_id' : course_instance_id,
+        'abort': False,
+    }
+    return render(request, 'self_enrollment_tool/lookup.html', context)

--- a/self_enrollment_tool/views.py
+++ b/self_enrollment_tool/views.py
@@ -99,7 +99,7 @@ def lookup(request):
 
     if roles:
         # todo : Get role names from role table and display role names in dropdown (currently role_ids are being shown)
-
+        # This seems to have been done in 4279 by. Validate after merge and remove this todo
         context['roles'] = roles
 
     return render(request, 'self_enrollment_tool/add_new.html', context)
@@ -137,7 +137,7 @@ def enable (request, course_instance_id):
     try:
         if role_id and course_instance_id:
 
-            # todo: add validation to check if self enrollment is already enabled for this course
+            # check if self enrollment is already enabled for this course
             exists  = SelfEnrollmentCourse.objects.filter(course_instance_id=course_instance_id).exists()
             if exists :
                 logger.error(f'Self Enrollment is already enabled for this course  {course_instance_id} ')

--- a/self_enrollment_tool/views.py
+++ b/self_enrollment_tool/views.py
@@ -1,0 +1,89 @@
+from django.shortcuts import render
+
+import logging
+
+from canvas_sdk.exceptions import CanvasAPIError
+from canvas_sdk.methods import courses
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+from django.views.decorators.http import require_http_methods
+from django_auth_lti import const
+from django_auth_lti.decorators import lti_role_required
+from icommons_common.canvas_utils import SessionInactivityExpirationRC
+from icommons_common.models import CourseInstance
+from lti_permissions.decorators import lti_permission_required
+
+logger = logging.getLogger(__name__)
+
+SDK_CONTEXT = SessionInactivityExpirationRC(**settings.CANVAS_SDK_SETTINGS)
+
+@login_required
+@lti_role_required(const.ADMINISTRATOR)
+@lti_permission_required(settings.PERMISSION_SELF_ENROLLMENT_TOOL)
+@require_http_methods(['GET'])
+def index(request):
+    context = {}
+    return render(request, 'self_enrollment_tool/index.html', context)
+
+
+@login_required
+@lti_role_required(const.ADMINISTRATOR)
+@lti_permission_required(settings.PERMISSION_CANVAS_SITE_DELETION)
+@require_http_methods(['GET', 'POST'])
+def lookup(request):
+    course_search_term = request.POST.get('course_search_term')
+    course_search_term = course_search_term.strip()
+    context = {
+        'canvas_url': settings.CANVAS_URL,
+        'abort': False,
+    }
+
+    if course_search_term.isnumeric():
+        try:
+            ci = CourseInstance.objects.get(course_instance_id=course_search_term)
+            context['course_instance'] = ci
+
+            if ci.canvas_course_id:
+                # get the Canvas course and make sure that the SIS ID matches
+                response = courses.get_single_course_courses(SDK_CONTEXT, id=ci.canvas_course_id)
+                if response.status_code == 200:
+                    cc = response.json()
+                else:
+                    logger.error(f'Could not retrieve Canvas course {ci.canvas_course_id}')
+                    messages.error(request, f'Could not find Canvas course {ci.canvas_course_id}')
+                    context['abort'] = True
+
+                if ci.course_instance_id != int(cc['sis_course_id']):
+                    logger.error(f'Course instance ID ({course_search_term}) does not match Canvas course '
+                                 f'SIS ID ({cc["sis_course_id"]}) for Canvas course {ci.canvas_course_id}. Aborting.')
+                    messages.error(request, f'Course instance ID ({course_search_term}) does not match Canvas '
+                                            f'course SIS ID ({cc["sis_course_id"]}) for Canvas course '
+                                            f'{ci.canvas_course_id}. Aborting.')
+                    context['abort'] = True
+            else:
+                logger.error(f'Course instance {ci.course_instance_id} does not have a Canvas course ID set.')
+                messages.error(request, f'Course instance {ci.course_instance_id} does not have a Canvas course ID set. Cannot continue.')
+                context['abort'] = True
+
+        except CourseInstance.DoesNotExist:
+            logger.exception('Could not determine the course instance for Canvas '
+                             'course instance id %s' % course_search_term)
+            messages.error(request, 'Could not find a Course Instance from search term')
+            context['abort'] = True
+        except CanvasAPIError:
+            logger.exception(f'Could not find Canvas course {ci.canvas_course_id} via Canvas API')
+            messages.error(request, f'Could not find Canvas course {ci.canvas_course_id}. Aborting.')
+            context['abort'] = True
+    else:
+        messages.error(request, 'Search term must be populated and may only be numbers')
+
+    # fetch the roles for the dropdown
+    roles = settings.SELF_ENROLLMENT_TOOL_ROLES_LIST
+    if roles:
+        context['roles'] = roles
+
+    return render(request, 'self_enrollment_tool/index.html', context)
+
+

--- a/self_enrollment_tool/views.py
+++ b/self_enrollment_tool/views.py
@@ -58,7 +58,7 @@ def lookup(request):
                     context['abort'] = True
 
                 if ci.course_instance_id != int(cc['sis_course_id']):
-                    logger.error(f'Course instance ID ({course_search_term}) does not match Canvas course '
+                    logger.warning(f'Course instance ID ({course_search_term}) does not match Canvas course '
                                  f'SIS ID ({cc["sis_course_id"]}) for Canvas course {ci.canvas_course_id}. Aborting.')
                     messages.error(request, f'Course instance ID ({course_search_term}) does not match Canvas '
                                             f'course SIS ID ({cc["sis_course_id"]}) for Canvas course '
@@ -67,14 +67,14 @@ def lookup(request):
 
                 # Check if it is an ILE or SB course. (source != xmlfeed)
                 if ci.source == 'xmlfeed':
-                    logger.error(f'Course instance ID ({course_search_term}) is not an ILE course. Aborting.')
+                    logger.warning(f'Course instance ID ({course_search_term}) is not an ILE course. Aborting.')
                     messages.error(request, f'Course instance ID ({course_search_term}) is not an ILE/SB course.')
                     context['abort'] = True
 
                 # Check if Self Enrollment record already exists for this course
                 exists = SelfEnrollmentCourse.objects.filter(course_instance_id=ci.course_instance_id).exists()
                 if exists:
-                    logger.error(f'Self Enrollment is already enabled for this course  {ci.course_instance_id} ')
+                    logger.warning(f'Self Enrollment is already enabled for this course  {ci.course_instance_id} ')
                     messages.error(request, f'Self Enrollment is already enabled for this course {ci.course_instance_id} ')
                     context['abort'] = True
             else:
@@ -123,7 +123,8 @@ def enable (request, course_instance_id):
     logger.debug(request)
     role_id = request.POST.get('role_id')
 
-    # todo: retrive role name
+    # todo: retrive role name. Note: Thsi is implemented in teh other story for thsi tool but will remove this comment
+    #  after verifying on merging upstream
     role_name = request.POST.get('role_id')
     logger.debug(f'Selected Role_id {role_id} for Self Enrollment in  course {course_instance_id}')
 
@@ -167,7 +168,7 @@ def enable (request, course_instance_id):
 @login_required
 @lti_role_required(const.ADMINISTRATOR)
 @lti_permission_required(settings.PERMISSION_SELF_ENROLLMENT_TOOL)
-@require_http_methods(['GET', 'POST'])
+@require_http_methods(['GET'])
 def enroll (request, course_instance_id):
     context = {
         'canvas_url': settings.CANVAS_URL,

--- a/self_enrollment_tool/views.py
+++ b/self_enrollment_tool/views.py
@@ -32,7 +32,7 @@ def index(request):
 
 @login_required
 @lti_role_required(const.ADMINISTRATOR)
-@lti_permission_required(settings.PERMISSION_CANVAS_SITE_DELETION)
+@lti_permission_required(settings.PERMISSION_SELF_ENROLLMENT_TOOL)
 @require_http_methods(['GET', 'POST'])
 def lookup(request):
     course_search_term = request.POST.get('course_search_term')
@@ -114,7 +114,7 @@ def add_new(request):
 
 @login_required
 @lti_role_required(const.ADMINISTRATOR)
-@lti_permission_required(settings.PERMISSION_CANVAS_SITE_DELETION)
+@lti_permission_required(settings.PERMISSION_SELF_ENROLLMENT_TOOL)
 @require_http_methods(['GET', 'POST'])
 def enable (request, course_instance_id):
     """
@@ -166,7 +166,7 @@ def enable (request, course_instance_id):
 
 @login_required
 @lti_role_required(const.ADMINISTRATOR)
-@lti_permission_required(settings.PERMISSION_CANVAS_SITE_DELETION)
+@lti_permission_required(settings.PERMISSION_SELF_ENROLLMENT_TOOL)
 @require_http_methods(['GET', 'POST'])
 def enroll (request, course_instance_id):
     context = {


### PR DESCRIPTION
This PR has changes for the new Self Enrollment tool as outlined in [TLT_4277](https://jira.huit.harvard.edu/browse/TLT-4277)

**Notes**:

- There's a new card in CAAT
-It has been deployed to dev
-Migrations have been run on both dev and qa DB
-There are some TODO including for displaying and using role names instead of role ids but it's handled by Hydn's branch
-One piece that is not complete is rendering the enrollment url to be distributed. There was some initial discussion if this new url should be within CAAT or a new simple tool(as it will be used by non-admin users and will the path needs to be HKEY protected). This is being worked on in 4278