### PR TITLE
TLT-4444 Course instance processing

### DIFF
--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -8,10 +8,12 @@ from ulid import ULID
 Defines the schema of the dynamodb table.
 """
 
+
 class JobRecord:
     def __init__(
         self,
         school: str,
+        sis_account_id: str,
         term_id: str,
         term_name: Optional[str],
         department_id: Optional[str],
@@ -26,6 +28,7 @@ class JobRecord:
     ):
         self.pk = f"SCHOOL#{school.upper()}"
         self.sk = f"JOB#{str(ULID())}"
+        self.sis_account_id = sis_account_id
         self.term_id = term_id
         self.term_name = term_name
         self.department_id = department_id
@@ -36,6 +39,7 @@ class JobRecord:
         self.user_id = user_id
         self.user_full_name = user_full_name
         self.user_email = user_email
+        self.school = school
         self.created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
         self.updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
@@ -50,6 +54,7 @@ class JobRecord:
         return {
             "pk": self.pk,
             "sk": self.sk,
+            "sis_account_id": self.sis_account_id,
             "term_id": self.term_id,
             "term_name": self.term_name,
             "department_id": self.department_id,
@@ -63,6 +68,7 @@ class JobRecord:
             "user_email": self.user_email,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            "school": self.school
         }
 
 
@@ -74,7 +80,9 @@ class TaskRecord:
         workflow_state: str,
         canvas_course_id: str,
         course_code: str,
-        course_title: str
+        course_title: str,
+        section: str,
+        department_id: str
     ):
         self.pk = job_record.sk
         self.sk = f"TASK#{str(ULID())}"
@@ -82,6 +90,8 @@ class TaskRecord:
         self.canvas_course_id = canvas_course_id
         self.course_code = course_code
         self.course_title = course_title
+        self.section = section
+        self.department_id = department_id
         self.created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
         self.updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
@@ -99,7 +109,9 @@ class TaskRecord:
             "course_instance_id": self.course_instance_id,
             "canvas_course_id": self.canvas_course_id,
             "course_code": self.course_code,
-            "course_title": self.course_title
+            "course_title": self.course_title,
+            "section": self.section,
+            "department_id": self.department_id
         }
 
 

--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -52,23 +52,23 @@ class JobRecord:
 
     def to_dict(self):
         return {
-            "pk": self.pk,
-            "sk": self.sk,
-            "sis_account_id": self.sis_account_id,
-            "term_id": self.term_id,
-            "term_name": self.term_name,
-            "department_id": self.department_id,
-            "department_name": self.department_name,
-            "course_group_id": self.course_group_id,
-            "course_group_name": self.course_group_name,
-            "template_id": self.template_id,
-            "user_id": self.user_id,
-            "user_full_name": self.user_full_name,
-            "workflow_state": self.workflow_state,
-            "user_email": self.user_email,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-            "school": self.school
+            "pk": str(self.pk),
+            "sk": str(self.sk),
+            "sis_account_id": str(self.sis_account_id),
+            "term_id": str(self.term_id),
+            "term_name": str(self.term_name),
+            "department_id": str(self.department_id),
+            "department_name": str(self.department_name),
+            "course_group_id": str(self.course_group_id),
+            "course_group_name": str(self.course_group_name),
+            "template_id": str(self.template_id),
+            "user_id": str(self.user_id),
+            "user_full_name": str(self.user_full_name),
+            "workflow_state": str(self.workflow_state),
+            "user_email": str(self.user_email),
+            "created_at": str(self.created_at),
+            "updated_at": str(self.updated_at),
+            "school": str(self.school)
         }
 
 
@@ -82,7 +82,8 @@ class TaskRecord:
         course_code: str,
         course_title: str,
         section: str,
-        department_id: str
+        department_id: str,
+        course_group_id: str
     ):
         self.pk = job_record.sk
         self.sk = f"TASK#{str(ULID())}"
@@ -92,6 +93,7 @@ class TaskRecord:
         self.course_title = course_title
         self.section = section
         self.department_id = department_id
+        self.course_group_id = course_group_id
         self.created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
         self.updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
@@ -101,17 +103,18 @@ class TaskRecord:
 
     def to_dict(self):
         return {
-            "pk": self.pk,
-            "sk": self.sk,
-            "workflow_state": self.workflow_state,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-            "course_instance_id": self.course_instance_id,
-            "canvas_course_id": self.canvas_course_id,
-            "course_code": self.course_code,
-            "course_title": self.course_title,
-            "section": self.section,
-            "department_id": self.department_id
+            "pk": str(self.pk),
+            "sk": str(self.sk),
+            "workflow_state": str(self.workflow_state),
+            "created_at": str(self.created_at),
+            "updated_at": str(self.updated_at),
+            "course_instance_id": str(self.course_instance_id),
+            "canvas_course_id": str(self.canvas_course_id),
+            "course_code": str(self.course_code),
+            "course_title": str(self.course_title),
+            "section": str(self.section),
+            "department_id": str(self.department_id),
+            "course_group_id": str(self.course_group_id),
         }
 
 

--- a/bulk_site_creator/templates/bulk_site_creator/base.html
+++ b/bulk_site_creator/templates/bulk_site_creator/base.html
@@ -11,13 +11,13 @@
     <link rel="stylesheet" type="text/css"
           href="https://static.tlt.harvard.edu/shared/fontawesome-6.3.0/css/all.min.css">
     <link rel="stylesheet" type="text/css"
-          href="https://static.tlt.harvard.edu/shared/bootstrap-5.3.0/css/bootstrap.min.css"
-          media="screen"/>
-    <link rel="stylesheet" type="text/css"
           href="https://static.tlt.harvard.edu/shared/DataTables-1.13.2/css/dataTables.bootstrap5.min.css"
           media="screen"/>
     <link rel="stylesheet" type="text/css"
           href="https://static.tlt.harvard.edu/shared/Select-1.6.0/css/select.bootstrap5.min.css"
+          media="screen"/>
+    <link rel="stylesheet" type="text/css"
+          href="https://static.tlt.harvard.edu/shared/harvard-base/css/base.min.css"
           media="screen"/>
 
     <script src="https://static.tlt.harvard.edu/shared/jquery-3.6.3/jquery-3.6.3.min.js"></script>
@@ -38,13 +38,6 @@
     <script>
       window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';
     </script>
-
-      <style>
-          a {
-            color: #337ab7;
-            text-decoration: none;
-            }
-      </style>
 
     {% block js %}
     {% endblock %}

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -4,7 +4,7 @@
 <nav>
   <h3 class="breadcrumbs">
     <a href="{% url 'dashboard_account' %}">Admin Console</a>
-    <i class="fa-solid fa-chevron-right"></i>
+    <small><i class="fa fa-chevron-right"></i></small>
     Bulk Site Creator
   </h3>
 </nav>

--- a/bulk_site_creator/templates/bulk_site_creator/job_detail.html
+++ b/bulk_site_creator/templates/bulk_site_creator/job_detail.html
@@ -4,9 +4,9 @@
   <nav>
     <h3 class="breadcrumbs">
       <a href="{% url 'dashboard_account' %}">Admin Console</a>
-      <i class="fa-solid fa-chevron-right"></i>
+      <small><i class="fa fa-chevron-right"></i></small>
       <a href="{% url 'bulk_site_creator:index' %}">Bulk Site Creator</a>
-      <i class="fa-solid fa-chevron-right"></i>
+      <small><i class="fa fa-chevron-right"></i></small>
       Job Detail
     </h3>
   </nav>

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -4,9 +4,9 @@
 <nav>
   <h3 class="breadcrumbs">
     <a href="{% url 'dashboard_account' %}">Admin Console</a>
-    <i class="fa-solid fa-chevron-right"></i>
+    <small><i class="fa fa-chevron-right"></i></small>
     <a href="{% url 'bulk_site_creator:index' %}">Bulk Site Creator</a>
-    <i class="fa-solid fa-chevron-right"></i>
+    <small><i class="fa fa-chevron-right"></i></small>
       New Job
   </h3>
 </nav>

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -37,12 +37,15 @@ def generate_task_objects(course_instances: list[dict], job: JobRecord):
             else:
                 course_code = ci.course.registrar_code
 
+
+
             task = TaskRecord(job_record=job,
                               course_instance_id=ci.course_instance_id,
                               course_code=course_code,
                               course_title=ci.title,
                               canvas_course_id=ci.canvas_course_id,
                               department_id=ci.course.department_id,
+                              course_group_id=ci.course.course_group_id,
                               section=ci.section,
                               workflow_state='pending').to_dict()
             tasks.append(task)

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -42,28 +42,14 @@ def generate_task_objects(course_instances: list[dict], job: JobRecord):
                               course_code=course_code,
                               course_title=ci.title,
                               canvas_course_id=ci.canvas_course_id,
+                              department_id=ci.course.department_id,
+                              section=ci.section,
                               workflow_state='pending').to_dict()
             tasks.append(task)
         except (TypeError, ValueError) as e:
             logging.error(f"Error creating TaskRecord for job {job.sk}: {e}")
             raise
     return tasks
-
-#  TODO delete, seems to be a dupe
-def get_course_instances_without_canvas_sites(account, term_id):
-    # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
-    # nor are set to be fed into Canvas via the automated feed
-    ci_query_set_without_canvas = get_course_instance_query_set(
-        term_id, account
-    ).filter(canvas_course_id__isnull=True, sync_to_canvas=0)
-
-    # Iterate through the query set to build a list of all the course instance id's
-    # for a school/course_group/department, which course sites will be created for.
-    course_instance_ids = []
-    for ci in ci_query_set_without_canvas:
-        course_instance_ids.append(ci.course_instance_id)
-
-    return course_instance_ids
 
 
 def get_course_instance_query_set(sis_term_id, sis_account_id):

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -30,7 +30,6 @@ from common.utils import (get_canvas_site_template,
 from .schema import JobRecord
 from .utils import (batch_write_item, generate_task_objects,
                     get_course_instance_query_set,
-                    get_course_instances_without_canvas_sites,
                     get_department_name_by_id, get_term_name_by_id)
 
 logger = logging.getLogger(__name__)
@@ -215,6 +214,7 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
 
         if potential_course_sites_query.count() > 0:
             job = JobRecord(
+                sis_account_id=sis_account_id,
                 user_id=user_id,
                 user_full_name=user_full_name,
                 user_email=user_email,
@@ -252,10 +252,11 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
 
     else:
         # TODO Abstraction - This block can potentially be pulled outside of the first condition check or separate method
-        # TODO cont. - Think about error handling and reeverting that fflag on exception
+        # TODO cont. - Think about error handling and reverting that flag on exception
         # Create tasks for each of the selected course instance IDs
         if course_instance_ids:
             job = JobRecord(
+                sis_account_id=sis_account_id,
                 user_id=user_id,
                 user_full_name=user_full_name,
                 user_email=user_email,
@@ -277,7 +278,7 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
             ).filter(canvas_course_id__isnull=True,
                      sync_to_canvas=0,
                      bulk_processing=0,
-                     course_instance_id__in=course_instance_ids)
+                     course_instance_id__in=course_instance_ids).select_related('course')
 
             # Create TaskRecord objects for each course instance
             tasks = generate_task_objects(course_instances, job)

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -179,7 +179,6 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
     user_email = request.LTI["lis_person_contact_email_primary"]
     sis_account_id = request.LTI["custom_canvas_account_sis_id"]
     school_id = sis_account_id.split(":")[1]
-    school_name = request.LTI["context_title"] # TODO add this to Job record
 
     table_data = json.loads(request.POST['data'])
 


### PR DESCRIPTION
- Modifies the Dynamo DB schema
- Use the Harvard styling (TLT-4455), tweaks to breadcrumbs making it similar to other apps, remove inline styling.
- Ensures items being used in the Dynamo put_item calls are string types