### PR TITLE
TLT-4437: Use lti-school-permissions

### DIFF
--- a/bulk_site_creator/tests.py
+++ b/bulk_site_creator/tests.py
@@ -6,9 +6,9 @@ from django.test import Client, RequestFactory, TestCase
 from .views import create_bulk_job
 
 
-@patch('lti_permissions.decorators.lti_permission_required_check', new=Mock(return_value=True))
+@patch('lti_school_permissions.decorators.lti_permission_required_check', new=Mock(return_value=True))
 @patch('django_auth_lti.decorators.is_allowed', new=Mock(return_value=True))
-@patch('lti_permissions.decorators.is_allowed', new=Mock(return_value=True))
+@patch('lti_school_permissions.decorators.is_allowed', new=Mock(return_value=True))
 class CreateBulkJobTestCase(TestCase):
     def setUp(self):
         self.Client = Client()

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -16,7 +16,7 @@ from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 from django_auth_lti import const
 from django_auth_lti.decorators import lti_role_required
-from lti_permissions.decorators import lti_permission_required
+from lti_school_permissions.decorators import lti_permission_required
 
 from common.utils import (get_canvas_site_template,
                           get_canvas_site_templates_for_school,

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -27,6 +27,8 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
 
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v3.2#egg=django-canvas-lti-school-permissions==3.2
+
 git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0#egg=django-harvardkey-cas==3.0
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.3#egg=django-coursemanager==0.3

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = [
     'icommons_common',
     'icommons_ui',
     'lti_permissions',
+    'lti_school_permissions',
     'people_tool',
     'proxy',
     'publish_courses',
@@ -467,6 +468,20 @@ PERMISSION_CANVAS_SITE_DELETION = 'canvas_site_deletion'
 PERMISSION_SELF_ENROLLMENT_TOOL = 'self_enrollment_tool'
 PERMISSION_MASQUERADE_TOOL = 'masquerade_tool'
 PERMISSION_BULK_SITE_CREATOR = 'bulk_site_creator'
+
+LTI_SCHOOL_PERMISSIONS_TOOL_PERMISSIONS = (
+    PERMISSION_ACCOUNT_ADMIN_TOOLS,
+    PERMISSION_SEARCH_COURSES,
+    PERMISSION_PEOPLE_TOOL,
+    PERMISSION_XLIST_TOOL,
+    PERMISSION_SITE_CREATOR,
+    PERMISSION_PUBLISH_COURSES,
+    PERMISSION_BULK_COURSE_SETTING,
+    PERMISSION_CANVAS_SITE_DELETION,
+    PERMISSION_SELF_ENROLLMENT_TOOL,
+    PERMISSION_MASQUERADE_TOOL,
+    PERMISSION_BULK_SITE_CREATOR
+)
 
 # in search courses, when you add a person to a course. This list
 # controls which roles show up in the drop down. The list contains


### PR DESCRIPTION
Depends on the [PR](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/pull/374) for TLT-4435.

This PR:
- Replaces the `icommons_common` version of our permissions library with `django-canvas-lti-school-permissions`.