### PR TITLE
Bulk Site Creator V2 Front End Second Pass

### DIFF
--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -41,7 +41,7 @@ class JobRecord:
 
         if not is_valid_state(workflow_state):
             raise ValueError(f"Invalid workflow state: {workflow_state}")
-        self.workflow_state = workflow_state.upper()
+        self.workflow_state = workflow_state.lower()
 
     def __getitem__(self, key):
         return self.__dict__[key]
@@ -72,16 +72,22 @@ class TaskRecord:
         job_record: JobRecord,
         course_instance_id: str,
         workflow_state: str,
+        canvas_course_id: str,
+        course_code: str,
+        course_title: str
     ):
         self.pk = job_record.sk
         self.sk = f"TASK#{str(ULID())}"
         self.course_instance_id = course_instance_id
+        self.canvas_course_id = canvas_course_id
+        self.course_code = course_code
+        self.course_title = course_title
         self.created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
         self.updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
         if not is_valid_state(workflow_state):
             raise ValueError(f"Invalid workflow state: {workflow_state}")
-        self.workflow_state = workflow_state.upper()
+        self.workflow_state = workflow_state.lower()
 
     def to_dict(self):
         return {
@@ -91,13 +97,17 @@ class TaskRecord:
             "created_at": self.created_at,
             "updated_at": self.updated_at,
             "course_instance_id": self.course_instance_id,
+            "canvas_course_id": self.canvas_course_id,
+            "course_code": self.course_code,
+            "course_title": self.course_title
         }
 
 
 class States(Enum):
-    PENDING = "PENDING"
-    IN_PROGRESS = "IN_PROGRESS"
-    COMPLETE = "COMPLETE"
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETE = "complete"
+
 
 def is_valid_state(workflow_state: str):
-    return workflow_state.upper() in [state.value for state in States]
+    return workflow_state.lower() in [state.value for state in States]

--- a/bulk_site_creator/templates/bulk_site_creator/base.html
+++ b/bulk_site_creator/templates/bulk_site_creator/base.html
@@ -21,18 +21,13 @@
           media="screen"/>
 
     <script src="https://static.tlt.harvard.edu/shared/jquery-3.6.3/jquery-3.6.3.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/bootstrap-5.3.0/js/bootstrap.min.js"></script>
     <script src="https://static.tlt.harvard.edu/shared/DataTables-1.13.2/js/jquery.dataTables.min.js"></script>
     <script src="https://static.tlt.harvard.edu/shared/DataTables-1.13.2/js/dataTables.bootstrap5.min.js"></script>
     <script src="https://static.tlt.harvard.edu/shared/Select-1.6.0/js/select.bootstrap5.min.js"></script>
     <script src="https://static.tlt.harvard.edu/shared/Select-1.6.0/js/select.dataTables.min.js"></script>
-
-      <!--    <link rel="stylesheet" type="text/css"-->
-<!--          href="https://static.tlt.harvard.edu/shared/datatables-1.10.15/media/css/jquery.dataTables.min.css"-->
-<!--          media="screen"/>-->
-
-<!--    <script src="https://static.tlt.harvard.edu/shared/jquery-2.2.2/jquery-2.2.2.js"></script>-->
-<!--    <script src="https://static.tlt.harvard.edu/shared/datatables-1.10.15/media/js/jquery.dataTables.js"></script>-->
-<!--    <script src="https://static.tlt.harvard.edu/shared/bootstrap-3.3.6/dist/js/bootstrap.js"></script>-->
+    <script src="https://static.tlt.harvard.edu/shared/Select-1.6.0/js/select.jqueryui.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/Select-1.6.0/js/dataTables.select.min.js"></script>
 
     {% include 'django_auth_lti/resource_link_id.html' %}
 

--- a/bulk_site_creator/templates/bulk_site_creator/base.html
+++ b/bulk_site_creator/templates/bulk_site_creator/base.html
@@ -9,22 +9,30 @@
           content="width=device-width, initial-scale=1, user-scalable=no">
     <link href="https://static.tlt.harvard.edu/shared/favicon.ico" rel="icon" type="image/x-icon">
     <link rel="stylesheet" type="text/css"
-          href="https://static.tlt.harvard.edu/shared/font-awesome-4.5.0/css/font-awesome.min.css">
+          href="https://static.tlt.harvard.edu/shared/fontawesome-6.3.0/css/all.min.css">
     <link rel="stylesheet" type="text/css"
-          href="https://static.tlt.harvard.edu/shared/bootstrap-3.3.6/dist/css/bootstrap.min.css"
+          href="https://static.tlt.harvard.edu/shared/bootstrap-5.3.0/css/bootstrap.min.css"
           media="screen"/>
-<!--    <link rel="stylesheet" type="text/css"-->
+    <link rel="stylesheet" type="text/css"
+          href="https://static.tlt.harvard.edu/shared/DataTables-1.13.2/css/dataTables.bootstrap5.min.css"
+          media="screen"/>
+    <link rel="stylesheet" type="text/css"
+          href="https://static.tlt.harvard.edu/shared/Select-1.6.0/css/select.bootstrap5.min.css"
+          media="screen"/>
+
+    <script src="https://static.tlt.harvard.edu/shared/jquery-3.6.3/jquery-3.6.3.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/DataTables-1.13.2/js/jquery.dataTables.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/DataTables-1.13.2/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/Select-1.6.0/js/select.bootstrap5.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/Select-1.6.0/js/select.dataTables.min.js"></script>
+
+      <!--    <link rel="stylesheet" type="text/css"-->
 <!--          href="https://static.tlt.harvard.edu/shared/datatables-1.10.15/media/css/jquery.dataTables.min.css"-->
 <!--          media="screen"/>-->
 
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/ju/jq-3.6.0/dt-1.13.2/sl-1.6.0/datatables.min.css"/>
-
-<script type="text/javascript" src="https://cdn.datatables.net/v/ju/jq-3.6.0/dt-1.13.2/sl-1.6.0/datatables.min.js"></script>
-
-
 <!--    <script src="https://static.tlt.harvard.edu/shared/jquery-2.2.2/jquery-2.2.2.js"></script>-->
 <!--    <script src="https://static.tlt.harvard.edu/shared/datatables-1.10.15/media/js/jquery.dataTables.js"></script>-->
-    <script src="https://static.tlt.harvard.edu/shared/bootstrap-3.3.6/dist/js/bootstrap.js"></script>
+<!--    <script src="https://static.tlt.harvard.edu/shared/bootstrap-3.3.6/dist/js/bootstrap.js"></script>-->
 
     {% include 'django_auth_lti/resource_link_id.html' %}
 
@@ -35,6 +43,13 @@
     <script>
       window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';
     </script>
+
+      <style>
+          a {
+            color: #337ab7;
+            text-decoration: none;
+            }
+      </style>
 
     {% block js %}
     {% endblock %}

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -14,23 +14,23 @@
     <div class="container-fluid">
         {% for message in messages %}
             {% if message.level_tag == "success" %}
-                <div class="alert alert-success" role="alert">
-                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                <div class="alert alert-success alert-dismissible fade show" role="alert">
+                    <button type="button" class="btn-close" data-bs-dismiss="alert">&times;</button>
                     {{ message }}
                 </div>
             {% elif message.level_tag == "error" %}
-                <div class="alert alert-danger" role="alert">
-                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                    <button type="button" class="btn-close" data-bs-dismiss="alert">&times;</button>
                     {{ message }}
                 </div>
             {% elif message.level_tag == "warning" %}
-                <div class="alert alert-warning" role="alert">
-                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                <div class="alert alert-warning alert-dismissible fade show" role="alert">
+                    <button type="button" class="btn-close" data-bs-dismiss="alert">&times;</button>
                     {{ message }}
                 </div>
             {% else %}
-                <div class="alert" role="alert">
-                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                <div class="alert alert-dismissible fade show" role="alert">
+                    <button type="button" class="btn-close" data-bs-dismiss="alert">&times;</button>
                     {{ message }}
                 </div>
             {% endif %}
@@ -40,6 +40,7 @@
     <div class="row container-fluid">
         <h3>
             Bulk Creation Jobs:
+            <!--TODO add refresh button-->
             <a href="{% url 'bulk_site_creator:new_job' %}" class="btn btn-primary" style="float: right;">New Job</a>
         </h3>
         <table class="datatable table table-striped table-bordered dataTable no-footer">
@@ -59,7 +60,7 @@
                     <td><a href="{% url 'bulk_site_creator:job_detail' job_id=bulk_job.sk %}">{{ bulk_job.sk }}</a></td>
                     <td>{{ bulk_job.created_at }}</td>
                     <td>{{ bulk_job.term_name }}</td>
-                    <td>{{ bulk_job.CREATOR_NAME }}</td>
+                    <td>{{ bulk_job.creator_name }}</td>
                     <td>{{ bulk_job.workflow_state }}</td>
                     <td>{{ bulk_job.summary }}</td>
                 </tr>

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -2,12 +2,13 @@
 
 {% block body %}
 <nav>
-  <h3>
+  <h3 class="breadcrumbs">
     <a href="{% url 'dashboard_account' %}">Admin Console</a>
-    <small><i class="fa fa-chevron-right"></i></small>
+    <i class="fa-solid fa-chevron-right"></i>
     Bulk Site Creator
   </h3>
 </nav>
+
 
 <body role="application">
     <div class="container-fluid">
@@ -39,9 +40,9 @@
     <div class="row container-fluid">
         <h3>
             Bulk Creation Jobs:
-            <a href="{% url 'bulk_site_creator:new_job' %}" class="btn btn-primary pull-right">New Job</a>
+            <a href="{% url 'bulk_site_creator:new_job' %}" class="btn btn-primary" style="float: right;">New Job</a>
         </h3>
-        <table class="datatable table display no-footer">
+        <table class="datatable table table-striped table-bordered dataTable no-footer">
             <thead>
                 <tr>
                     <th>Job ID</th>

--- a/bulk_site_creator/templates/bulk_site_creator/job_detail.html
+++ b/bulk_site_creator/templates/bulk_site_creator/job_detail.html
@@ -2,11 +2,11 @@
 
 {% block body %}
   <nav>
-    <h3>
+    <h3 class="breadcrumbs">
       <a href="{% url 'dashboard_account' %}">Admin Console</a>
-      <small><i class="fa fa-chevron-right"></i></small>
+      <i class="fa-solid fa-chevron-right"></i>
       <a href="{% url 'bulk_site_creator:index' %}">Bulk Site Creator</a>
-      <small><i class="fa fa-chevron-right"></i></small>
+      <i class="fa-solid fa-chevron-right"></i>
       Job Detail
     </h3>
   </nav>

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -14,47 +14,70 @@
 <body role="application">
     <div class="container-fluid">
         {% if terms %}
-            <form class="form-inline" method="POST" action="{% url 'bulk_site_creator:new_job' %}">{% csrf_token %}
+            <form id="ci-filters" class="form-inline" method="POST" action="{% url 'bulk_site_creator:new_job' %}">{% csrf_token %}
                 <div class="row">
                     <div class="col-sm-6 margin-bottom-md">
-                        <label for="course-term">Term
+                        <label for="courseTerm">Term
                             <span class="required-field-marker">*</span>
                         </label>
                         <br>
-                        <select id="course-term" name="course-term" class="form-control">
+                        <select id="courseTerm" name="courseTerm" class="form-control">
                             {% for term in terms %}
-                                <option value="{{ term.id }}">{{ term.name }}</option>
+                                {% if selected_term_id == term.id %}
+                                    <option value="{{ term.id }}" selected>{{ term.name }}</option>
+                                {% else %}
+                                    <option value="{{ term.id }}">{{ term.name }}</option>
+                                {% endif %}
                             {% endfor %}
                         </select>
                         <br>
                         {% if departments %}
-                            <label for="course-term">Department
+                            <label for="courseDepartment">Department
                                 <span class="required-field-marker">*</span>
                             </label>
                             <br>
-                            <select id="course-department" name="course-department" class="form-control">
-                                <option value="0" selected>Department</option>
+                            <select id="courseDepartment" name="courseDepartment" class="form-control">
+                                {% if not selected_department_id %}
+                                    <option value="0" selected>Department</option>
+                                {% else %}
+                                    <option value="0">Department</option>
+                                {% endif %}
                                 {% for department in departments %}
-                                    <option value="{{ department.id }}">{{ department.name }}</option>
+                                    {% if selected_department_id and selected_department_id == department.id %}
+                                        <option value="{{ department.id }}" selected>{{ department.name }}</option>
+                                    {% else %}
+                                        <option value="{{ department.id }}">{{ department.name }}</option>
+                                    {% endif %}
                                 {% endfor %}
                             </select>
                             <br>
                         {% elif course_groups %}
-                            <label for="course-term">Course Group
+                            <label for="courseCourseGroup">Course Group
                                 <span class="required-field-marker">*</span>
                             </label>
                             <br>
-                            <select id="course-course-group" name="course-course-group" class="form-control">
-                                <option value="0" selected>Course Group</option>
+                            <select id="courseCourseGroup" name="courseCourseGroup" class="form-control">
+                                {% if not selected_course_group_id %}
+                                    <option value="0" selected>Course Group</option>
+                                {% else %}
+                                    <option value="0">Course Group</option>
+                                {% endif %}
                                 {% for course_group in course_groups %}
-                                    <option value="{{ course_group.id }}">{{ course_group.name }}</option>
+                                    {% if selected_course_group_id and selected_course_group_id == course_group.id %}
+                                        <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
+                                    {% else %}
+                                        <option value="{{ course_group.id }}">{{ course_group.name }}</option>
+                                    {% endif %}
                                 {% endfor %}
                             </select>
                         {% endif %}
                     </div>
-
                     <div class="col-md-12">
-                        <button id="find-courses-in-term" type="submit" class="btn btn-primary" style="margin-top: 25px; margin-bottom: 25px;">
+                        <button id="find-courses-in-term"
+                                type="submit"
+                                class="btn btn-primary"
+                                style="margin-top: 25px; margin-bottom: 25px;"
+                                onclick="displayLoading()">
                             Find Courses
                         </button>
                     </div>
@@ -69,8 +92,8 @@
             <div class="row">
                 <h4>{{ potential_site_count }} courses ready for Canvas course site creation</h4>
                 <div class="col-sm-6 margin-bottom-md">
-                    <select id="template-select" class="form-control">
-                        <option value="no-template">
+                    <select id="templateSelect" class="form-control">
+                        <option value="0">
                             No Template
                         </option>
                         {% for site_template in canvas_site_templates %}
@@ -86,7 +109,7 @@
                     <br>
                     <p>You may select individual courses from the list below to customize your Canvas course site creation job.</p>
                 </div>
-                <table class="datatable table table-striped table-bordered dataTable no-footer">
+                <table id="course-table" class="datatable table table-striped table-bordered dataTable no-footer">
                     <thead>
                         <tr>
                             <th></th>
@@ -108,6 +131,11 @@
                     {% endfor %}
                     </tbody>
                 </table>
+                <form id="submitJob" method="POST" action="{% url 'bulk_site_creator:create_bulk_job' %}">{% csrf_token %}
+                    <input id="termID" name="termID" type="hidden" value={{ selected_term_id }}>
+                    <input id="courseGroupID" name="courseGroupID" type="hidden" value={{ selected_course_group_id }}>
+                    <input id="departmentID" name="departmentID" type="hidden" value={{ selected_department_id }}>
+                </form>
             </div>
 
             <!-- Confirmation Modal -->
@@ -122,8 +150,8 @@
                     Are you sure you would like to proceed?
                   </div>
                   <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                    <button type="button" class="btn btn-primary">Yes</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" >Close</button>
+                    <button type="button" class="btn btn-primary" id="confirmCreateButton">Yes</button>
                   </div>
                 </div>
               </div>
@@ -136,7 +164,7 @@
 {% block js %}
     <script>
 		$(document).ready(function() {
-			$('.datatable').DataTable( {
+			 table = $('.datatable').DataTable( {
                 columnDefs: [ {
                     orderable: false,
                     className: 'select-checkbox',
@@ -148,7 +176,55 @@
                 },
                 order: [[ 1, 'asc' ]]
             } );
-		});
+
+            $('#confirmCreateButton').on('click', function () {
+                var selectedRows = table.rows( { selected: true } ).data();
+                var courseInstanceIDList = buildCourseInstanceIDList(selectedRows);
+                var selectedCourseCount = selectedRows.count();
+                var selectedTemplate = $("#templateSelect").find(":selected").val();
+                var createAll = false;
+
+                // If no items have been selected, this will be a "Create All" job
+                // Set the createAll flag to true
+                if (selectedCourseCount == 0){
+                    createAll = true;
+                }
+                var data = {
+                    course_instance_ids: courseInstanceIDList,
+                    create_all: createAll,
+                    template: selectedTemplate
+                };
+                $('<input>').attr({
+                    type: 'hidden',
+                    id: 'data',
+                    name: 'data'
+                }).val(JSON.stringify(data)).appendTo("#submitJob");
+                $("#submitJob").submit();
+            });
+        });
+
+        function displayLoading() {
+            // Disable the search for courses button and display a loading spinner before submitting the form
+
+            var button = $("#find-courses-in-term");
+            // disable button
+            button.prop("disabled", true);
+            // add spinner to button
+            button.html(
+                `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Loading...`
+            );
+            $("#ci-filters").submit();
+        };
+
+        function buildCourseInstanceIDList(rowList) {
+            // Iterate over the given row list and return a list containing the course instance ids from each row
+            var ciIDList = [];
+
+            for (let i = 0; i < rowList.length; i++) {
+                ciIDList.push(rowList[i][1])
+            }
+            return ciIDList;
+        };
 	</script>
 {% endblock js %}
 

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -2,11 +2,11 @@
 
 {% block body %}
 <nav>
-  <h3>
+  <h3 class="breadcrumbs">
     <a href="{% url 'dashboard_account' %}">Admin Console</a>
-    <small><i class="fa fa-chevron-right"></i></small>
+    <i class="fa-solid fa-chevron-right"></i>
     <a href="{% url 'bulk_site_creator:index' %}">Bulk Site Creator</a>
-    <small><i class="fa fa-chevron-right"></i></small>
+    <i class="fa-solid fa-chevron-right"></i>
       New Job
   </h3>
 </nav>
@@ -54,61 +54,60 @@
                     </div>
 
                     <div class="col-md-12">
-                        <button id="find-courses-in-term" type="submit" class="btn btn-primary pull-right">
+                        <button id="find-courses-in-term" type="submit" class="btn btn-primary" style="margin-top: 25px; margin-bottom: 25px;">
                             Find Courses
                         </button>
                     </div>
                 </div>
             </form>
         {% else %}
-            Placeholder text for no terms for the current school
+            No terms exist for this account
         {% endif %}
 
         {% if potential_course_sites %}
-            <div class="row container-fluid">
-                <div class="row">
-                    <h4>{{ potential_site_count }} courses ready for Canvas course site creation</h4>
-                    <div class="col-sm-6 margin-bottom-md">
-                        <select id="template-select" class="form-control">
-                            <option value="no-template">
-                                No Template
+            <hr>
+            <div class="row">
+                <h4>{{ potential_site_count }} courses ready for Canvas course site creation</h4>
+                <div class="col-sm-6 margin-bottom-md">
+                    <select id="template-select" class="form-control">
+                        <option value="no-template">
+                            No Template
+                        </option>
+                        {% for site_template in canvas_site_templates %}
+                            <option value="{{ site_template.canvas_course_id }}">
+                                {{ site_template.canvas_course_name }}
                             </option>
-                            {% for site_template in canvas_site_templates %}
-                                <option value="{{ site_template.canvas_course_id }}">
-                                    {{ site_template.canvas_course_name }}
-                                </option>
-                            {% endfor %}
-                        </select>
-                        <br>
-                        <button type="button" ng-cloak class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmCreate">Create All</button>
-                        <button type="button" ng-cloak class="btn btn-primary" data-toggle="modal" data-target="#confirmCreate">Create Selected</button>
-                        <br>
-                        <br>
-                        <p>You may select individual courses from the list below to customize your Canvas course site creation job.</p>
-                    </div>
-                    <table class="datatable table display no-footer">
-                        <thead>
-                            <tr>
-                                <th></th>
-                                <th>SIS ID</th>
-                                <th>Course Code</th>
-                                <th>Course Title</th>
-                                <th>Course Section</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for potential_course_site in potential_course_sites %}
-                            <tr>
-                                <td></td>
-                                <td>{{ potential_course_site.course_instance_id }}</td>
-                                <td>{{ potential_course_site.short_title }}</td>
-                                <td>{{ potential_course_site.title }}</td>
-                                <td>{{ potential_course_site.section }}</td>
-                            </tr>
                         {% endfor %}
-                        </tbody>
-                    </table>
+                    </select>
+                    <br>
+                    <button type="button" ng-cloak class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmCreate">Create All</button>
+                    <button type="button" ng-cloak class="btn btn-primary" data-toggle="modal" data-target="#confirmCreate">Create Selected</button>
+                    <br>
+                    <br>
+                    <p>You may select individual courses from the list below to customize your Canvas course site creation job.</p>
                 </div>
+                <table class="datatable table table-striped table-bordered dataTable no-footer">
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>SIS ID</th>
+                            <th>Course Code</th>
+                            <th>Course Title</th>
+                            <th>Course Section</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for potential_course_site in potential_course_sites %}
+                        <tr>
+                            <td></td>
+                            <td>{{ potential_course_site.course_instance_id }}</td>
+                            <td>{{ potential_course_site.short_title }}</td>
+                            <td>{{ potential_course_site.title }}</td>
+                            <td>{{ potential_course_site.section }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
             </div>
 
             <!-- Confirmation Modal -->

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -28,10 +28,20 @@ def generate_task_objects(course_instances: list[dict], job: JobRecord):
     tasks = []
     for ci in course_instances:
         try:
+            # course_code block taken from feed_course_sections_enrollments
+            # management command in the canvas_integration project
+            course_code = None
+            if ci.short_title != '':
+                course_code = ci.short_title
+            elif ci.course.registrar_code_display != '':
+                course_code = ci.course.registrar_code_display
+            else:
+                course_code = ci.course.registrar_code
+
             task = TaskRecord(job_record=job,
                               course_instance_id=ci.course_instance_id,
-                              course_code=ci.course_code,
-                              course_title=ci.course_title,
+                              course_code=course_code,
+                              course_title=ci.title,
                               canvas_course_id=ci.canvas_course_id,
                               workflow_state='pending').to_dict()
             tasks.append(task)
@@ -57,7 +67,6 @@ def get_course_instances_without_canvas_sites(account, term_id):
     return course_instance_ids
 
 
-#  TODO Currently a method in canvas_site_creator models, using for temp testing
 def get_course_instance_query_set(sis_term_id, sis_account_id):
     # Exclude records that have parent_course_instance_id  set(TLT-3558) as we don't want to create sites for the
     # children; they will be associated with the parent site

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -10,6 +10,8 @@ from .schema import JobRecord, TaskRecord
 
 logger = logging.getLogger(__name__)
 
+# TODO add documentation to each method
+
 # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/dynamodb.html#batch-writing
 def batch_write_item(table, items: list[dict]):
     try:
@@ -22,18 +24,23 @@ def batch_write_item(table, items: list[dict]):
         raise
 
 
-def generate_task_objects(course_instance_ids: list[str], job: JobRecord):
+def generate_task_objects(course_instances: list[dict], job: JobRecord):
     tasks = []
-    for ci_id in course_instance_ids:
+    for ci in course_instances:
         try:
-            task = TaskRecord(job_record=job, course_instance_id=ci_id, workflow_state='PENDING').to_dict()
+            task = TaskRecord(job_record=job,
+                              course_instance_id=ci.course_instance_id,
+                              course_code=ci.course_code,
+                              course_title=ci.course_title,
+                              canvas_course_id=ci.canvas_course_id,
+                              workflow_state='pending').to_dict()
             tasks.append(task)
         except (TypeError, ValueError) as e:
-            logging.error(f"Error creating TaskRecord for job {job['job_id']}: {e}")
+            logging.error(f"Error creating TaskRecord for job {job.sk}: {e}")
             raise
     return tasks
 
-#  TODO delete
+#  TODO delete, seems to be a dupe
 def get_course_instances_without_canvas_sites(account, term_id):
     # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
     # nor are set to be fed into Canvas via the automated feed

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -33,7 +33,7 @@ def generate_task_objects(course_instance_ids: list[str], job: JobRecord):
             raise
     return tasks
 
-
+#  TODO delete
 def get_course_instances_without_canvas_sites(account, term_id):
     # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
     # nor are set to be fed into Canvas via the automated feed
@@ -74,8 +74,10 @@ def get_course_instance_query_set(sis_term_id, sis_account_id):
 
     return CourseInstance.objects.filter(**filters)
 
+
 def get_term_name_by_id(term_id: str):
     return get_term_data(term_id).get("name")
+
 
 def get_department_name_by_id(department_id: str):
     return Department.objects.get(department_id=department_id).name

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -10,7 +10,7 @@ from canvas_course_site_wizard.models import CanvasSchoolTemplate
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, JsonResponse
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.views.decorators.http import require_http_methods
 from django_auth_lti import const
 from django_auth_lti.decorators import lti_role_required
@@ -50,6 +50,7 @@ table = dynamodb.Table(table_name)
 @lti_permission_required(settings.PERMISSION_BULK_SITE_CREATOR)
 @require_http_methods(["GET", "POST"])
 def index(request):
+    print(request.LTI)
     sis_account_id = request.LTI["custom_canvas_account_sis_id"]
     school_id = sis_account_id.split(":")[1]
     school_key = f'SCHOOL#{school_id.upper()}'
@@ -104,6 +105,9 @@ def new_job(request):
     potential_course_sites_query = None
     departments = []
     course_groups = []
+    selected_term_id = None
+    selected_course_group_id = None
+    selected_department_id = None
 
     # Only display the Course Groups dropdown if the tool is launched in the COLGSAS sub-account
     if school_id == 'colgsas':
@@ -119,9 +123,13 @@ def new_job(request):
             logger.exception(f"Failed to get departments with sis_account_id {sis_account_id}")
 
     if request.method == "POST":
-        selected_term_id = request.POST["course-term"]
+        selected_term_id = request.POST.get("courseTerm", None)
+        selected_course_group_id = request.POST.get("courseCourseGroup", None)
+        selected_department_id = request.POST.get("department", None)
+
         # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed
+        # TODO Add bulk_processing flag to filter
         potential_course_sites_query = get_course_instance_query_set(
             selected_term_id, sis_account_id
         ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
@@ -137,7 +145,10 @@ def new_job(request):
         "potential_site_count": potential_course_site_count,
         "canvas_site_templates": canvas_site_templates,
         "departments": departments,
-        "course_groups": course_groups
+        "course_groups": course_groups,
+        'selected_term_id': selected_term_id,
+        'selected_course_group_id': selected_course_group_id,
+        'selected_department_id': selected_department_id
     }
 
     return render(request, "bulk_site_creator/new_job.html", context=context)
@@ -150,104 +161,172 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
     user_id = request.LTI["lis_person_sourcedid"]
     user_full_name = request.LTI["lis_person_name_full"]
     user_email = request.LTI["lis_person_contact_email_primary"]
+    sis_account_id = request.LTI["custom_canvas_account_sis_id"]
+    school_id = sis_account_id.split(":")[1]
+    # school_name =
 
-    data = json.loads(request.body)
-    filters = data["filters"]
+    table_data = json.loads(request.POST['data'])
 
-    term_id = filters.get("term")
-    if term_id:
-        try:
-            term_name = get_term_name_by_id(term_id)
-        except Term.DoesNotExist as e:
-            logger.info(f"Term {term_id} does not exist: {e}")
-            return JsonResponse({"error": "Term does not exist"}, status=400)
-    else:
-        term_name = None
+    term_id = request.POST['termID']
+    term_name = get_term_name_by_id(term_id)
+    course_group_id = request.POST['courseGroupID']
+    course_group_name = None
+    department_id = request.POST['departmentID']
+    department_name = None
+    create_all = table_data['create_all']
+    course_instance_ids = table_data['course_instance_ids']
+    template_id = table_data['template']
 
-    school_account_id = filters["school"]
-    (_, school_id) = canvas_api_accounts.parse_canvas_account_id(school_account_id)
+    if create_all:
+        # Get all course instance records that will have Canvas sites created by filtering on the
+        # term and (course group or department) values
 
-    department_id = None
-    department_account_id = filters.get("department")
-    if department_account_id:
-        (_, department_id) = department_account_id.split(":")
+        # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
+        # nor are set to be fed into Canvas via the automated feed.
+        # Also filter on the 'bulk_processing' flag to avoid multiple job submission conflicts
+        # TODO Add bulk_processing flag to filter
+        potential_course_sites_query = get_course_instance_query_set(
+            term_id, sis_account_id
+        ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
 
-    if department_id:
-        try:
-            department_name = get_department_name_by_id(department_id)
-        except Department.DoesNotExist as e:
-            logger.info(f"Department {department_id} does not exist: {e}")
-            return JsonResponse({"error": "Department does not exist"}, status=400)
-    else:
-        department_name = None
-
-    course_group_id = None
-    course_group_account_id = filters.get("course_group")
-    if course_group_account_id:
-        (_, course_group_id) = course_group_account_id.split(":")
-
-    if course_group_id:
-        try:
-            course_group_name = CourseGroup.objects.get(course_group_id=course_group_id).name
-        except CourseGroup.DoesNotExist as e:
-            logger.info(f"Course Group {course_group_id} does not exist: {e}")
-            return JsonResponse({"error": "Course Group does not exist"}, status=400)
-    else:
-        course_group_name = None
-
-    template_id = data.get("template")
-
-    # If the create_all flag has been set and passed with the form,
-    # then create a query to get the all course instances with the applied filters that are to be created.
-    if data.get("create_all", False):
-        # Get the account data to be used in the course instance query.
-        if filters["course_group"]:
-            account = course_group_id
-        elif filters["department"]:
-            account = department_id
+        # Check if a course group or department filter needs to be applied to queryset
+        if school_id == 'colgsas':
+            if course_group_id and course_group_id != '0':
+                course_group_name = CourseGroup.objects.get(course_group_id=course_group_id).name
+                potential_course_sites_query = potential_course_sites_query.filter(course__course_group=course_group_id.split(":")[1])
         else:
-            account = school_account_id
+            if department_id and department_id != '0':
+                department_name = get_department_name_by_id(department_id)
+                potential_course_sites_query = potential_course_sites_query.filter(course__department=department_id.split(":")[1])
 
-        course_instance_ids = get_course_instances_without_canvas_sites(account, term_id)
-    else:
-        course_instance_ids = data["course_instance_ids"]
+        print(potential_course_sites_query.count())
 
-    # Create JobRecord object first so we can reference the job_id in the TaskRecord objects
-    try:
-        job = JobRecord(
-            user_id=user_id,
-            user_full_name=user_full_name,
-            user_email=user_email,
-            school=school_id,
-            term_id=term_id,
-            term_name=term_name,
-            department_id=department_id,
-            department_name=department_name,
-            course_group_id=course_group_id,
-            course_group_name=course_group_name,
-            template_id=template_id,
-            workflow_state="PENDING",
-        )
-    except (TypeError, ValueError) as e:
-        logger.error(f"Unexpected input during JobRecord creation: {e}")
-        return JsonResponse({"status": 400})
+        if potential_course_sites_query.count() > 0:
+            job = JobRecord(
+                user_id=user_id,
+                user_full_name=user_full_name,
+                user_email=user_email,
+                school=school_id,
+                term_id=term_id,
+                term_name=term_name,
+                department_id=department_id,
+                department_name=department_name,
+                course_group_id=course_group_id,
+                course_group_name=course_group_name,
+                template_id=template_id,
+                workflow_state="pending",
+            )
 
-    # Create TaskRecord objects for each course instance
-    try:
-        tasks = generate_task_objects(course_instance_ids, job)
-    except (TypeError, ValueError) as e:
-        return JsonResponse({"status": 400})
+        else:
+            # Create tasks for each of the selected course instance IDs
 
-    # Write the TaskRecords to DynamoDB. We insert these first since the subsequent JobRecord
-    # kicks off the downstream bulk workflow via a DynamoDB stream.
-    try:
-        batch_write_item(table, tasks)
-    except ClientError as e:
-        return JsonResponse({"status": 500})
+            pass
 
-    # Now write the JobRecord to DynamoDB
-    response = table.put_item(Item=job.to_dict())
-    if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
-        logger.error(f"Error adding JobRecord to DynamoDB: {response}")
-        return JsonResponse({"status": 500})
-    return JsonResponse({"status": 200})
+    # TODO Add messages to request session before redirecting to index
+    return redirect('bulk_site_creator:index')
+
+
+    # user_id = request.LTI["lis_person_sourcedid"]
+    # user_full_name = request.LTI["lis_person_name_full"]
+    # user_email = request.LTI["lis_person_contact_email_primary"]
+    # 
+    # data = json.loads(request.body)
+    # filters = data["filters"]
+    # 
+    # term_id = filters.get("term")
+    # if term_id:
+    #     try:
+    #         term_name = get_term_name_by_id(term_id)
+    #     except Term.DoesNotExist as e:
+    #         logger.info(f"Term {term_id} does not exist: {e}")
+    #         return JsonResponse({"error": "Term does not exist"}, status=400)
+    # else:
+    #     term_name = None
+    # 
+    # school_account_id = filters["school"]
+    # (_, school_id) = canvas_api_accounts.parse_canvas_account_id(school_account_id)
+    # 
+    # department_id = None
+    # department_account_id = filters.get("department")
+    # if department_account_id:
+    #     (_, department_id) = department_account_id.split(":")
+    # 
+    # if department_id:
+    #     try:
+    #         department_name = get_department_name_by_id(department_id)
+    #     except Department.DoesNotExist as e:
+    #         logger.info(f"Department {department_id} does not exist: {e}")
+    #         return JsonResponse({"error": "Department does not exist"}, status=400)
+    # else:
+    #     department_name = None
+    # 
+    # course_group_id = None
+    # course_group_account_id = filters.get("course_group")
+    # if course_group_account_id:
+    #     (_, course_group_id) = course_group_account_id.split(":")
+    # 
+    # if course_group_id:
+    #     try:
+    #         course_group_name = CourseGroup.objects.get(course_group_id=course_group_id).name
+    #     except CourseGroup.DoesNotExist as e:
+    #         logger.info(f"Course Group {course_group_id} does not exist: {e}")
+    #         return JsonResponse({"error": "Course Group does not exist"}, status=400)
+    # else:
+    #     course_group_name = None
+    # 
+    # template_id = data.get("template")
+    # 
+    # # If the create_all flag has been set and passed with the form,
+    # # then create a query to get the all course instances with the applied filters that are to be created.
+    # if data.get("create_all", False):
+    #     # Get the account data to be used in the course instance query.
+    #     if filters["course_group"]:
+    #         account = course_group_id
+    #     elif filters["department"]:
+    #         account = department_id
+    #     else:
+    #         account = school_account_id
+    # 
+    #     course_instance_ids = get_course_instances_without_canvas_sites(account, term_id)
+    # else:
+    #     course_instance_ids = data["course_instance_ids"]
+    # 
+    # # Create JobRecord object first so we can reference the job_id in the TaskRecord objects
+    # try:
+    #     job = JobRecord(
+    #         user_id=user_id,
+    #         user_full_name=user_full_name,
+    #         user_email=user_email,
+    #         school=school_id,
+    #         term_id=term_id,
+    #         term_name=term_name,
+    #         department_id=department_id,
+    #         department_name=department_name,
+    #         course_group_id=course_group_id,
+    #         course_group_name=course_group_name,
+    #         template_id=template_id,
+    #         workflow_state="PENDING",
+    #     )
+    # except (TypeError, ValueError) as e:
+    #     logger.error(f"Unexpected input during JobRecord creation: {e}")
+    #     return JsonResponse({"status": 400})
+    # 
+    # # Create TaskRecord objects for each course instance
+    # try:
+    #     tasks = generate_task_objects(course_instance_ids, job)
+    # except (TypeError, ValueError) as e:
+    #     return JsonResponse({"status": 400})
+    # 
+    # # Write the TaskRecords to DynamoDB. We insert these first since the subsequent JobRecord
+    # # kicks off the downstream bulk workflow via a DynamoDB stream.
+    # try:
+    #     batch_write_item(table, tasks)
+    # except ClientError as e:
+    #     return JsonResponse({"status": 500})
+    # 
+    # # Now write the JobRecord to DynamoDB
+    # response = table.put_item(Item=job.to_dict())
+    # if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
+    #     logger.error(f"Error adding JobRecord to DynamoDB: {response}")
+    #     return JsonResponse({"status": 500})
+    # return JsonResponse({"status": 200})

--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -491,7 +491,7 @@ BULK_COURSE_CREATION = {
                                'course sites were created successfully.\n',
     'notification_email_body_failed_count': ' - {} course sites were not '
                                             'created.',
-    'site_creator_dynamo_table_name': SECURE_SETTINGS.get('site_creator_dynamo_table_name', None),
+    'site_creator_dynamo_table_name': SECURE_SETTINGS.get('site_creator_dynamo_table_name'),
 }
 
 


### PR DESCRIPTION
- Use front end libraries located in the S3 location vs CDN
- Modifies Task and Job schema classes to match fields in wireframes
- Adds initial functionality to the "Create All" button on the "New Job" page
- Adds JS to "New Job" page to disable "Search Courses" button and display a loading spinner
- Multiple template updates to show data returned from DynamoDB, conditions on select dropdowns 