### PR TITLE
Task/haydn9000/tlt 4449/fix coursegroup and department not filtering

### DIFF
--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -67,7 +67,7 @@
                     </td>
                     <td>{{ bulk_job.created_at }}</td>
                     <td>{{ bulk_job.term_name }}</td>
-                    <td>{{ bulk_job.creator_name }}</td>
+                    <td>{{ bulk_job.user_full_name }}</td>
                     <td>{{ bulk_job.workflow_state }}</td>
                     <td>{{ bulk_job.summary }}</td>
                 </tr>

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -38,12 +38,12 @@
                             <br>
                             <select id="courseDepartment" name="courseDepartment" class="form-control">
                                 {% if not selected_department_id or selected_department_id == '0' %}
-                                    <option value="0" selected>Department</option>
+                                    <option value="dept:0" selected>Department</option>
                                 {% else %}
-                                    <option value="0">Department</option>
+                                    <option value="dept:0">Department</option>
                                 {% endif %}
                                 {% for department in departments %}
-                                    {% if selected_department_id and selected_department_id == department.id %}
+                                    {% if selected_department_id and "dept:"|add:selected_department_id == department.id %}
                                         <option value="{{ department.id }}" selected>{{ department.name }}</option>
                                     {% else %}
                                         <option value="{{ department.id }}">{{ department.name }}</option>
@@ -58,12 +58,12 @@
                             <br>
                             <select id="courseCourseGroup" name="courseCourseGroup" class="form-control">
                                 {% if not selected_course_group_id or selected_course_group_id == '0' %}
-                                    <option value="0" selected>Course Group</option>
+                                    <option value="coursegroup:0" selected>Course Group</option>
                                 {% else %}
-                                    <option value="0">Course Group</option>
+                                    <option value="coursegroup:0">Course Group</option>
                                 {% endif %}
                                 {% for course_group in course_groups %}
-                                    {% if selected_course_group_id and selected_course_group_id == course_group.id %}
+                                    {% if selected_course_group_id and "coursegroup:"|add:selected_course_group_id == course_group.id %}
                                         <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
                                     {% else %}
                                         <option value="{{ course_group.id }}">{{ course_group.name }}</option>

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -38,9 +38,9 @@
                             <br>
                             <select id="courseDepartment" name="courseDepartment" class="form-control">
                                 {% if not selected_department_id or selected_department_id == '0' %}
-                                    <option value="department:0" selected>Department</option>
+                                    <option value="dept:0" selected>Department</option>
                                 {% else %}
-                                    <option value="department:0">Department</option>
+                                    <option value="dept:0">Department</option>
                                 {% endif %}
                                 {% for department in departments %}
                                     {% if selected_department_id and "dept:"|add:selected_department_id == department.id %}

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -37,13 +37,13 @@
                             </label>
                             <br>
                             <select id="courseDepartment" name="courseDepartment" class="form-control">
-                                {% if not selected_department_id %}
-                                    <option value="0" selected>Department</option>
+                                {% if not selected_department_id or selected_department_id == '0' %}
+                                    <option value="department:0" selected>Department</option>
                                 {% else %}
-                                    <option value="0">Department</option>
+                                    <option value="department:0">Department</option>
                                 {% endif %}
                                 {% for department in departments %}
-                                    {% if selected_department_id and selected_department_id == department.id %}
+                                    {% if selected_department_id and "dept:"|add:selected_department_id == department.id %}
                                         <option value="{{ department.id }}" selected>{{ department.name }}</option>
                                     {% else %}
                                         <option value="{{ department.id }}">{{ department.name }}</option>
@@ -57,13 +57,13 @@
                             </label>
                             <br>
                             <select id="courseCourseGroup" name="courseCourseGroup" class="form-control">
-                                {% if not selected_course_group_id %}
-                                    <option value="0" selected>Course Group</option>
+                                {% if not selected_course_group_id or selected_course_group_id == '0' %}
+                                    <option value="coursegroup:0" selected>Course Group</option>
                                 {% else %}
-                                    <option value="0">Course Group</option>
+                                    <option value="coursegroup:0">Course Group</option>
                                 {% endif %}
                                 {% for course_group in course_groups %}
-                                    {% if selected_course_group_id and selected_course_group_id == course_group.id %}
+                                    {% if selected_course_group_id and "coursegroup:"|add:selected_course_group_id == course_group.id %}
                                         <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
                                     {% else %}
                                         <option value="{{ course_group.id }}">{{ course_group.name }}</option>

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -38,12 +38,12 @@
                             <br>
                             <select id="courseDepartment" name="courseDepartment" class="form-control">
                                 {% if not selected_department_id or selected_department_id == '0' %}
-                                    <option value="dept:0" selected>Department</option>
+                                    <option value="0" selected>Department</option>
                                 {% else %}
-                                    <option value="dept:0">Department</option>
+                                    <option value="0">Department</option>
                                 {% endif %}
                                 {% for department in departments %}
-                                    {% if selected_department_id and "dept:"|add:selected_department_id == department.id %}
+                                    {% if selected_department_id and selected_department_id == department.id %}
                                         <option value="{{ department.id }}" selected>{{ department.name }}</option>
                                     {% else %}
                                         <option value="{{ department.id }}">{{ department.name }}</option>
@@ -58,12 +58,12 @@
                             <br>
                             <select id="courseCourseGroup" name="courseCourseGroup" class="form-control">
                                 {% if not selected_course_group_id or selected_course_group_id == '0' %}
-                                    <option value="coursegroup:0" selected>Course Group</option>
+                                    <option value="0" selected>Course Group</option>
                                 {% else %}
-                                    <option value="coursegroup:0">Course Group</option>
+                                    <option value="0">Course Group</option>
                                 {% endif %}
                                 {% for course_group in course_groups %}
-                                    {% if selected_course_group_id and "coursegroup:"|add:selected_course_group_id == course_group.id %}
+                                    {% if selected_course_group_id and selected_course_group_id == course_group.id %}
                                         <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
                                     {% else %}
                                         <option value="{{ course_group.id }}">{{ course_group.name }}</option>

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -130,8 +130,8 @@ def new_job(request):
     
     if request.method == "POST":
         selected_term_id = request.POST.get("courseTerm", None)
-        selected_course_group_id = request.POST.get("courseCourseGroup").split(":")[1] if request.POST.get("courseCourseGroup", None) else None
-        selected_department_id = request.POST.get("courseDepartment").split(":")[1] if request.POST.get("courseDepartment", None) else None
+        selected_course_group_id = request.POST.get("courseCourseGroup") if request.POST.get("courseCourseGroup", None) else None
+        selected_department_id = request.POST.get("courseDepartment") if request.POST.get("courseDepartment", None) else None
 
         # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -152,7 +152,7 @@ def new_job(request):
         # Filter potential_course_sites_query by department.
         elif selected_department_id and selected_department_id != '0':
             potential_course_sites_query = potential_course_sites_query.filter(
-                course__departments=selected_department_id)
+                course__department=selected_department_id)
 
     # TODO maybe better to use template tag unless used elsewhere?
     # TODO cont. this may be included in a summary generation to be displayed in page (see wireframe and Jira ticket)

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -130,8 +130,10 @@ def new_job(request):
     
     if request.method == "POST":
         selected_term_id = request.POST.get("courseTerm", None)
-        selected_course_group_id = request.POST.get("courseCourseGroup").split(":")[1] if request.POST.get("courseCourseGroup", None) else None
-        selected_department_id = request.POST.get("courseDepartment").split(":")[1] if request.POST.get("courseDepartment", None) else None
+        selected_course_group_id = request.POST.get("courseCourseGroup").split(
+            ":")[1] if request.POST.get("courseCourseGroup", None) else None
+        selected_department_id = request.POST.get("courseDepartment").split(
+            ":")[1] if request.POST.get("courseDepartment", None) else None
         
         # TODO Add bulk_processing flag to filter
 

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -130,8 +130,8 @@ def new_job(request):
     
     if request.method == "POST":
         selected_term_id = request.POST.get("courseTerm", None)
-        selected_course_group_id = request.POST.get("courseCourseGroup") if request.POST.get("courseCourseGroup", None) else None
-        selected_department_id = request.POST.get("courseDepartment") if request.POST.get("courseDepartment", None) else None
+        selected_course_group_id = request.POST.get("courseCourseGroup").split(":")[1] if request.POST.get("courseCourseGroup", None) else None
+        selected_department_id = request.POST.get("courseDepartment").split(":")[1] if request.POST.get("courseDepartment", None) else None
 
         # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -113,8 +113,6 @@ def new_job(request):
     selected_department_id = None
 
     # Only display the Course Groups dropdown if the tool is launched in the COLGSAS sub-account
-    print('request ------------------------------>', request.POST)
-    print('school_id ------------------------------>', school_id)
     if school_id == 'colgsas':
         try:
             course_groups = get_course_group_data_for_school(sis_account_id)
@@ -127,6 +125,9 @@ def new_job(request):
         except Exception:
             logger.exception(f"Failed to get departments with sis_account_id {sis_account_id}")
 
+    print('request ------------------------------>', request.POST)
+    print('school_id ------------------------------>', school_id)
+    
     if request.method == "POST":
         selected_term_id = request.POST.get("courseTerm", None)
         selected_course_group_id = request.POST.get("courseCourseGroup", None)
@@ -135,13 +136,6 @@ def new_job(request):
         # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed
         # TODO Add bulk_processing flag to filter
-        # if school_id == 'colgsas':
-        #     if selected_course_group_id == '0':
-        #         print('selected_term_id ------------------------------>', selected_term_id)
-        #     else:
-        #         print('selected_term_id, selected_department_id------------------------------>', selected_term_id, selected_course_group_id.split(":")[1])
-        # else:
-        #     print('selected_term_id, selected_department_id------------------------------>', selected_term_id, selected_department_id)
         if selected_course_group_id or selected_department_id:
             if selected_course_group_id == '0' or selected_department_id == '0':
                 potential_course_sites_query = get_course_instance_query_set(
@@ -164,13 +158,7 @@ def new_job(request):
                          term__term_id=selected_term_id,
                          course__departments=selected_department_id.split(":")[1])
 
-            # potential_course_sites_query = get_course_instance_query_set(
-            #     selected_term_id, sis_account_id
-            # ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
-
             print('potential_course_sites_query ------------------------------>', potential_course_sites_query)
-            print('selected_department_id ------------------------------>', selected_department_id)
-            print('selected_course_group_id ------------------------------>', selected_course_group_id)
 
 
     # TODO maybe better to use template tag unless used elsewhere?

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -124,9 +124,6 @@ def new_job(request):
             departments = get_department_data_for_school(sis_account_id)
         except Exception:
             logger.exception(f"Failed to get departments with sis_account_id {sis_account_id}")
-
-    print('request ------------------------------>', request.POST)
-    print('school_id ------------------------------>', school_id)
     
     if request.method == "POST":
         selected_term_id = request.POST.get("courseTerm", None)
@@ -136,29 +133,30 @@ def new_job(request):
         # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed
         # TODO Add bulk_processing flag to filter
-        if selected_course_group_id or selected_department_id:
-            if selected_course_group_id == '0' or selected_department_id == '0':
-                potential_course_sites_query = get_course_instance_query_set(
-                    selected_term_id, sis_account_id
-                ).filter(canvas_course_id__isnull=True,
-                         sync_to_canvas=0,
-                         term__term_id=selected_term_id)
-            elif selected_course_group_id:
-                potential_course_sites_query = get_course_instance_query_set(
-                    selected_term_id, sis_account_id
-                ).filter(canvas_course_id__isnull=True,
-                         sync_to_canvas=0,
-                         term__term_id=selected_term_id,
-                         course__course_group=selected_course_group_id.split(":")[1])
-            elif selected_department_id:
-                potential_course_sites_query = get_course_instance_query_set(
-                    selected_term_id, sis_account_id
-                ).filter(canvas_course_id__isnull=True,
-                         sync_to_canvas=0,
-                         term__term_id=selected_term_id,
-                         course__departments=selected_department_id.split(":")[1])
+        if selected_course_group_id and selected_course_group_id == '0' or \
+                selected_department_id and selected_department_id == '0':
+            potential_course_sites_query = get_course_instance_query_set(
+                selected_term_id, sis_account_id
+            ).filter(canvas_course_id__isnull=True,
+                     sync_to_canvas=0,
+                     term__term_id=selected_term_id)
+        elif selected_course_group_id:
+            potential_course_sites_query = get_course_instance_query_set(
+                selected_term_id, sis_account_id
+            ).filter(canvas_course_id__isnull=True,
+                     sync_to_canvas=0,
+                     term__term_id=selected_term_id,
+                     course__course_group=selected_course_group_id.split(":")[1])
+        elif selected_department_id:
+            potential_course_sites_query = get_course_instance_query_set(
+                selected_term_id, sis_account_id
+            ).filter(canvas_course_id__isnull=True,
+                     sync_to_canvas=0,
+                     term__term_id=selected_term_id,
+                     course__departments=selected_department_id.split(":")[1])
 
-            print('potential_course_sites_query ------------------------------>', potential_course_sites_query)
+        print('potential_course_sites_query ------------------------------>',
+              potential_course_sites_query)
 
 
     # TODO maybe better to use template tag unless used elsewhere?

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -130,10 +130,8 @@ def new_job(request):
     
     if request.method == "POST":
         selected_term_id = request.POST.get("courseTerm", None)
-        selected_course_group_id = request.POST.get("courseCourseGroup").split(
-            ":")[1] if request.POST.get("courseCourseGroup", None) else None
-        selected_department_id = request.POST.get("courseDepartment").split(
-            ":")[1] if request.POST.get("courseDepartment", None) else None
+        selected_course_group_id = request.POST.get("courseCourseGroup").split(":")[1] if request.POST.get("courseCourseGroup", None) else None
+        selected_department_id = request.POST.get("courseDepartment").split(":")[1] if request.POST.get("courseDepartment", None) else None
         
         # TODO Add bulk_processing flag to filter
 
@@ -147,12 +145,10 @@ def new_job(request):
 
         # Filter potential_course_sites_query by course group.
         if selected_course_group_id and selected_course_group_id != '0':
-            potential_course_sites_query = potential_course_sites_query.filter(
-                course__course_group=selected_course_group_id)
+            potential_course_sites_query = potential_course_sites_query.filter(course__course_group=selected_course_group_id)
         # Filter potential_course_sites_query by department.
         elif selected_department_id and selected_department_id != '0':
-            potential_course_sites_query = potential_course_sites_query.filter(
-                course__department=selected_department_id)
+            potential_course_sites_query = potential_course_sites_query.filter(course__department=selected_department_id)
 
     # TODO maybe better to use template tag unless used elsewhere?
     # TODO cont. this may be included in a summary generation to be displayed in page (see wireframe and Jira ticket)

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -113,6 +113,8 @@ def new_job(request):
     selected_department_id = None
 
     # Only display the Course Groups dropdown if the tool is launched in the COLGSAS sub-account
+    print('request ------------------------------>', request.POST)
+    print('school_id ------------------------------>', school_id)
     if school_id == 'colgsas':
         try:
             course_groups = get_course_group_data_for_school(sis_account_id)
@@ -128,14 +130,31 @@ def new_job(request):
     if request.method == "POST":
         selected_term_id = request.POST.get("courseTerm", None)
         selected_course_group_id = request.POST.get("courseCourseGroup", None)
-        selected_department_id = request.POST.get("department", None)
+        selected_department_id = request.POST.get("courseDepartment", None)
 
         # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed
         # TODO Add bulk_processing flag to filter
-        potential_course_sites_query = get_course_instance_query_set(
-            selected_term_id, sis_account_id
-        ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
+        if school_id == 'colgsas':
+            print('selected_term_id, selected_department_id------------------------------>', selected_term_id, selected_course_group_id.split(":")[1])
+        else:
+            print('selected_term_id, selected_department_id------------------------------>', selected_term_id, selected_department_id)
+
+        if selected_course_group_id == 0:
+            pass
+        else:
+            # potential_course_sites_query = get_course_instance_query_set(
+            #     selected_term_id, sis_account_id
+            # ).filter(canvas_course_id__isnull=True, sync_to_canvas=0, term__term_id=selected_term_id, course__course_groups=selected_course_group_id.split(":")[1])
+
+            potential_course_sites_query = get_course_instance_query_set(
+                selected_term_id, sis_account_id
+            ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
+
+            print('potential_course_sites_query ------------------------------>', potential_course_sites_query)
+            print('selected_department_id ------------------------------>', selected_department_id)
+            print('selected_course_group_id ------------------------------>', selected_course_group_id)
+
 
     # TODO maybe better to use template tag unless used elsewhere?
     # TODO cont. this may be included in a summary generation to be displayed in page (see wireframe and Jira ticket)

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -135,21 +135,38 @@ def new_job(request):
         # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed
         # TODO Add bulk_processing flag to filter
-        if school_id == 'colgsas':
-            print('selected_term_id, selected_department_id------------------------------>', selected_term_id, selected_course_group_id.split(":")[1])
-        else:
-            print('selected_term_id, selected_department_id------------------------------>', selected_term_id, selected_department_id)
+        # if school_id == 'colgsas':
+        #     if selected_course_group_id == '0':
+        #         print('selected_term_id ------------------------------>', selected_term_id)
+        #     else:
+        #         print('selected_term_id, selected_department_id------------------------------>', selected_term_id, selected_course_group_id.split(":")[1])
+        # else:
+        #     print('selected_term_id, selected_department_id------------------------------>', selected_term_id, selected_department_id)
+        if selected_course_group_id or selected_department_id:
+            if selected_course_group_id == '0' or selected_department_id == '0':
+                potential_course_sites_query = get_course_instance_query_set(
+                    selected_term_id, sis_account_id
+                ).filter(canvas_course_id__isnull=True,
+                         sync_to_canvas=0,
+                         term__term_id=selected_term_id)
+            elif selected_course_group_id:
+                potential_course_sites_query = get_course_instance_query_set(
+                    selected_term_id, sis_account_id
+                ).filter(canvas_course_id__isnull=True,
+                         sync_to_canvas=0,
+                         term__term_id=selected_term_id,
+                         course__course_group=selected_course_group_id.split(":")[1])
+            elif selected_department_id:
+                potential_course_sites_query = get_course_instance_query_set(
+                    selected_term_id, sis_account_id
+                ).filter(canvas_course_id__isnull=True,
+                         sync_to_canvas=0,
+                         term__term_id=selected_term_id,
+                         course__departments=selected_department_id.split(":")[1])
 
-        if selected_course_group_id == 0:
-            pass
-        else:
             # potential_course_sites_query = get_course_instance_query_set(
             #     selected_term_id, sis_account_id
-            # ).filter(canvas_course_id__isnull=True, sync_to_canvas=0, term__term_id=selected_term_id, course__course_groups=selected_course_group_id.split(":")[1])
-
-            potential_course_sites_query = get_course_instance_query_set(
-                selected_term_id, sis_account_id
-            ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
+            # ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
 
             print('potential_course_sites_query ------------------------------>', potential_course_sites_query)
             print('selected_department_id ------------------------------>', selected_department_id)

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -133,6 +133,7 @@ def new_job(request):
         # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed
         # TODO Add bulk_processing flag to filter
+        # Filter by term only.
         if selected_course_group_id and selected_course_group_id == '0' or \
                 selected_department_id and selected_department_id == '0':
             potential_course_sites_query = get_course_instance_query_set(
@@ -140,6 +141,7 @@ def new_job(request):
             ).filter(canvas_course_id__isnull=True,
                      sync_to_canvas=0,
                      term__term_id=selected_term_id)
+        # Filter also by term and course group.
         elif selected_course_group_id:
             potential_course_sites_query = get_course_instance_query_set(
                 selected_term_id, sis_account_id
@@ -147,6 +149,7 @@ def new_job(request):
                      sync_to_canvas=0,
                      term__term_id=selected_term_id,
                      course__course_group=selected_course_group_id.split(":")[1])
+        # Filter by term and department.
         elif selected_department_id:
             potential_course_sites_query = get_course_instance_query_set(
                 selected_term_id, sis_account_id

--- a/common/utils.py
+++ b/common/utils.py
@@ -108,8 +108,7 @@ def get_department_data_for_school(school_sis_account_id, department_sis_account
         account_id = account['sis_account_id']
         if account_id and account_id.lower().startswith('dept:'):
             department = {
-                'id': int(account_id.split(":")[1]),
-                'custom_canvas_account_sis_id': account_id.lower(),
+                'id': account_id.lower(),
                 'name': account['name']
             }
             if department_sis_account_id and department_sis_account_id == account_id:
@@ -134,8 +133,7 @@ def get_course_group_data_for_school(school_sis_account_id, course_group_sis_acc
         account_id = account['sis_account_id']
         if account_id and account_id.lower().startswith('coursegroup:'):
             course_group = {
-                'id': int(account_id.split(":")[1]),
-                'custom_canvas_account_sis_id': account_id.lower(),
+                'id': account_id.lower(),
                 'name': account['name']
             }
             if course_group_sis_account_id and course_group_sis_account_id == account_id:

--- a/common/utils.py
+++ b/common/utils.py
@@ -108,7 +108,7 @@ def get_department_data_for_school(school_sis_account_id, department_sis_account
         account_id = account['sis_account_id']
         if account_id and account_id.lower().startswith('dept:'):
             department = {
-                'id': account_id.split(":")[1],
+                'id': int(account_id.split(":")[1]),
                 'custom_canvas_account_sis_id': account_id.lower(),
                 'name': account['name']
             }
@@ -134,7 +134,7 @@ def get_course_group_data_for_school(school_sis_account_id, course_group_sis_acc
         account_id = account['sis_account_id']
         if account_id and account_id.lower().startswith('coursegroup:'):
             course_group = {
-                'id': account_id.split(":")[1],
+                'id': int(account_id.split(":")[1]),
                 'custom_canvas_account_sis_id': account_id.lower(),
                 'name': account['name']
             }

--- a/common/utils.py
+++ b/common/utils.py
@@ -108,7 +108,7 @@ def get_department_data_for_school(school_sis_account_id, department_sis_account
         account_id = account['sis_account_id']
         if account_id and account_id.lower().startswith('dept:'):
             department = {
-                'id': int(account_id.split(":")[1]),
+                'id': account_id.split(":")[1],
                 'custom_canvas_account_sis_id': account_id.lower(),
                 'name': account['name']
             }
@@ -134,7 +134,7 @@ def get_course_group_data_for_school(school_sis_account_id, course_group_sis_acc
         account_id = account['sis_account_id']
         if account_id and account_id.lower().startswith('coursegroup:'):
             course_group = {
-                'id': int(account_id.split(":")[1]),
+                'id': account_id.split(":")[1],
                 'custom_canvas_account_sis_id': account_id.lower(),
                 'name': account['name']
             }

--- a/common/utils.py
+++ b/common/utils.py
@@ -108,7 +108,8 @@ def get_department_data_for_school(school_sis_account_id, department_sis_account
         account_id = account['sis_account_id']
         if account_id and account_id.lower().startswith('dept:'):
             department = {
-                'id': account_id.lower(),
+                'id': int(account_id.split(":")[1]),
+                'custom_canvas_account_sis_id': account_id.lower(),
                 'name': account['name']
             }
             if department_sis_account_id and department_sis_account_id == account_id:
@@ -133,7 +134,8 @@ def get_course_group_data_for_school(school_sis_account_id, course_group_sis_acc
         account_id = account['sis_account_id']
         if account_id and account_id.lower().startswith('coursegroup:'):
             course_group = {
-                'id': account_id.lower(),
+                'id': int(account_id.split(":")[1]),
+                'custom_canvas_account_sis_id': account_id.lower(),
                 'name': account['name']
             }
             if course_group_sis_account_id and course_group_sis_account_id == account_id:


### PR DESCRIPTION
- Fixed Course Group and Department filter not filtering potential course sites in new_job template/view 
- Formatted timestamps displayed in index table.
- Fixed Started by column not populated in index table.

Note:

- Tested (locally) filtering potential course sites in new_job template/view in account -> Harvard University > Harvard College/GSAS
  - Selecting term 2023 Spring / January, and Spanish for Course Group should return test data.
  
- And tested in account -> Harvard University > Harvard Divinity School
  - Selecting term Spring 2023, and ECON for Department should return test data.

- Deployed in DEV