### PR TITLE
TLT-4336: Separate Search and Enable sections within UI

### DIFF
--- a/self_enrollment_tool/templates/self_enrollment_tool/add_new.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/add_new.html
@@ -28,26 +28,28 @@
             {% endif %}
         {% endfor %}
     <br><br>
-    <div>
-        <div class="row">
-            <div class="col-sm-6">
-                <b>Enter an SIS Course Id to lookup the ILE course:</b>
+    {% if not course_instance or abort is True %}
+        <div>
+            <div class="row">
+                <div class="col-sm-6">
+                    <b>Enter an SIS Course Id to lookup the ILE course:</b>
+                </div>
+            </div>
+            <br>
+            <div class="row">
+                <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:lookup' %}">{% csrf_token %}
+                    <div class="form-group col-sm-3">
+                        <label class="sr-only" for="course_search_term"> Enter Course Instance ID</label>
+                        <input type="search" name="course_search_term" class="form-control" id="course_search_term" placeholder="Enter Course Instance ID" style="width: 100%"/>
+                    </div>
+                    <div class="col-sm-3">
+                        <button type="submit" name="Search" id="course_search_button" class="btn btn-primary" data-loading-text="<i class='fa fa-spinner fa-spin'></i> Searching...">
+                        <i class="fa fa-search"></i> Find Course</button>
+                    </div>
+                </form>
             </div>
         </div>
-        <br>
-        <div class="row">
-            <form class="form-inline" method="POST" action="{% url 'self_enrollment_tool:lookup' %}">{% csrf_token %}
-                <div class="form-group col-sm-3">
-                    <label class="sr-only" for="course_search_term"> Enter Course Instance ID</label>
-                    <input type="search" name="course_search_term" class="form-control" id="course_search_term" placeholder="Enter Course Instance ID" style="width: 100%"/>
-                </div>
-                <div class="col-sm-3">
-                    <button type="submit" name="Search" id="course_search_button" class="btn btn-primary" data-loading-text="<i class='fa fa-spinner fa-spin'></i> Searching...">
-                    <i class="fa fa-search"></i> Find Course</button>
-                </div>
-            </form>
-        </div>
-    </div>
+    {% endif %}
     <br>
     <div>
     {% if course_instance and abort is False %}

--- a/self_enrollment_tool/views.py
+++ b/self_enrollment_tool/views.py
@@ -118,6 +118,7 @@ def lookup(request):
     context = {
         'canvas_url': settings.CANVAS_URL,
         'abort': False,
+        'course_instance': None,
     }
 
     if course_search_term.isnumeric():

--- a/self_enrollment_tool/views.py
+++ b/self_enrollment_tool/views.py
@@ -341,7 +341,7 @@ def enroll (request, uuid):
         return redirect(course_url)
     else:
         # rollback enrollment entry from earlier
-        logger.warning('Enrolling self-reg user via Canvas API returned a non-200 HTTP reseponse. Rolling back database entry.')
+        logger.warning('Enrolling self-reg user via Canvas API returned a non-200 HTTP response. Rolling back database entry.')
         result = enrollment.delete()
         logger.info(f'Database response from DELETE operation: {result}')
         return render(request, 'self_enrollment_tool/error.html', {'message': 'Sorry, there was a problem enrolling you in this course.'})


### PR DESCRIPTION
Resolves [TLT-4336](https://jira.huit.harvard.edu/browse/TLT-4336).

This PR updates the UI such that after a successful course lookup (via SIS ID), the search box is removed from the subsequent view. Previously, the search box would still be present alongside the resulting course information.

Deployed to QA.