### PR TITLE
Only allow access to the Bulk Enrollment tool at the school-account level

### DIFF
--- a/bulk_enrollment_tool/views.py
+++ b/bulk_enrollment_tool/views.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 @lti_permission_required(settings.PERMISSION_BULK_ENROLLMENT_TOOL)
 @require_http_methods(['GET', 'POST'])
 def index(request):
+
     if request.method == "POST":
         logger.info(f'Bulk enrollment file uploaded. File: '
                     f'{request.FILES["bulkEnrollmentFile"]}')
@@ -35,6 +36,13 @@ def index(request):
         return redirect('bulk_enrollment_tool:index')
 
     tool_launch_school = get_tool_launch_school(request)
+
+    if not tool_launch_school:
+        template_context = {
+            'error_title': 'Error',
+            'error_message': 'Sorry, this tool can only be used in a school-level sub-account.'
+        }
+        return render(request, 'canvas_account_admin_tools/error.html', context=template_context)
 
     # Read data from DynamoDB table (get n most recent records).
     dynamodb = boto3.resource('dynamodb')
@@ -101,7 +109,7 @@ def errors(request, pk: str, sk: str):
     )
 
     # Slice errors string to remove `["` and `"]` at the beginning and end.
-    # Then update errors string to be a list of errors.   
+    # Then update errors string to be a list of errors.
     response['Item'].update(errors=response['Item']
                             ['errors'][2:-2].split('", "'))
     # Update string timestamp to datetime.
@@ -175,7 +183,10 @@ def get_tool_launch_school(request) -> str:
     Get the school that this tool is being launched in.
     """
     try:
-        tool_launch_school = request.LTI['custom_canvas_account_sis_id'].split(':')[1]
+        if request.LTI['custom_canvas_account_sis_id'].startswith('school:'):
+            tool_launch_school = request.LTI['custom_canvas_account_sis_id'].split(':')[1]
+        else:
+            tool_launch_school = None
     except Exception:
         logger.exception('Error getting launch school')
 

--- a/canvas_account_admin_tools/templates/canvas_account_admin_tools/error.html
+++ b/canvas_account_admin_tools/templates/canvas_account_admin_tools/error.html
@@ -1,0 +1,25 @@
+{% extends 'canvas_account_admin_tools/base.html' %}
+
+{% load static %}
+
+{% block stylesheets %}
+<link href="{% static 'canvas_account_admin_tools/css/dashboard.css' %}" rel="stylesheet" />
+{% endblock stylesheets %}
+
+{% block content %}
+
+    <header>
+      <nav>
+        <h3>
+            <a href="{% url 'dashboard_account' %}">Admin Console</a>
+            <small><i class="fa fa-chevron-right"></i></small>
+            Error
+        </h3>
+    </nav>
+    </header>
+
+
+    <h2>{{ error_title }}</h2>
+    <p class="lead">{{ error_message }}</p>
+
+{% endblock content %}

--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -89,6 +89,8 @@ def dashboard_account(request):
     custom_canvas_membership_roles = request.LTI['custom_canvas_membership_roles']
     build_info = settings.BUILD_INFO
 
+    school_level_sub_account: bool = custom_canvas_account_sis_id.startswith('school:')
+
     """
     Verify that the current user has permission to see the Search Courses (aka course_info) tool
     """
@@ -153,7 +155,8 @@ def dashboard_account(request):
     """
     bulk_enrollment_tool_is_allowed = is_allowed(custom_canvas_membership_roles,
                                                  settings.PERMISSION_BULK_ENROLLMENT_TOOL,
-                                                 canvas_account_sis_id=custom_canvas_account_sis_id)
+                                                 canvas_account_sis_id=custom_canvas_account_sis_id) \
+        and school_level_sub_account
 
     """
         verify that user has permissions to view the masquerade tool


### PR DESCRIPTION
This PR limits access to the Bulk Enrollment tool to school-level sub-accounts. 

The dashboard card will be hidden if the launching sub-account SIS ID doesn't start with `school:`. If the user were to somehow request the Bulk Enrollment index page, they will get an error message. 

This PR adds a generic `error.html` template that can be rendered by any view in this project. The view context dict can contain `error_title` and `error_message` keys which will be used to render the error page. 