### PR TITLE
TLT-4346: Prevent lookup of courses outside current sub-account

### DIFF
--- a/self_enrollment_tool/templates/self_enrollment_tool/index.html
+++ b/self_enrollment_tool/templates/self_enrollment_tool/index.html
@@ -29,7 +29,7 @@
     <div class="row" style="margin-top: 1em;">
         <a href="{% url 'self_enrollment_tool:add_new' %}" class="btn btn-primary pull-right">Add New</a>
     </div>
-    
+
     <!-- Modal Delete Confirmation START -->
     <div class="modal fade" id="delConfirmModalCenter" tabindex="-1" role="dialog" aria-labelledby="delConfirmModalCenterTitle" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered" role="document">
@@ -125,7 +125,7 @@
                         {% comment %} Delete column {% endcomment %}
                         <td>
                             <a>
-                                <i class="fa fa-lg fa-trash" aria-hidden="true" data-toggle="modal" data-target="#delConfirmModalCenter" 
+                                <i style="cursor: pointer;" class="fa fa-lg fa-trash" aria-hidden="true" data-toggle="modal" data-target="#delConfirmModalCenter"
                                 onclick="delItem('{% url 'self_enrollment_tool:disable' uuid=crs.uuid %}')"></i>
                             </a>
                         </td>
@@ -150,7 +150,7 @@
             });
 
             function delItem(item) {
-                document.getElementById("modalDeleteButton").href=item; 
+                document.getElementById("modalDeleteButton").href=item;
             };
 
             const showCopyError = function(el) {

--- a/self_enrollment_tool/views.py
+++ b/self_enrollment_tool/views.py
@@ -123,8 +123,9 @@ def lookup(request):
     }
 
     if course_search_term.isnumeric():
+        tool_launch_school = request.LTI['custom_canvas_account_sis_id'].split(':')[1]
         try:
-            ci = CourseInstance.objects.get(course_instance_id=course_search_term)
+            ci = CourseInstance.objects.get(course_instance_id=course_search_term, course__school=tool_launch_school)
             context['course_instance'] = ci
 
             if ci.canvas_course_id:


### PR DESCRIPTION
Resolves [TLT-4346](https://jira.huit.harvard.edu/browse/TLT-4346).

This PR:
- Adds an additional search constraint in the `lookup` view to remove the user's ability to search for courses outside of the current sub-account
- Unrelated to the story itself, some CSS was added to the delete icon to make the cursor become a pointer on mouseover. This is to make it more clear that the icon is clickable.

Testing:
These changes have been deployed to dev and can be accessed through beta (example sub-account here: https://harvard.beta.instructure.com/accounts/749/external_tools/21863).