### PR TITLE
WIP: Initial bulk_create_job workflow

### DIFF
--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -1,4 +1,5 @@
 import datetime
+from enum import Enum
 from typing import List, Optional
 
 from ulid import ULID
@@ -7,35 +8,42 @@ from ulid import ULID
 Defines the schema of the dynamodb table.
 """
 
-
 class JobRecord:
     def __init__(
         self,
         school: str,
-        sis_term_id: int,
-        sis_department_id: Optional[int],
-        sis_course_group_id: Optional[int],
-        created_by_user_id: str,
-        course_instance_ids: List[str],
-        workflow_state: str,
-        creator_email: str,
-        user_full_name: str,
+        term_id: str,
+        term_name: Optional[str],
+        department_id: Optional[str],
+        department_name: Optional[str],
+        course_group_id: Optional[str],
+        course_group_name: Optional[str],
+        template_id: Optional[str],
         template_name: Optional[str],
-        template_id: Optional[int],
+        user_id: str,
+        user_full_name: str,
+        user_email: str,
+        workflow_state: str,
     ):
-        self.pk = f"SCHOOL#{school}"
+        self.pk = f"SCHOOL#{school.upper()}"
         self.sk = f"JOB#{str(ULID)}"
-        self.sis_term_id = sis_term_id
-        self.sis_department_id = sis_department_id
-        self.sis_course_group_id = sis_course_group_id
-        self.created_by_user_id = created_by_user_id
-        self.course_instance_ids = course_instance_ids
-        self.workflow_state = workflow_state
-        self.created_at = datetime.datetime.now()
-        self.creator_email = creator_email
-        self.user_full_name = user_full_name
-        self.template_name = template_name
+        self.term_id = term_id
+        self.term_name = term_name
+        self.department_id = department_id
+        self.department_name = department_name
+        self.course_group_id = course_group_id
+        self.course_group_name = course_group_name
         self.template_id = template_id
+        self.template_name = template_name
+        self.user_id = user_id
+        self.user_full_name = user_full_name
+        self.user_email = user_email
+        self.created_at = datetime.datetime.now()
+        self.updated_at = datetime.datetime.now()
+
+        if not is_valid_state(workflow_state):
+            raise ValueError(f"Invalid workflow state: {workflow_state}")
+        self.workflow_state = workflow_state.upper()
 
     def __getitem__(self, key):
         return self.__dict__[key]
@@ -44,12 +52,19 @@ class JobRecord:
         return {
             "pk": self.pk,
             "sk": self.sk,
-            "sis_term_id": self.sis_term_id,
-            "sis_department_id": self.sis_department_id,
-            "sis_course_group_id": self.sis_course_group_id,
-            "created_by_user_id": self.created_by_user_id,
-            "course_instance_ids": self.course_instance_ids,
+            "term_id": self.term_id,
+            "department_id": self.department_id,
+            "department_name": self.department_name,
+            "course_group_id": self.course_group_id,
+            "course_group_name": self.course_group_name,
+            "template_name": self.template_name,
+            "template_id": self.template_id,
+            "user_id": self.user_id,
+            "user_full_name": self.user_full_name,
             "workflow_state": self.workflow_state,
+            "user_email": self.user_email,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
         }
 
 
@@ -57,20 +72,33 @@ class TaskRecord:
     def __init__(
         self,
         job_record: JobRecord,
+        course_instance_id: str,
         workflow_state: str,
-        created_by_user_id: str,
     ):
         self.pk = job_record.sk
         self.sk = f"TASK#{str(ULID)}"
-        self.workflow_state = workflow_state
-        self.created_by_user_id = created_by_user_id
+        self.course_instance_id = course_instance_id
         self.created_at = datetime.datetime.now()
+        self.updated_at = datetime.datetime.now()
+
+        if not is_valid_state(workflow_state):
+            raise ValueError(f"Invalid workflow state: {workflow_state}")
+        self.workflow_state = workflow_state.upper()
 
     def to_dict(self):
         return {
             "pk": self.pk,
             "sk": self.sk,
-            "created_by_user_id": self.created_by_user_id,
             "workflow_state": self.workflow_state,
             "created_at": self.created_at,
+            "updated_at": self.updated_at,
         }
+
+
+class States(Enum):
+    PENDING = "PENDING"
+    IN_PROGRESS = "IN_PROGRESS"
+    COMPLETE = "COMPLETE"
+
+def is_valid_state(workflow_state: str):
+    return workflow_state.upper() in [state.value for state in States]

--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import List, Optional
 
 from ulid import ULID
@@ -6,6 +7,7 @@ from ulid import ULID
 Defines the schema of the dynamodb table.
 """
 
+
 class JobRecord:
     def __init__(
         self,
@@ -13,20 +15,27 @@ class JobRecord:
         sis_term_id: int,
         sis_department_id: Optional[int],
         sis_course_group_id: Optional[int],
-        template_canvas_course_id: int,
         created_by_user_id: str,
         course_instance_ids: List[str],
-        status: str
+        workflow_state: str,
+        creator_email: str,
+        user_full_name: str,
+        template_name: Optional[str],
+        template_id: Optional[int],
     ):
         self.pk = f"SCHOOL#{school}"
         self.sk = f"JOB#{str(ULID)}"
         self.sis_term_id = sis_term_id
         self.sis_department_id = sis_department_id
         self.sis_course_group_id = sis_course_group_id
-        self.template_canvas_course_id = template_canvas_course_id
         self.created_by_user_id = created_by_user_id
         self.course_instance_ids = course_instance_ids
-        self.status = status
+        self.workflow_state = workflow_state
+        self.created_at = datetime.datetime.now()
+        self.creator_email = creator_email
+        self.user_full_name = user_full_name
+        self.template_name = template_name
+        self.template_id = template_id
 
     def __getitem__(self, key):
         return self.__dict__[key]
@@ -38,29 +47,30 @@ class JobRecord:
             "sis_term_id": self.sis_term_id,
             "sis_department_id": self.sis_department_id,
             "sis_course_group_id": self.sis_course_group_id,
-            "template_canvas_course_id": self.template_canvas_course_id,
             "created_by_user_id": self.created_by_user_id,
             "course_instance_ids": self.course_instance_ids,
-            "status": self.status
+            "workflow_state": self.workflow_state,
         }
 
 
 class TaskRecord:
     def __init__(
-        self, job_record: JobRecord, sis_course_id: str, created_by_user_id: str, status: str
+        self,
+        job_record: JobRecord,
+        workflow_state: str,
+        created_by_user_id: str,
     ):
         self.pk = job_record.sk
         self.sk = f"TASK#{str(ULID)}"
-        self.sis_course_id = sis_course_id
-        self.created_by_user_id = created_by_user_id,
-        self.status = status
+        self.workflow_state = workflow_state
+        self.created_by_user_id = created_by_user_id
+        self.created_at = datetime.datetime.now()
 
     def to_dict(self):
         return {
             "pk": self.pk,
             "sk": self.sk,
-            "sis_course_id": self.sis_course_id,
             "created_by_user_id": self.created_by_user_id,
-            "status": self.status
+            "workflow_state": self.workflow_state,
+            "created_at": self.created_at,
         }
-

--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -1,0 +1,66 @@
+from typing import List, Optional
+
+from ulid import ULID
+
+"""
+Defines the schema of the dynamodb table.
+"""
+
+class JobRecord:
+    def __init__(
+        self,
+        school: str,
+        sis_term_id: int,
+        sis_department_id: Optional[int],
+        sis_course_group_id: Optional[int],
+        template_canvas_course_id: int,
+        created_by_user_id: str,
+        course_instance_ids: List[str],
+        status: str
+    ):
+        self.pk = f"SCHOOL#{school}"
+        self.sk = f"JOB#{str(ULID)}"
+        self.sis_term_id = sis_term_id
+        self.sis_department_id = sis_department_id
+        self.sis_course_group_id = sis_course_group_id
+        self.template_canvas_course_id = template_canvas_course_id
+        self.created_by_user_id = created_by_user_id
+        self.course_instance_ids = course_instance_ids
+        self.status = status
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+    def to_dict(self):
+        return {
+            "pk": self.pk,
+            "sk": self.sk,
+            "sis_term_id": self.sis_term_id,
+            "sis_department_id": self.sis_department_id,
+            "sis_course_group_id": self.sis_course_group_id,
+            "template_canvas_course_id": self.template_canvas_course_id,
+            "created_by_user_id": self.created_by_user_id,
+            "course_instance_ids": self.course_instance_ids,
+            "status": self.status
+        }
+
+
+class TaskRecord:
+    def __init__(
+        self, job_record: JobRecord, sis_course_id: str, created_by_user_id: str, status: str
+    ):
+        self.pk = job_record.sk
+        self.sk = f"TASK#{str(ULID)}"
+        self.sis_course_id = sis_course_id
+        self.created_by_user_id = created_by_user_id,
+        self.status = status
+
+    def to_dict(self):
+        return {
+            "pk": self.pk,
+            "sk": self.sk,
+            "sis_course_id": self.sis_course_id,
+            "created_by_user_id": self.created_by_user_id,
+            "status": self.status
+        }
+

--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -1,6 +1,6 @@
 import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 from ulid import ULID
 
@@ -19,14 +19,13 @@ class JobRecord:
         course_group_id: Optional[str],
         course_group_name: Optional[str],
         template_id: Optional[str],
-        template_name: Optional[str],
         user_id: str,
         user_full_name: str,
         user_email: str,
         workflow_state: str,
     ):
         self.pk = f"SCHOOL#{school.upper()}"
-        self.sk = f"JOB#{str(ULID)}"
+        self.sk = f"JOB#{str(ULID())}"
         self.term_id = term_id
         self.term_name = term_name
         self.department_id = department_id
@@ -34,12 +33,11 @@ class JobRecord:
         self.course_group_id = course_group_id
         self.course_group_name = course_group_name
         self.template_id = template_id
-        self.template_name = template_name
         self.user_id = user_id
         self.user_full_name = user_full_name
         self.user_email = user_email
-        self.created_at = datetime.datetime.now()
-        self.updated_at = datetime.datetime.now()
+        self.created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        self.updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
         if not is_valid_state(workflow_state):
             raise ValueError(f"Invalid workflow state: {workflow_state}")
@@ -53,11 +51,11 @@ class JobRecord:
             "pk": self.pk,
             "sk": self.sk,
             "term_id": self.term_id,
+            "term_name": self.term_name,
             "department_id": self.department_id,
             "department_name": self.department_name,
             "course_group_id": self.course_group_id,
             "course_group_name": self.course_group_name,
-            "template_name": self.template_name,
             "template_id": self.template_id,
             "user_id": self.user_id,
             "user_full_name": self.user_full_name,
@@ -76,10 +74,10 @@ class TaskRecord:
         workflow_state: str,
     ):
         self.pk = job_record.sk
-        self.sk = f"TASK#{str(ULID)}"
+        self.sk = f"TASK#{str(ULID())}"
         self.course_instance_id = course_instance_id
-        self.created_at = datetime.datetime.now()
-        self.updated_at = datetime.datetime.now()
+        self.created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        self.updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
         if not is_valid_state(workflow_state):
             raise ValueError(f"Invalid workflow state: {workflow_state}")
@@ -92,6 +90,7 @@ class TaskRecord:
             "workflow_state": self.workflow_state,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            "course_instance_id": self.course_instance_id,
         }
 
 

--- a/bulk_site_creator/tests.py
+++ b/bulk_site_creator/tests.py
@@ -1,34 +1,48 @@
 import json
+from unittest.mock import Mock, patch
 
-from django.test import Client, TestCase
-from django.urls import reverse
+from django.test import Client, RequestFactory, TestCase
+
+from .views import create_bulk_job
 
 
-class BulkCreateJobTestCase(TestCase):
+@patch('lti_permissions.decorators.lti_permission_required_check', new=Mock(return_value=True))
+@patch('django_auth_lti.decorators.is_allowed', new=Mock(return_value=True))
+@patch('lti_permissions.decorators.is_allowed', new=Mock(return_value=True))
+class CreateBulkJobTestCase(TestCase):
     def setUp(self):
-        self.client = Client()
-        self.url = reverse("create_bulk_job")
+        self.Client = Client()
+        self.url = '/bulk_site_creator/create_bulk_job'
         self.data = {
             "canvas_user_id": 1,
             "logged_in_user_id": 2,
             "filters": {
-                "term": "2018-summer",
-                "school": "colgsas",
-                "department": "anthropology",
-                "course_group": 1,
+                "term": "10571",
+                "department": "dept:1864",
+                "course_group": "",
+                "school": "school:hds",
             },
             "course_instance_ids": [1, 2, 3],
+            "create_all": False,
+            "template": "2550"
         }
+        self.json_data = json.dumps(self.data)
 
-    def test_bulk_create_job_post(self):
-        # Make a POST request to the view with the data
-        response = self.client.post(
-            self.url, data=json.dumps(self.data), content_type="application/json"
-        )
+    @patch('bulk_site_creator.utils.get_term_data')
+    @patch('bulk_site_creator.views.get_term_name_by_id')
+    @patch('bulk_site_creator.views.get_department_name_by_id')
+    def test_create_bulk_job(self, mock_department, mock_get_term_name_by_id, mock_get_term_data):
+        mock_department.return_value = "OMS"
+        mock_get_term_data.return_value = {'id': "10571", 'name': "Spring 2021"}
+        mock_get_term_name_by_id.return_value = 'Spring 2021'
 
-        # Assert that the response has a 200 OK status code
+        self.request = RequestFactory().post(self.url, data=self.json_data, content_type='application/json')
+        self.request.LTI = {
+            "lis_person_sourcedid": "12345678",
+            "lis_person_name_full": "First Last",
+            "lis_person_contact_email_primary": "test@test.com",
+        }
+        self.request.user = Mock(is_authenticated=Mock(return_value=True))
+        response = create_bulk_job(self.request)
+
         self.assertEqual(response.status_code, 200)
-
-        # Assert that the response content is what you expect
-        expected_response = {"status": "success"}
-        self.assertEqual(json.loads(response.content), expected_response)

--- a/bulk_site_creator/tests.py
+++ b/bulk_site_creator/tests.py
@@ -1,3 +1,34 @@
-from django.test import TestCase
+import json
 
-# Create your tests here.
+from django.test import Client, TestCase
+from django.urls import reverse
+
+
+class BulkCreateJobTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("create_bulk_job")
+        self.data = {
+            "canvas_user_id": 1,
+            "logged_in_user_id": 2,
+            "filters": {
+                "term": "2018-summer",
+                "school": "colgsas",
+                "department": "anthropology",
+                "course_group": 1,
+            },
+            "course_instance_ids": [1, 2, 3],
+        }
+
+    def test_bulk_create_job_post(self):
+        # Make a POST request to the view with the data
+        response = self.client.post(
+            self.url, data=json.dumps(self.data), content_type="application/json"
+        )
+
+        # Assert that the response has a 200 OK status code
+        self.assertEqual(response.status_code, 200)
+
+        # Assert that the response content is what you expect
+        expected_response = {"status": "success"}
+        self.assertEqual(json.loads(response.content), expected_response)

--- a/bulk_site_creator/urls.py
+++ b/bulk_site_creator/urls.py
@@ -4,4 +4,5 @@ from bulk_site_creator import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('create_bulk_job', views.create_bulk_job, name='create_bulk_job'),
 ]

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -1,8 +1,10 @@
 import logging
 
 from botocore.exceptions import ClientError
-from icommons_common.models import \
-    CourseInstance  # TODO: update to coursemanager.models
+from icommons_common.models import (  # TODO: update to coursemanager.models
+    CourseInstance, Department)
+
+from common.utils import get_canvas_site_template, get_term_data
 
 from .schema import JobRecord, TaskRecord
 
@@ -67,3 +69,9 @@ def get_course_instance_query_set(sis_term_id_id, sis_account_id):
         filters["course__course_group"] = account_id
 
     return CourseInstance.objects.filter(**filters)
+
+def get_term_name_by_id(term_id: str):
+    return get_term_data(term_id).get("name")
+
+def get_department_name_by_id(department_id: str):
+    return Department.objects.get(department_id=department_id).name

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -1,1 +1,13 @@
 import logging
+
+from botocore.exceptions import ClientError
+
+
+# https://boto3.amazonaws.com/v1/documentation/api/latest/guide/dynamodb.html#batch-writing
+def batch_write_item(table, items: list[dict]):
+    try:
+        with table.batch_writer() as batch:
+            for item in items:
+                batch.put_item(Item=item)
+    except ClientError as e:
+        logging.error(e.response["Error"]["Message"])

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -18,7 +18,8 @@ def batch_write_item(table, items: list[dict]):
                 response = batch.put_item(Item=item)
                 logging.info(response)
     except ClientError as e:
-        logging.error(e.response["Error"]["Message"])
+        logging.error(f"Error writing to DynamoDB: {e}")
+        raise
 
 def generate_task_objects(course_instance_ids: list[str], job: JobRecord):
     tasks = []

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -1,13 +1,69 @@
 import logging
 
 from botocore.exceptions import ClientError
+from icommons_common.models import \
+    CourseInstance  # TODO: update to coursemanager.models
 
+from .schema import JobRecord, TaskRecord
+
+logger = logging.getLogger(__name__)
 
 # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/dynamodb.html#batch-writing
 def batch_write_item(table, items: list[dict]):
     try:
         with table.batch_writer() as batch:
             for item in items:
-                batch.put_item(Item=item)
+                response = batch.put_item(Item=item)
+                logging.info(response)
     except ClientError as e:
         logging.error(e.response["Error"]["Message"])
+
+def generate_task_objects(course_instance_ids: list[str], job: JobRecord):
+    tasks = []
+    for ci_id in course_instance_ids:
+        try:
+            task = TaskRecord(job_record=job, course_instance_id=ci_id, workflow_state='PENDING').to_dict()
+            tasks.append(task)
+        except (TypeError, ValueError) as e:
+            logging.error(f"Error creating TaskRecord for job {job['job_id']}: {e}")
+            raise
+    return tasks
+
+def get_course_instances_without_canvas_sites(account, term_id):
+    # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
+    # nor are set to be fed into Canvas via the automated feed
+    ci_query_set_without_canvas = get_course_instance_query_set(
+        term_id, account
+    ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
+
+    # Iterate through the query set to build a list of all the course instance id's
+    # for a school/course_group/department, which course sites will be created for.
+    course_instance_ids = []
+    for ci in ci_query_set_without_canvas:
+        course_instance_ids.append(ci.course_instance_id)
+
+    return course_instance_ids
+
+#  TODO Currently a method in canvas_site_creator models, using for temp testing
+def get_course_instance_query_set(sis_term_id_id, sis_account_id):
+    # Exclude records that have parent_course_instance_id  set(TLT-3558) as we don't want to create sites for the
+    # children; they will be associated with the parent site
+    filters = {
+        "exclude_from_isites": 0,
+        "term_id_id": sis_term_id_id,
+        "parent_course_instance_id__isnull": True,
+    }
+
+    logger.debug(
+        f"Getting CI objects for term_id: {sis_term_id_id} and school: {sis_account_id}"
+    )
+
+    (account_type, account_id) = sis_account_id.split(":")
+    if account_type == "school":
+        filters["course__school"] = account_id
+    elif account_type == "dept":
+        filters["course__department"] = account_id
+    elif account_type == "coursegroup":
+        filters["course__course_group"] = account_id
+
+    return CourseInstance.objects.filter(**filters)

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -12,6 +12,7 @@ from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 from django_auth_lti import const
 from django_auth_lti.decorators import lti_role_required
+from icommons_common.canvas_api.helpers import accounts as canvas_api_accounts
 from icommons_common.canvas_utils import \
     SessionInactivityExpirationRC  # TODO replace this
 from icommons_common.models import (  # TODO: update to coursemanager.models

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional
 
 import boto3
-from canvas_api.helpers import accounts as canvas_api_accounts
+from botocore.exceptions import ClientError
 from canvas_course_site_wizard.models import CanvasSchoolTemplate
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -83,7 +83,7 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
         try:
             term_name = get_term_name_by_id(term_id)
         except Term.DoesNotExist as e:
-            logger.error(f"Term {term_id} does not exist: {e}")
+            logger.info(f"Term {term_id} does not exist: {e}")
             return JsonResponse({"error": "Term does not exist"}, status=400)
     else:
         term_name = None
@@ -100,7 +100,7 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
         try:
             department_name = get_department_name_by_id(department_id)
         except Department.DoesNotExist as e:
-            logger.error(f"Department {department_id} does not exist: {e}")
+            logger.info(f"Department {department_id} does not exist: {e}")
             return JsonResponse({"error": "Department does not exist"}, status=400)
     else:
         department_name = None
@@ -114,7 +114,7 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
         try:
             course_group_name = CourseGroup.objects.get(course_group_id=course_group_id).name
         except CourseGroup.DoesNotExist as e:
-            logger.error(f"Course Group {course_group_id} does not exist: {e}")
+            logger.info(f"Course Group {course_group_id} does not exist: {e}")
             return JsonResponse({"error": "Course Group does not exist"}, status=400)
     else:
         course_group_name = None
@@ -168,7 +168,10 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
 
     # Write the TaskRecords to DynamoDB. We insert these first since the subsequent JobRecord
     # kicks off the downstream bulk workflow via a DynamoDB stream.
-    batch_write_item(table, tasks)
+    try:
+        batch_write_item(table, tasks)
+    except ClientError as e:
+        return JsonResponse({"status": 500})
 
     # Now write the JobRecord to DynamoDB
     response = table.put_item(Item=job.to_dict())

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import boto3
 from canvas_api.helpers import accounts as canvas_api_accounts
+from canvas_course_site_wizard.models import CanvasSchoolTemplate
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, JsonResponse
@@ -11,16 +12,20 @@ from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 from django_auth_lti import const
 from django_auth_lti.decorators import lti_role_required
-from icommons_common.canvas_utils import (
-    SessionInactivityExpirationRC,
-)  # TODO replace this
-from icommons_common.models import CourseInstance, School
+from icommons_common.canvas_utils import \
+    SessionInactivityExpirationRC  # TODO replace this
+from icommons_common.models import (  # TODO: update to coursemanager.models
+    CourseGroup, Department)
 from lti_permissions.decorators import lti_permission_required
 
-from common.utils import get_canvas_site_templates_for_school, get_term_data_for_school
+from common.utils import (get_canvas_site_template,
+                          get_canvas_site_templates_for_school, get_term_data,
+                          get_term_data_for_school)
 
-from .schema import JobRecord, TaskRecord
-from .utils import batch_write_item
+from .schema import JobRecord
+from .utils import (batch_write_item, generate_task_objects,
+                    get_course_instance_query_set,
+                    get_course_instances_without_canvas_sites)
 
 logger = logging.getLogger(__name__)
 
@@ -33,19 +38,17 @@ SDK_CONTEXT = SessionInactivityExpirationRC(**settings.CANVAS_SDK_SETTINGS)
 @require_http_methods(["GET", "POST"])
 def index(request):
     sis_account_id = request.LTI["custom_canvas_account_sis_id"]
-    terms, _current_term_id = get_term_data_for_school(sis_account_id)
+    term_ids, _current_term_id_id = get_term_data_for_school(sis_account_id)
     school_id = sis_account_id.split(":")[1]
-    school = School.objects.get(school_id=school_id)
     canvas_site_templates = get_canvas_site_templates_for_school(school_id)
     potential_course_sites_query = None
 
     if request.method == "POST":
-        selected_term = request.POST["course-term"]
-        selected_template = request.POST["template-select"]
-        # Retrieve all course instances for the given term and account that do not have Canvas course sites
+        selected_term_id = request.POST["course-term_id"]
+        # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed
         potential_course_sites_query = get_course_instance_query_set(
-            selected_term, sis_account_id
+            selected_term_id, sis_account_id
         ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
 
     # TODO maybe better to use template tag unless used elsewhere?
@@ -54,7 +57,7 @@ def index(request):
     )
 
     context = {
-        "terms": terms,
+        "term_ids": term_ids,
         "potential_course_sites": potential_course_sites_query,
         "potential_site_count": potential_course_site_count,
         "canvas_site_templates": canvas_site_templates,
@@ -66,95 +69,96 @@ def index(request):
 @lti_permission_required(settings.PERMISSION_BULK_SITE_CREATOR)
 @require_http_methods(["POST"])
 def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
-    canvas_user_id = request.LTI["custom_canvas_user_id"]
-    logged_in_user_id = request.LTI["lis_person_sourcedid"]
-    user_email = request.LTI["lis_person_contact_email_primary"]
+    user_id = request.LTI["lis_person_sourcedid"]
     user_full_name = request.LTI["list_person_name_full"]
+    user_email = request.LTI["lis_person_contact_email_primary"]
 
     data = json.loads(request.POST["data"])
-    template_id = data.get("template")
-    template_name = data.get("template_name")
-    term_id = data.get("term_id")
-    term_name = data.get("term_name")
     filters = data["filters"]
-    term = filters.get("term")
+
+    term_id = filters.get("term_id")
+    term_name = get_term_data(term_id).get("name")
 
     school_account_id = filters["school"]
     (_, school_id) = canvas_api_accounts.parse_canvas_account_id(school_account_id)
 
-    department = None
+    department_id = None
     department_account_id = filters.get("department")
     if department_account_id:
-        (_, department) = department_account_id.split(":")
+        (_, department_id) = department_account_id.split(":")
 
-    course_group = None
+    try:
+        department_name = Department.objects.get(department_id=department_id).name
+    except Department.DoesNotExist as e:
+        logger.error(f"Department {department_id} does not exist: {e}")
+        return JsonResponse({"error": "Department does not exist"}, status=400)
+
+    course_group_id = None
     course_group_account_id = filters.get("course_group")
     if course_group_account_id:
-        (_, course_group) = course_group_account_id.split(":")
+        (_, course_group_id) = course_group_account_id.split(":")
 
-    created_by_user_id = logged_in_user_id
-    if not created_by_user_id:
-        created_by_user_id = f"canvas_user_id:{canvas_user_id}"
+    try:
+        course_group_name = CourseGroup.objects.get(course_group_id=course_group_id).name
+    except CourseGroup.DoesNotExist as e:
+        logger.error(f"Course Group {course_group_id} does not exist: {e}")
+        return JsonResponse({"error": "Course Group does not exist"}, status=400)
+
+    template_id = data.get("template")
+    try:
+        template_name = get_canvas_site_template(school_id, template_id).name
+    except CanvasSchoolTemplate.DoesNotExist as e:
+        logger.error(f"Template {template_id} does not exist: {e}")
+        return JsonResponse({"error": "Template does not exist"}, status=400)
 
     # If the create_all flag has been set and passed with the form,
     # then create a query to get the all course instances with the applied filters that are to be created.
-    course_instance_ids = []
     if data.get("create_all", False):
         # Get the account data to be used in the course instance query.
         if filters["course_group"]:
-            account = course_group
+            account = course_group_id
         elif filters["department"]:
-            account = department
+            account = department_id
         else:
             account = school_account_id
 
-        # Retrieve all course instances for the given term and account that do not have Canvas course sites
-        # nor are set to be fed into Canvas via the automated feed
-        ci_query_set_without_canvas = get_course_instance_query_set(
-            term, account
-        ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
-
-        # Iterate through the query set to build a list of all the course instance id's
-        # for a school/course_group/department, which course sites will be created for.
-        for ci in ci_query_set_without_canvas:
-            course_instance_ids.append(ci.course_instance_id)
+        course_instance_ids = get_course_instances_without_canvas_sites(account, term_id)
     else:
         course_instance_ids = data["course_instance_ids"]
 
     # Create JobRecord object first so we can reference the job_id in the TaskRecord objects
     try:
         job = JobRecord(
-            school_id,
-            term,
-            department,
-            course_group,
-            created_by_user_id,
-            course_instance_ids,
-            "pending",
-            user_email,
-            user_full_name,
-            template_name,
-            template_id,
+            user_id=user_id,
+            user_full_name=user_full_name,
+            user_email=user_email,
+            school=school_id,
+            term_id=term_id,
+            term_name=term_name,
+            department_id=department_id,
+            department_name=department_name,
+            course_group_id=course_group_id,
+            course_group_name=course_group_name,
+            template_id=template_id,
+            template_name=template_name,
+            workflow_state="PENDING",
         )
     except (TypeError, ValueError) as e:
         logger.error(f"Unexpected input during JobRecord creation: {e}")
-        return JsonResponse({"status": 500})
+        return JsonResponse({"status": 400})
 
-    tasks = []
-    for ci_id in course_instance_ids:
-        try:
-            task = TaskRecord(job, ci_id, created_by_user_id, "pending").to_dict()
-            tasks.append(task)
-        except (TypeError, ValueError) as e:
-            logger.error(f"Error creating TaskRecord for job {job['job_id']}: {e}")
-            return JsonResponse({"status": 500})
+    # Create TaskRecord objects for each course instance
+    try:
+        tasks = generate_task_objects(course_instance_ids, job)
+    except (TypeError, ValueError) as e:
+        return JsonResponse({"status": 400})
 
     dynamodb = boto3.resource("dynamodb")
-    # TODO: Make SSM parameter
-    table_name = "bulk-enrollment-tool-backend-dev-DynamoDbTable-305A936QYVK9"
+    table_name = settings.BULK_COURSE_CREATION.get("dynamo_table_name")
     table = dynamodb.Table(table_name)
 
-    # Write the TaskRecords to DynamoDB
+    # Write the TaskRecords to DynamoDB. We insert these first since the subsequent JobRecord
+    # kicks off the downstream bulk workflow via a DynamoDB stream.
     batch_write_item(table, tasks)
 
     # Now write the JobRecord to DynamoDB
@@ -163,28 +167,3 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
         logger.error(f"Error adding JobRecord to DynamoDB: {response}")
         return JsonResponse({"status": 500})
     return JsonResponse({"status": 200})
-
-
-#  TODO Currently a method in canvas_site_creator models, using for temp testing
-def get_course_instance_query_set(sis_term_id, sis_account_id):
-    # Exclude records that have parent_course_instance_id  set(TLT-3558) as we don't want to create sites for the
-    # children; they will be associated with the parent site
-    filters = {
-        "exclude_from_isites": 0,
-        "term_id": sis_term_id,
-        "parent_course_instance_id__isnull": True,
-    }
-
-    logger.debug(
-        f"Getting CI objects for term: {sis_term_id} and school: {sis_account_id}"
-    )
-
-    (account_type, account_id) = sis_account_id.split(":")
-    if account_type == "school":
-        filters["course__school"] = account_id
-    elif account_type == "dept":
-        filters["course__department"] = account_id
-    elif account_type == "coursegroup":
-        filters["course__course_group"] = account_id
-
-    return CourseInstance.objects.filter(**filters)

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -1,22 +1,27 @@
+import json
 import logging
-from ast import literal_eval
-from uuid import uuid4
+from typing import Optional
 
+import boto3
+from canvas_api.helpers import accounts as canvas_api_accounts
 from django.conf import settings
-from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import redirect, render
-from django.urls import reverse
+from django.http import HttpRequest, JsonResponse
+from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 from django_auth_lti import const
 from django_auth_lti.decorators import lti_role_required
-from icommons_common.canvas_utils import (SessionInactivityExpirationRC) # TODO replace this
+from icommons_common.canvas_utils import (
+    SessionInactivityExpirationRC,
+)  # TODO replace this
+from icommons_common.models import CourseInstance, School
 from lti_permissions.decorators import lti_permission_required
-from common.utils import (
-    get_term_data_for_school,
-    get_canvas_site_templates_for_school,
-)
-from icommons_common.models import School, CourseInstance
+from ulid import ULID
+
+from common.utils import get_canvas_site_templates_for_school, get_term_data_for_school
+
+from .schema import JobRecord, TaskRecord
+from .utils import batch_write_item
 
 logger = logging.getLogger(__name__)
 
@@ -26,50 +31,158 @@ SDK_CONTEXT = SessionInactivityExpirationRC(**settings.CANVAS_SDK_SETTINGS)
 @login_required
 @lti_role_required(const.ADMINISTRATOR)
 @lti_permission_required(settings.PERMISSION_BULK_SITE_CREATOR)
-@require_http_methods(['GET', 'POST'])
+@require_http_methods(["GET", "POST"])
 def index(request):
-    sis_account_id = request.LTI['custom_canvas_account_sis_id']
+    sis_account_id = request.LTI["custom_canvas_account_sis_id"]
     terms, _current_term_id = get_term_data_for_school(sis_account_id)
-    school_id = sis_account_id.split(':')[1]
+    school_id = sis_account_id.split(":")[1]
     school = School.objects.get(school_id=school_id)
     canvas_site_templates = get_canvas_site_templates_for_school(school_id)
     potential_course_sites_query = None
 
-    if request.method == 'POST':
-        selected_term = request.POST['course-term']
-        selected_template = request.POST['template-select']
+    if request.method == "POST":
+        selected_term = request.POST["course-term"]
+        selected_template = request.POST["template-select"]
         # Retrieve all course instances for the given term and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed
-        potential_course_sites_query = get_course_instance_query_set(selected_term, sis_account_id).filter(
-            canvas_course_id__isnull=True, sync_to_canvas=0)
+        potential_course_sites_query = get_course_instance_query_set(
+            selected_term, sis_account_id
+        ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
 
     # TODO maybe better to use template tag unless used elsewhere?
-    potential_course_site_count = potential_course_sites_query.count() if potential_course_sites_query else 0
+    potential_course_site_count = (
+        potential_course_sites_query.count() if potential_course_sites_query else 0
+    )
 
     context = {
-        'terms': terms,
-        'potential_course_sites': potential_course_sites_query,
-        'potential_site_count': potential_course_site_count,
-        'canvas_site_templates': canvas_site_templates
-     }
-    return render(request, 'bulk_site_creator/index.html', context=context)
+        "terms": terms,
+        "potential_course_sites": potential_course_sites_query,
+        "potential_site_count": potential_course_site_count,
+        "canvas_site_templates": canvas_site_templates,
+    }
+    return render(request, "bulk_site_creator/index.html", context=context)
+
+
+@login_required
+@lti_permission_required(settings.PERMISSION_BULK_SITE_CREATOR)
+@require_http_methods(["POST"])
+def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
+    canvas_user_id = request.LTI["custom_canvas_user_id"]
+    logged_in_user_id = request.LTI["lis_person_sourcedid"]
+    data = json.loads(request.POST["data"])
+
+    template_canvas_course_id = data.get("template")
+    filters = data["filters"]
+    term = filters.get("term")
+
+    school_account_id = filters["school"]
+    (_, school_id) = canvas_api_accounts.parse_canvas_account_id(school_account_id)
+
+    department = None
+    department_account_id = filters.get("department")
+    if department_account_id:
+        (_, department) = department_account_id.split(":")
+
+    course_group = None
+    course_group_account_id = filters.get("course_group")
+    if course_group_account_id:
+        (_, course_group) = course_group_account_id.split(":")
+
+    created_by_user_id = logged_in_user_id
+    if not created_by_user_id:
+        created_by_user_id = f"canvas_user_id:{canvas_user_id}"
+
+    # If the create_all flag has been set and passed with the form,
+    # then create a query to get the all course instances with the applied filters that are to be created.
+    course_instance_ids = []
+    if data.get("create_all", False):
+        # Get the account data to be used in the course instance query.
+        if filters["course_group"]:
+            account = filters["course_group"]
+        elif filters["department"]:
+            account = filters["department"]
+        else:
+            account = filters["school"]
+
+        # Retrieve all course instances for the given term and account that do not have Canvas course sites
+        # nor are set to be fed into Canvas via the automated feed
+        ci_query_set_without_canvas = get_course_instance_query_set(
+            term, account
+        ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
+
+        # Iterate through the query set to build a list of all the course instance id's
+        # for a school/course_group/department, which course sites will be created for.
+        for ci in ci_query_set_without_canvas:
+            course_instance_ids.append(ci.course_instance_id)
+    else:
+        course_instance_ids = data["course_instance_ids"]
+
+    # Create JobRecord object first so we can reference the job_id in the TaskRecord objects
+    try:
+        job = JobRecord(
+            school_id,
+            term,
+            department,
+            course_group,
+            template_canvas_course_id,
+            created_by_user_id,
+            course_instance_ids,
+            "pending",
+        )
+    except (TypeError, ValueError) as e:
+        logger.error(f"Unexpected input during JobRecord creation: {e}")
+        return JsonResponse({"status": 500})
+
+    tasks = []
+    for ci_id in course_instance_ids:
+        try:
+            task = TaskRecord(job, ci_id, created_by_user_id, "pending").to_dict()
+            tasks.append(task)
+        except (TypeError, ValueError) as e:
+            logger.error(f"Error creating TaskRecord for job {job['job_id']}: {e}")
+            return JsonResponse({"status": 500})
+
+    dynamodb = boto3.resource("dynamodb")
+    # TODO: Make SSM parameter
+    table_name = "bulk-enrollment-tool-backend-dev-DynamoDbTable-305A936QYVK9"
+    table = dynamodb.Table(table_name)
+
+    # Write the TaskRecords to DynamoDB
+    batch_write_item(table, tasks)
+
+    # Wait for all write operations to complete before adding the JobRecord.
+    # The addition of the JobRecord triggers a DynamoDB stream event
+    # that kicks off downstream processing, so all TaskRecords should be
+    # present at that time.
+    table.meta.client.get_waiter("table_exists").wait(TableName=table_name)
+
+    response = table.put_item(job.to_dict())
+    if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
+        logger.error(f"Error adding JobRecord to DynamoDB: {response}")
+        return JsonResponse({"status": 500})
+    return JsonResponse({"status": 200})
 
 
 #  TODO Currently a method in canvas_site_creator models, using for temp testing
 def get_course_instance_query_set(sis_term_id, sis_account_id):
     # Exclude records that have parent_course_instance_id  set(TLT-3558) as we don't want to create sites for the
     # children; they will be associated with the parent site
-    filters = {'exclude_from_isites': 0, 'term_id': sis_term_id, 'parent_course_instance_id__isnull': True}
+    filters = {
+        "exclude_from_isites": 0,
+        "term_id": sis_term_id,
+        "parent_course_instance_id__isnull": True,
+    }
 
-    logger.debug(f'Getting CI objects for term: {sis_term_id} and school: {sis_account_id}')
+    logger.debug(
+        f"Getting CI objects for term: {sis_term_id} and school: {sis_account_id}"
+    )
 
-    (account_type, account_id) = sis_account_id.split(':')
-    if account_type == 'school':
-        filters['course__school'] = account_id
-    elif account_type == 'dept':
-        filters['course__department'] = account_id
-    elif account_type == 'coursegroup':
-        filters['course__course_group'] = account_id
+    (account_type, account_id) = sis_account_id.split(":")
+    if account_type == "school":
+        filters["course__school"] = account_id
+    elif account_type == "dept":
+        filters["course__department"] = account_id
+    elif account_type == "coursegroup":
+        filters["course__course_group"] = account_id
 
     return CourseInstance.objects.filter(**filters)
-

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -44,3 +44,4 @@ splunk_handler==3.0.0
 python-json-logger==2.0.4
 
 PyLTI1p3==1.12.2
+python-ulid==1.1.0

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -491,7 +491,7 @@ BULK_COURSE_CREATION = {
                                'course sites were created successfully.\n',
     'notification_email_body_failed_count': ' - {} course sites were not '
                                             'created.',
-    'dynamo_table_name': SECURE_SETTINGS.get('dynamo_table_name', None),
+    'site_creator_dynamo_table_name': SECURE_SETTINGS.get('site_creator_dynamo_table_name', None),
 }
 
 

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -491,6 +491,7 @@ BULK_COURSE_CREATION = {
                                'course sites were created successfully.\n',
     'notification_email_body_failed_count': ' - {} course sites were not '
                                             'created.',
+    'dynamo_table_name': SECURE_SETTINGS.get('dynamo_table_name', None),
 }
 
 

--- a/canvas_account_admin_tools/settings/test.py
+++ b/canvas_account_admin_tools/settings/test.py
@@ -6,17 +6,21 @@ SECRET_KEY = 'zd_*c@fm5@inktc5jo1y+t=6m&fx0$81f=vjv*^nk894cfgyg@'
 
 ENV_NAME = 'test'
 
+MIGRATION_MODULES = {
+    "icommons_common": None,
+    "canvas_course_site_wizard": None,
+}
+
 # no router necessary in a test environment
 DATABASE_ROUTERS = []
 
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': SECURE_SETTINGS.get('db_default_name', 'canvas_account_admin_tools_test'),
-        'USER': SECURE_SETTINGS.get('db_default_user', 'postgres'),
-        'PASSWORD': SECURE_SETTINGS.get('db_default_password'),
-        'HOST': SECURE_SETTINGS.get('db_default_host', '127.0.0.1'),
-        'PORT': SECURE_SETTINGS.get('db_default_port', 5432),  # Default postgres port
+        'NAME': 'canvas_account_admin_tools',
+        'USER': 'postgres',
+        'HOST': '127.0.0.1',
+        'PORT': 5432,  # Default postgres port
     },
 }
 


### PR DESCRIPTION
Resolves [TLT-4425](https://jira.huit.harvard.edu/browse/TLT-4425).

This PR sets up the bulk workflow logic within the `bulk_site_creator` app in CAAT. At a high-level, accomplishing this involved:
- Creating a `create_bulk_job` view to carry out this piece of functionality.
- Defining `JobRecord` and `TaskRecord` schemas at the application level in order to ensure proper data format going into DynamoDB.
- Implementing an integration test for testing the view. This test serves as a quick way to validate that the input data can successfully get placed into DynamoDB. This was necessary for validating `create_bulk_job` since the UI has yet to be implemented.
  - The test can be run via `ENV=dev DJANGO_SETTINGS_MODULE=canvas_account_admin_tools.settings.test python manage.py test bulk_site_creator.tests.CreateBulkJobTestCase`.
- Various miscellaneous tasks (e.g. adding an SSM param for the DynamoDB table).