### PR TITLE
TLT-4359: Lookup individual course members in place of entire roster

### DIFF
--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -22,13 +22,13 @@
         // set up functions we'll be calling later
         $scope.addNewMember = function(personResult) {
             /* Make a call to add the person to the course as a new member
-             if person is:
-             - not already in `members`
-             - not found in people lookup
+             if the person is:
+             - successfully returned by a person lookup (lookupPeople)
+             - not already enrolled in the course (unless dual-enrollment is allowed)
              - not represented by more than one profile
              Returns a promise representing the call made to add the new member
-             to the course, or null if the add was not attempted for one of the
-             reasons listed above.
+             to the course, or a resolved promise with no further action if one
+             or more of the above criteria fail
              */
             var memberRecords = personResult[0];
             var searchTerm = personResult[1];
@@ -444,6 +444,11 @@
         };
 
         $scope.lookupCourseMember = function(person) {
+            /* Given an array containing person data obtained
+            via a people lookup (lookupPeople) and the original
+            searchTerm, returns a promise representing a call
+            to identify the person's enrollment in the course
+            */
             var personData = person[0]
             var searchTerm = person[1];
             if (personData.length === 0) {
@@ -467,7 +472,7 @@
                     function courseMemberLookupFailure(error) {
                         $scope.tracking.failures++;
                         $scope.messages.warnings.push({
-                            type: 'courseMemberLookupFailed', // check this
+                            type: 'courseMemberLookupFailed',
                             searchTerm: searchTerm
                         });
                         return $q.reject(error);

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -17,7 +17,7 @@
         $scope.peopleData = {};
 
         // Tracks the divID of any currently displayed popovers
-        $scope.popOverID = null;1
+        $scope.popOverID = null;
 
         // set up functions we'll be calling later
         $scope.addNewMember = function(personResult) {

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -41,6 +41,7 @@
                 });
                 $scope.tracking.failures++;
                 return Promise.resolve([memberRecords, searchTerm, peopleData])
+                    .finally($scope.showAddNewMemberResults);
             }
 
             if (peopleData.length > 1) {
@@ -53,6 +54,7 @@
                 });
                 $scope.tracking.failures++;
                 return Promise.resolve([memberRecords, searchTerm, peopleData])
+                    .finally($scope.showAddNewMemberResults);
             }
 
             if (memberRecords.length === 0 || $scope.allowDualEnrollment(memberRecords, $scope.selectedRole.roleId)) {
@@ -61,7 +63,8 @@
                     user_id: peopleData[0].univ_id,
                     role_id: $scope.selectedRole.roleId};
                 return $scope.addNewMemberToCourse(postParams, name,
-                        searchTerm);
+                        searchTerm)
+                        .finally($scope.showAddNewMemberResults);
             } else {
                 // the user already has an enrollment in the course
                 $scope.messages.warnings.push({
@@ -73,6 +76,7 @@
                 });
                 $scope.tracking.failures++;
                 return Promise.resolve([memberRecords, searchTerm, peopleData])
+                    .finally($scope.showAddNewMemberResults);
             }
         }
 
@@ -187,8 +191,7 @@
                         }).finally($scope.updateProgressBar)
                     );
             });
-            $q.all(addNewMemberPromises)
-            .finally($scope.showAddNewMemberResults);
+            $q.all(addNewMemberPromises);
         };
 
         $scope.clearMessages = function() {

--- a/course_info/static/course_info/js/controllers/PeopleController.js
+++ b/course_info/static/course_info/js/controllers/PeopleController.js
@@ -299,36 +299,6 @@
             return ($scope.operationInProgress || ($scope.searchTerms.length == 0));
         };
 
-        $scope.filterSearchResults = function(searchResults){
-            var filteredResults = Array();
-            var resultsDict = {};
-
-            // short circuit if there's no results, which happens on timeout
-            if (!searchResults) {
-                return resultsDict;
-            }
-
-            // create a dict of the id's as keys and the
-            // role records as values
-            for (i = 0; i < searchResults.length; i++) {
-                var role = searchResults[i];
-                if (resultsDict[role.univ_id] != undefined) {
-                    resultsDict[role.univ_id].push(role);
-                } else {
-                    resultsDict[role.univ_id] = [role];
-                }
-            }
-            // for each id sort the role list
-            // and fetch the top record
-            for (id in resultsDict) {
-                var roleList = resultsDict[id];
-                roleList.sort($scope.compareRoles);
-                filteredResults.push(roleList[0]);
-            }
-            // return the filtered list
-            return filteredResults;
-        };
-
         // todo: move this into a service/app.js?
         $scope.getCourseDescription = function(course) {
             // If a course's title is [NULL], attempt to display the short title.
@@ -381,22 +351,6 @@
                 courseInstance['site_list']= siteIds.length>0 ? siteIds.join(', ') : 'N/A';
             }
             return courseInstance;
-        };
-
-        $scope.getMembersByUserId = function(memberList) {
-            /* generates a lookup table/dict/object to find a member's profile
-             by univ_id; used e.g. for checking whether the univ_id found for
-             each person in the search term lookup results is already in the
-             course or not
-             */
-            var membersByUserId = {};
-            memberList.forEach(function(member) {
-                var memberCopy = angular.copy(member);
-
-                membersByUserId[memberCopy.user_id] =
-                    (membersByUserId[memberCopy.user_id] || []).concat(memberCopy);
-            });
-            return membersByUserId;
         };
 
         $scope.getProfileFullName = function(profile) {


### PR DESCRIPTION
Resolves [TLT-4359](https://jira.huit.harvard.edu/browse/TLT-4359).

This PR resolves an issue whereby end users were unable to enroll individuals in large courses (due to a timeout on request to get all course enrollments via the iCommons REST API).

To get around this, this PR:
- Removes the original API call to retrieve all course enrollments
- Adds an API call to determine the potential enrollee's current enrollment in the course
- Refactors the appropriate code to accomodate the above changes

Deployed to dev.

