### PR TITLE
TLT-4443 Set and filter bulk processing flag

### DIFF
--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -132,10 +132,9 @@ def new_job(request):
 
         # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed
-        # TODO Add bulk_processing flag to filter
         potential_course_sites_query = get_course_instance_query_set(
             selected_term_id, sis_account_id
-        ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
+        ).filter(canvas_course_id__isnull=True, sync_to_canvas=0, bulk_processing=0)
 
     # TODO maybe better to use template tag unless used elsewhere?
     # TODO cont. this may be included in a summary generation to be displayed in page (see wireframe and Jira ticket)
@@ -162,7 +161,6 @@ def new_job(request):
 @lti_permission_required(settings.PERMISSION_BULK_SITE_CREATOR)
 @require_http_methods(["POST"])
 def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
-    # TODO - Set 'bulk_processing' flag to true for all course instances processed by this view before inserting into DynamoDB
     dynamodb_table = dynamodb.Table(table_name)
     user_id = request.LTI["lis_person_sourcedid"]
     user_full_name = request.LTI["lis_person_name_full"]
@@ -187,10 +185,9 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
         # Get all course instance records that will have Canvas sites created by filtering on the
         # term and (course group or department) values
         # Also filter on the 'bulk_processing' flag to avoid multiple job submission conflicts
-        # TODO Add bulk_processing flag to filter
         potential_course_sites_query = get_course_instance_query_set(
             term_id, sis_account_id
-        ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
+        ).filter(canvas_course_id__isnull=True, sync_to_canvas=0, bulk_processing=0)
 
         # Check if a course group or department filter needs to be applied to queryset
         # The value of 0 is for the default option of no selected Department/Course Group
@@ -221,6 +218,10 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
 
             # Create TaskRecord objects for each course instance
             tasks = generate_task_objects(potential_course_sites_query, job)
+
+            # Set the bulk_processing field to true for all course instances being processed by this job so they
+            # do not show up in the new job page
+            potential_course_sites_query.update(bulk_processing=True)
 
             # Write the TaskRecords to DynamoDB. We insert these first since the subsequent JobRecord
             # kicks off the downstream bulk workflow via a DynamoDB stream.
@@ -256,10 +257,21 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
                 workflow_state="pending",
             )
 
-            course_instances = CourseInstance.objects.filter(course_instance_id__in=course_instance_ids)
+            # Get all potential course instances for the selected term in the account
+            # Further filter by the selected course instances from the DataTable
+            course_instances = get_course_instance_query_set(
+                term_id, sis_account_id
+            ).filter(canvas_course_id__isnull=True,
+                     sync_to_canvas=0,
+                     bulk_processing=0,
+                     course_instance_id__in=course_instance_ids)
 
             # Create TaskRecord objects for each course instance
             tasks = generate_task_objects(course_instances, job)
+
+            # Set the bulk_processing field to true for all course instances being processed by this job so they
+            # do not show up in the new job page
+            course_instances.update(bulk_processing=True)
 
             # Write the TaskRecords to DynamoDB. We insert these first since the subsequent JobRecord
             # kicks off the downstream bulk workflow via a DynamoDB stream.

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -27,7 +27,7 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-pe
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0#egg=django-harvardkey-cas==3.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.3#egg=django-coursemanager==0.3
+git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.4#egg=django-coursemanager==0.4
 
 git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4#egg=canvas_python_sdk==1.4
 


### PR DESCRIPTION
Adds bulk_processing field to CourseInstance queryset filters to filter out potential course instances that are currently being processed by a bulk job.

Set bulk_processing to true for each course instance prior to submitting a bulk job.

To test, create a new bulk job via the tool. Upon successful submission of job, go to new job page with the same filters that were used for the bulk job (term + dept/cg) and there should be no results returned.