### PR TITLE
TLT-4455: utilize Bootstrap 5.3 base styling

### DIFF
--- a/bulk_site_creator/templates/bulk_site_creator/base.html
+++ b/bulk_site_creator/templates/bulk_site_creator/base.html
@@ -11,13 +11,13 @@
     <link rel="stylesheet" type="text/css"
           href="https://static.tlt.harvard.edu/shared/fontawesome-6.3.0/css/all.min.css">
     <link rel="stylesheet" type="text/css"
-          href="https://static.tlt.harvard.edu/shared/bootstrap-5.3.0/css/bootstrap.min.css"
-          media="screen"/>
-    <link rel="stylesheet" type="text/css"
           href="https://static.tlt.harvard.edu/shared/DataTables-1.13.2/css/dataTables.bootstrap5.min.css"
           media="screen"/>
     <link rel="stylesheet" type="text/css"
           href="https://static.tlt.harvard.edu/shared/Select-1.6.0/css/select.bootstrap5.min.css"
+          media="screen"/>
+    <link rel="stylesheet" type="text/css"
+          href="https://static.tlt.harvard.edu/shared/harvard-base/css/base.min.css"
           media="screen"/>
 
     <script src="https://static.tlt.harvard.edu/shared/jquery-3.6.3/jquery-3.6.3.min.js"></script>

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -21,7 +21,7 @@ django-rq==2.5.1
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.3#egg=django-icommons-ui==2.3
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v3.2#egg=django-canvas-lti-school-permissions==3.2
 


### PR DESCRIPTION
Resolves [TLT-4455](https://jira.huit.harvard.edu/browse/TLT-4455).

This PR:
- Replaces the vanilla Bootstrap 5.3 library used in Bulk Site Creator with a customized version of the same library (`harvard-base`).
- Bumps django-icommons-ui to the latest version (v2.3).

Deployed to dev (beta) ([link to AcTS sub-account Admin Console](https://harvard.beta.instructure.com/accounts/749/external_tools/21863)).