### PR TITLE
Task/haydn9000/tlt 4450/populate summary column in index table

### DIFF
--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -75,6 +75,8 @@
                             Success:&nbsp;{{ bulk_job.task_succeeded }}&nbsp;&nbsp;|&nbsp;&nbsp;
                             Fail:&nbsp;{{ bulk_job.task_failed }}
                         </td>
+                    {% else %}
+                        <td></td>
                     {% endif %}
                 </tr>
             {% endfor %}

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -69,9 +69,10 @@
                     <td>{{ bulk_job.term_name }}</td>
                     <td>{{ bulk_job.user_full_name }}</td>
                     <td>{{ bulk_job.workflow_state }}</td>
-                    <td>total: {{ bulk_job.task_total }}<br>
-                        success: {{ bulk_job.task_succeeded }}<br>
-                        fail: {{ bulk_job.task_failed }}
+                    <td>
+                        Total:&nbsp;{{ bulk_job.task_total }}&nbsp;&nbsp;|&nbsp;&nbsp;
+                        Success:&nbsp;{{ bulk_job.task_succeeded }}&nbsp;&nbsp;|&nbsp;&nbsp;
+                        Fail:&nbsp;{{ bulk_job.task_failed }}
                     </td>
                 </tr>
             {% endfor %}

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -69,11 +69,13 @@
                     <td>{{ bulk_job.term_name }}</td>
                     <td>{{ bulk_job.user_full_name }}</td>
                     <td>{{ bulk_job.workflow_state }}</td>
-                    <td>
-                        Total:&nbsp;{{ bulk_job.task_total }}&nbsp;&nbsp;|&nbsp;&nbsp;
-                        Success:&nbsp;{{ bulk_job.task_succeeded }}&nbsp;&nbsp;|&nbsp;&nbsp;
-                        Fail:&nbsp;{{ bulk_job.task_failed }}
-                    </td>
+                    {% if bulk_job.workflow_state == 'complete' %}
+                        <td>
+                            Total:&nbsp;{{ bulk_job.task_total }}&nbsp;&nbsp;|&nbsp;&nbsp;
+                            Success:&nbsp;{{ bulk_job.task_succeeded }}&nbsp;&nbsp;|&nbsp;&nbsp;
+                            Fail:&nbsp;{{ bulk_job.task_failed }}
+                        </td>
+                    {% endif %}
                 </tr>
             {% endfor %}
             </tbody>

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -69,7 +69,10 @@
                     <td>{{ bulk_job.term_name }}</td>
                     <td>{{ bulk_job.user_full_name }}</td>
                     <td>{{ bulk_job.workflow_state }}</td>
-                    <td>{{ bulk_job.summary }}</td>
+                    <td>total: {{ bulk_job.task_total }}<br>
+                        success: {{ bulk_job.task_succeeded }}<br>
+                        fail: {{ bulk_job.task_failed }}
+                    </td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/bulk_site_creator/templates/bulk_site_creator/job_detail.html
+++ b/bulk_site_creator/templates/bulk_site_creator/job_detail.html
@@ -60,7 +60,7 @@
                               {% if task.workflow_state == 'fail' or not task.canvas_course_id %}
                                 <td>{{ task.canvas_course_id }}</td>
                               {% else %}
-                                <td><a href="{{ task.canvas_course_url }}">{{ task.canvas_course_id }}</a></td>
+                                <td><a href="{{ task.canvas_course_url }}" target="_blank">{{ task.canvas_course_id }} </a></td>
                               {% endif %}
                                 <td>{{ task.course_instance_id }}</td>
                                 <td>{{ task.course_code }}</td>

--- a/bulk_site_creator/templates/bulk_site_creator/job_detail.html
+++ b/bulk_site_creator/templates/bulk_site_creator/job_detail.html
@@ -22,11 +22,11 @@
           <div class="col-sm-6">
               <table class="table table-condensed">
                   <tr><th>Status: </th><td>{{ job.workflow_state }}</td></tr>
-                  <tr><th>Started at: </th><td>{{ job.started_at }}</td></tr>
-                  <tr><th>Completed at: </th><td>{{ job.completed_at }}</td></tr>
-                  <tr><th>Template: </th><td>{{ job.template_name }}</td></tr>
+                  <tr><th>Started at: </th><td>{{ job.created_at }}</td></tr>
+                  <tr><th>Completed at: </th><td>{{ job.updated_at }}</td></tr>
+                  <tr><th>Template: </th><td>{{ job.template_id }}</td></tr>
                   <tr><th>Term: </th><td>{{ job.term_name }}</td></tr>
-                  <tr><th>Created by: </th><td>{{ job.CREATOR_NAME }}</td></tr>
+                  <tr><th>Created by: </th><td>{{ job.user_full_name }}</td></tr>
               </table>
           </div>
           <div class="col-sm-6">
@@ -42,7 +42,8 @@
                 <div id="job-detail-refresh-btn">
                   <a href="{% url 'bulk_site_creator:job_detail' job_id=job.sk %}" class="btn btn-primary float-end mb-2" role="button"
                     aria-pressed="true" aria-label="refresh page" title="Refresh page" data-bs-toggle="tooltip" data-bs-placement="top"
-                    data-bs-title="Refresh page"><i class="fa-solid fa-rotate-right"></i></a>
+                    data-bs-title="Refresh page"><i class="fa-solid fa-rotate-right"></i>
+                  </a>
                 </div>
                 <div class="col-sm-12">
                     <table class="datatable table table-striped table-bordered dataTable no-footer" id="details_table">
@@ -56,7 +57,11 @@
                         <tbody>
                         {% for task in tasks %}
                             <tr>
-                              <td><a href="{{ task.canvas_course_id }}">{{ task.canvas_course_id }}</a></td>
+                              {% if task.workflow_state == 'fail' or not task.canvas_course_id %}
+                                <td>{{ task.canvas_course_id }}</td>
+                              {% else %}
+                                <td><a href="{{ task.canvas_course_url }}">{{ task.canvas_course_id }}</a></td>
+                              {% endif %}
                                 <td>{{ task.course_instance_id }}</td>
                                 <td>{{ task.course_code }}</td>
                                 <td>{{ task.course_title }}</td>

--- a/bulk_site_creator/templates/bulk_site_creator/job_detail.html
+++ b/bulk_site_creator/templates/bulk_site_creator/job_detail.html
@@ -57,7 +57,11 @@
                         <tbody>
                         {% for task in tasks %}
                             <tr>
-                                <td>{% if task.canvas_course_id %}<a href="{{ canvas_url }}/courses/{{ task.canvas_course_id }}" target="_blank">{{ task.canvas_course_id }}</a>{% endif %}</td>
+                                <td>
+                                  {% if task.canvas_course_id and task.workflow_state != "fail" %}
+                                    <a href="{{ canvas_url }}/courses/{{ task.canvas_course_id }}" target="_blank">{{ task.canvas_course_id }}</a>
+                                  {% endif %}
+                                </td>
                                 <td>{{ task.course_instance_id }}</td>
                                 <td>{{ task.course_code }}</td>
                                 <td>{{ task.course_title }}</td>

--- a/bulk_site_creator/templates/bulk_site_creator/job_detail.html
+++ b/bulk_site_creator/templates/bulk_site_creator/job_detail.html
@@ -57,7 +57,7 @@
                         <tbody>
                         {% for task in tasks %}
                             <tr>
-                              {% if task.workflow_state == 'fail' or not task.canvas_course_id %}
+                              {% if task.workflow_state != 'complete' or task.workflow_state == 'fail' or not task.canvas_course_id %}
                                 <td>{{ task.canvas_course_id }}</td>
                               {% else %}
                                 <td><a href="{{ task.canvas_course_url }}" target="_blank">{{ task.canvas_course_id }} </a></td>

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -178,26 +178,25 @@
                 order: [[ 1, 'asc' ]]
             });
             
-            // Select/Deselect all checkbox.
+            // Select/Deselect all (on current page) checkbox.
             $("#select-all-checkbox").on( "click", function(e) {
                 if ($(this).is( ":checked" )) {
-                    table.rows().select();      
+                    table.rows({page: "current"}).select();      
                 } else {
-                    table.rows().deselect();
+                    table.rows({page: "current"}).deselect();
                 }
             });
-
-            $("#course-table").on( "click", function(e) {
+            // Update Select/Deselect all checkbox if some rows are unselected 
+            // or all rows are selected manually.
+            $(".select-checkbox").on( "click", function(e) {
                 const currentPageTotalTableRowItems = table.rows( {page: "current"} ).count();
                 const currentPageSelectedCourseCount = table.rows( { selected: true, page: "current" } ).count();
-                console.log("--------------------------", currentPageTotalTableRowItems, currentPageSelectedCourseCount)
-                // Update checkbox if some rows are unselected or all rows are selected manually.
+                console.log("-------------------------- Total", currentPageTotalTableRowItems, "--- Selected", currentPageSelectedCourseCount)
+
                 if (currentPageTotalTableRowItems == currentPageSelectedCourseCount) {
-                    $(this).prop( "checked", true );
-                    console.log("--------------------------true", )
+                    $("#select-all-checkbox").prop( "checked", true );
                 } else {
-                    $(this).prop( "checked", false );
-                    console.log("--------------------------false")
+                    $("#select-all-checkbox").prop( "checked", false );
                 }
             });
 
@@ -273,4 +272,3 @@
         };
 	</script>
 {% endblock js %}
-

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -103,8 +103,8 @@
                         {% endfor %}
                     </select>
                     <br>
-                    <button type="button" ng-cloak class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirmCreate">Create All</button>
-                    <button type="button" ng-cloak class="btn btn-primary" data-toggle="modal" data-target="#confirmCreate">Create Selected</button>
+                    <button type="button" ng-cloak class="btn btn-primary bsc-create-btn" data-bs-toggle="modal" data-bs-target="#confirmCreate">Create All</button>
+                    <button type="button" ng-cloak class="btn btn-primary bsc-create-btn" data-bs-toggle="modal" data-bs-target="#confirmCreate">Create Selected</button>
                     <br>
                     <br>
                     <p>You may select individual courses from the list below to customize your Canvas course site creation job.</p>
@@ -143,14 +143,15 @@
               <div class="modal-dialog">
                 <div class="modal-content">
                   <div class="modal-header">
-                    <h5 class="modal-title" id="staticBackdropLabel">Confirm Creation</h5>
+                    <h5 class="modal-title" id="staticBackdropLabel">Confirm Canvas Course Site Creation</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                   </div>
                   <div class="modal-body">
+                    <span id="modal-body-text"></span>
                     Are you sure you would like to proceed?
                   </div>
                   <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" >Close</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" >Cancel</button>
                     <button type="button" class="btn btn-primary" id="confirmCreateButton">Yes</button>
                   </div>
                 </div>
@@ -184,6 +185,21 @@
                     table.rows().deselect();
                 }
             });
+
+            // For updating modal body text.
+            $(".bsc-create-btn").on( "click", function(e) {
+                const totalTableRowItems = table.rows().count();
+                const selectedCourseCount = table.rows( { selected: true } ).count();
+                const selectedTemplateText = $.trim($("#templateSelect :selected").text());
+                const selectedTemplateVal = $("#templateSelect").val();
+                const modalBodyTextBeginning = (selectedCourseCount == 0) ? `You are about to create ${totalTableRowItems}` : `You have selected ${selectedCourseCount}`;
+                
+                if (selectedTemplateText.toLowerCase() == "no template") {
+                    $("#modal-body-text").text(`${modalBodyTextBeginning} courses for Canvas site creation with no template.`);
+                } else {
+                    $("#modal-body-text").text(`${modalBodyTextBeginning} courses for Canvas site creation with template ${selectedTemplateText}.`);
+                }
+            });            
 
             $('#confirmCreateButton').on('click', function () {
                 var selectedRows = table.rows( { selected: true } ).data();

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -193,6 +193,7 @@
                     // Template URL
                     $("<a>", {
                         class: "template-url",
+                        target: "_blank",
                         text: ` ${selectedTemplateText}` + ` (${selectedTemplateVal}).`,
                         title: "template URL",
                         href: window.location.origin + "/courses/" + `${selectedTemplateVal}`

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -112,7 +112,7 @@
                 <table id="course-table" class="datatable table table-striped table-bordered dataTable no-footer">
                     <thead>
                         <tr>
-                            <th class="form-check-input"><input type="checkbox" id="select-all-checkbox"></th>
+                            <th></th>
                             <th>SIS ID</th>
                             <th>Course Code</th>
                             <th>Course Title</th>
@@ -176,28 +176,6 @@
                     selector: 'td:first-child'
                 },
                 order: [[ 1, 'asc' ]]
-            });
-            
-            // Select/Deselect all (on current page) checkbox.
-            $("#select-all-checkbox").on( "click", function(e) {
-                if ($(this).is( ":checked" )) {
-                    table.rows({page: "current"}).select();      
-                } else {
-                    table.rows({page: "current"}).deselect();
-                }
-            });
-            // Update Select/Deselect all checkbox if some rows are unselected 
-            // or all rows are selected manually.
-            $(".select-checkbox").on( "click", function(e) {
-                const currentPageTotalTableRowItems = table.rows( {page: "current"} ).count();
-                const currentPageSelectedCourseCount = table.rows( { selected: true, page: "current" } ).count();
-                console.log("-------------------------- Total", currentPageTotalTableRowItems, "--- Selected", currentPageSelectedCourseCount)
-
-                if (currentPageTotalTableRowItems == currentPageSelectedCourseCount) {
-                    $("#select-all-checkbox").prop( "checked", true );
-                } else {
-                    $("#select-all-checkbox").prop( "checked", false );
-                }
             });
 
             // For updating modal body text.

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -178,11 +178,26 @@
                 order: [[ 1, 'asc' ]]
             });
             
+            // Select/Deselect all checkbox.
             $("#select-all-checkbox").on( "click", function(e) {
                 if ($(this).is( ":checked" )) {
                     table.rows().select();      
                 } else {
                     table.rows().deselect();
+                }
+            });
+
+            $("#course-table").on( "click", function(e) {
+                const currentPageTotalTableRowItems = table.rows( {page: "current"} ).count();
+                const currentPageSelectedCourseCount = table.rows( { selected: true, page: "current" } ).count();
+                console.log("--------------------------", currentPageTotalTableRowItems, currentPageSelectedCourseCount)
+                // Update checkbox if some rows are unselected or all rows are selected manually.
+                if (currentPageTotalTableRowItems == currentPageSelectedCourseCount) {
+                    $(this).prop( "checked", true );
+                    console.log("--------------------------true", )
+                } else {
+                    $(this).prop( "checked", false );
+                    console.log("--------------------------false")
                 }
             });
 
@@ -197,7 +212,14 @@
                 if (selectedTemplateText.toLowerCase() == "no template") {
                     $("#modal-body-text").text(`${modalBodyTextBeginning} courses for Canvas site creation with no template.`);
                 } else {
-                    $("#modal-body-text").text(`${modalBodyTextBeginning} courses for Canvas site creation with template ${selectedTemplateText}.`);
+                    $("#modal-body-text").text(`${modalBodyTextBeginning} courses for Canvas site creation with template`);
+                    // Template URL
+                    $("<a>", {
+                        class: "template-url",
+                        text: ` ${selectedTemplateText}` + ` (${selectedTemplateVal}).`,
+                        title: "template URL",
+                        href: window.location.origin + "/courses/" + `${selectedTemplateVal}`
+                    }).appendTo("#modal-body-text");
                 }
             });            
 

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -112,7 +112,7 @@
                 <table id="course-table" class="datatable table table-striped table-bordered dataTable no-footer">
                     <thead>
                         <tr>
-                            <th></th>
+                            <th class="form-check-input"><input type="checkbox" id="select-all-checkbox"></th>
                             <th>SIS ID</th>
                             <th>Course Code</th>
                             <th>Course Title</th>
@@ -175,7 +175,15 @@
                     selector: 'td:first-child'
                 },
                 order: [[ 1, 'asc' ]]
-            } );
+            });
+            
+            $("#select-all-checkbox").on( "click", function(e) {
+                if ($(this).is( ":checked" )) {
+                    table.rows().select();      
+                } else {
+                    table.rows().deselect();
+                }
+            });
 
             $('#confirmCreateButton').on('click', function () {
                 var selectedRows = table.rows( { selected: true } ).data();

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -65,10 +65,34 @@ def index(request):
     [item.update(created_at=parse_datetime(item['created_at']))
      for item in jobs_for_school]
 
+    # Add job tasks summary to job object.
+    for job in jobs_for_school:
+        tasks_query_params = {
+            'KeyConditionExpression': Key('pk').eq(job['sk']),
+            'ScanIndexForward': False,
+        }
+        tasks = table.query(**tasks_query_params)
+        
+        generate_job_summary(job, tasks)
+
     context = {
         'jobs_for_school': jobs_for_school
     }
     return render(request, "bulk_site_creator/index.html", context=context)
+
+
+def generate_job_summary(job, job_tasks):
+    """
+    This function generates job summary data based on job's tasks attributes.
+    Summary then gets added to job object.
+    """
+    task_total = job_tasks['Count']
+    task_succeeded = sum(1 for k in job_tasks['Items'] if k.get('workflow_state') == 'success')
+    task_failed = sum(1 for k in job_tasks['Items'] if k.get('workflow_state') == 'fail')
+
+    job.update(task_total=task_total,
+               task_succeeded=task_succeeded,
+               task_failed=task_failed)
 
 
 @login_required
@@ -84,18 +108,29 @@ def job_detail(request, job_id):
         'KeyConditionExpression': Key('pk').eq(school_key) & Key('sk').eq(job_id),
         'ScanIndexForward': False,
     }
-    job = table.query(**job_query_params)['Items'][0]
+    job = table.query(**job_query_params)['Items']
+
+    # Update string timestamp to datetime.
+    job[0].update(created_at=parse_datetime(job[0]['created_at']))
+    job[0].update(updated_at=parse_datetime(job[0]['updated_at']))
 
     tasks_query_params = {
         'KeyConditionExpression': Key('pk').eq(job_id),
         'ScanIndexForward': False,
     }
-    tasks = table.query(**tasks_query_params)['Items']
+    tasks = table.query(**tasks_query_params)
+
+    # Add Canvas course URL to tasks with a Canvas course ID and workflow_state != 'fail'.
+    [item.update(canvas_course_url=f"{settings.CANVAS_URL}/courses/{item['canvas_course_id']})")
+     for item in tasks['Items'] if item['canvas_course_id'] and item['workflow_state'] != 'fail']
+
+    generate_job_summary(job[0], tasks)
 
     context = {
-        'job': job,
-        'tasks': tasks
+        'job': job[0],
+        'tasks': tasks['Items']
     }
+    print('------------------------------>', context)
     return render(request, "bulk_site_creator/job_detail.html", context=context)
 
 
@@ -128,6 +163,7 @@ def new_job(request):
         except Exception:
             logger.exception(f"Failed to get departments with sis_account_id {sis_account_id}")
     
+    print('new_jobv ================================>', request.POST)
     if request.method == "POST":
         selected_term_id = request.POST.get("courseTerm", None)
         selected_course_group_id = request.POST.get("courseCourseGroup").split(":")[1] if request.POST.get("courseCourseGroup", None) else None
@@ -167,6 +203,7 @@ def new_job(request):
         'selected_department_id': selected_department_id
     }
 
+    print('new_job ================================>', context)
     return render(request, "bulk_site_creator/new_job.html", context=context)
 
 

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -5,7 +5,7 @@ boto3==1.26.12
 # NOTE: jasmine testing relies on a checked-in version of the django-angular js.
 # if you bump the version of django-angular, please also download and check in
 # new copies of django-angular[.min].js.
-git+ssh://git@github.com/Harvard-University-iCommons/django-angular.git@v2.3#egg=django-angular==2.3
+django-angular @ git+ssh://git@github.com/Harvard-University-iCommons/django-angular.git@v2.3
 django-cached-authentication-middleware==0.2.2
 
 django-proxy==1.2.1
@@ -19,19 +19,19 @@ django-crispy-forms==1.14.0
 rq==1.10.0
 django-rq==2.5.1
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0
+django-auth-lti @ git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
+django-icommons-ui @ git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v3.2#egg=django-canvas-lti-school-permissions==3.2
+django-canvas-lti-school-permissions @ git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v3.2
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0#egg=django-harvardkey-cas==3.0
+django-harvardkey-cas @ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.4#egg=django-coursemanager==0.4
+django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.4
 
-git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4#egg=canvas_python_sdk==1.4
+canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4
 
-git+ssh://git@github.com/Harvard-University-iCommons/harvard-django-utils.git@v0.1#egg=harvard-django-utils==0.1
+harvard-django-utils @ git+ssh://git@github.com/Harvard-University-iCommons/harvard-django-utils.git@v0.1
 
 hiredis==2.0.0
 kitchen==1.2.6
@@ -40,7 +40,7 @@ redis==3.5.3
 urllib3>=1.26
 requests==2.28.0
 simplejson==3.17.6
-git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6
+django-ssm-parameter-store @ git+ssh://git@github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6
 
 splunk_handler==3.0.0
 python-json-logger==2.0.4

--- a/canvas_account_admin_tools/requirements/local.txt
+++ b/canvas_account_admin_tools/requirements/local.txt
@@ -16,7 +16,7 @@ pyvirtualdisplay==3.0
 selenium==2.53.0
 xlrd==1.0.0
 
-git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1.8#egg=selenium-common==1.8
+selenium-common @ git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1.8
 
 #-e ../selenium_common
 


### PR DESCRIPTION
- Populate “Summary” column in index table based on the total/success/fail BulkJob columns
    - <img width="1110" alt="Screenshot 2023-05-10 at 3 14 00 PM" src="https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/108423994/f9bf5f32-76e4-4bf2-9d89-602e738d7aa9">

- In the job detail page, update fields in template to reflect job fields (started at, completed at, template, etc)
    - <img width="1119" alt="Screenshot 2023-05-10 at 3 11 33 PM" src="https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/108423994/6830b1a2-0632-4960-8c69-f5887c3e5cab">

- If a task record is in progress or has a status of failed or canvas course ID is Null, do not provide a link in “Canvas Course ID” column
    - In progress or failed: <img width="1110" alt="Screenshot 2023-05-10 at 3 18 08 PM" src="https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/108423994/9aee057d-1965-45eb-9ca0-d65b32a77dca">
    - Complete (has a link): <img width="1110" alt="Screenshot 2023-05-10 at 3 13 04 PM" src="https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/108423994/fc717afb-6e07-4cda-8912-792d88093b95">

- Display summary in confirmation modal
    - ![tryufty](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/108423994/1f163cbc-69e6-4eee-96c8-866dd170208f)
