### PR TITLE
Dependency updates

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -29,9 +29,9 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0#egg=django-harvardkey-cas==3.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v3.0#egg=django-canvas-lti-school-permissions==3.0
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v3.1#egg=django-canvas-lti-school-permissions==3.1
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.2#egg=django-coursemanager==0.2
+git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.3#egg=django-coursemanager==0.3
 
 git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4#egg=canvas_python_sdk==1.4
 


### PR DESCRIPTION
- Updated `django-canvas-lti-school-permissions` to [3.1](https://github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions/releases/tag/v3.1) 

- Updated `django-coursemanager` to [0.3](https://github.com/Harvard-University-iCommons/django-coursemanager/releases/tag/v0.3)