### PR TITLE
TLT-4316: Allow dual TA/Student roles for GSD

### DIFF
--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -35,7 +35,7 @@
             var filteredResults = $scope.filterSearchResults(personRecords);
             if (filteredResults.length == 1) {
                 var memberRecordsInCourse = members[filteredResults[0].univ_id];
-                if (angular.isUndefined(memberRecordsInCourse)) {
+                if (angular.isUndefined(memberRecordsInCourse) || $scope.allowDualEnrollment(memberRecordsInCourse, $scope.selectedRole.roleId)) {
                     var name = $scope.getProfileFullName(filteredResults[0]);
                     var postParams = {
                         user_id: filteredResults[0].univ_id,
@@ -71,6 +71,26 @@
             $scope.tracking.failures++;
             return null;
         };
+
+        $scope.getSchool = function() {
+            return $scope.courseInstance.school
+        }
+
+        $scope.allowDualEnrollment = function(member, roleId) {
+            // Check if enrollment request is for TA/Student roles in GSD.
+            // For this school only, we allow a given HUID to be enrolled
+            // twice if (and only if) they are enrolled as one of the
+            // two eligble roles.
+
+            var eligibleSchool = 'GSD'
+            var eligbleRolesIds = [0, 5]
+            var memberRole = member[0].role.role_id
+
+            return ($scope.getSchool() === eligibleSchool
+                && eligbleRolesIds.includes(roleId)
+                && memberRole !== roleId
+            )
+        }
 
         $scope.addNewMemberToCourse = function(userPostParams, userName,
                                                searchTerm) {
@@ -193,7 +213,7 @@
              * we want to sort roles by a combination of two fields.
              * - active = (0 | 1)
              * - prime_role_indicator = ('Y' | 'N' | '')
-             * 
+             *
              * we're sorting descending by active, then descending by
              * prime_role_indicator, where 'Y' > 'N' > ''.
              */
@@ -865,7 +885,7 @@
             ordering: ([1, 'asc']),
             info : false
         };
-        
+
         // configure the datatable
         $scope.dtInstance = null;
         $scope.dtOptions = {

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -80,14 +80,14 @@
             // Check if enrollment request is for TA/Student roles in GSD.
             // For this school only, we allow a given HUID to be enrolled
             // twice if (and only if) they are enrolled as one of the
-            // two eligble roles.
+            // two eligble roles (TA/Student).
 
             var eligibleSchool = 'GSD'
-            var eligbleRolesIds = [0, 5]
+            var eligbleRoleIds = [0, 5]
             var memberRole = member[0].role.role_id
 
             return ($scope.getSchool() === eligibleSchool
-                && eligbleRolesIds.includes(roleId)
+                && eligbleRoleIds.includes(roleId)
                 && memberRole !== roleId
             )
         }


### PR DESCRIPTION
Resolves [TLT-4316](https://jira.huit.harvard.edu/secure/RapidBoard.jspa?rapidView=710&projectKey=TLT&view=detail&selectedIssue=TLT-4316).

This PR adds the ability for GSD courses to enroll a given user as both a Student and TA (two separate enrollments). All other functionality remains the same.

Deployed to dev.

### Testing

To test, search for a GSD course within Search Courses. Select the course and enroll a given user twice, once as a Student and again as a TA. Both enrollments should be accepted.

Attempting to do this outside of a GSD course will result in an error (the same error that has always been present when trying to enroll a user twice).

