### PR TITLE
TLT-4453: Get department + course group data from coursemanager

### DIFF
--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -21,7 +21,7 @@
                             <span class="required-field-marker">*</span>
                         </label>
                         <br>
-                        <select id="courseTerm" name="courseTerm" class="form-control">
+                        <select id="courseTerm" name="courseTerm" class="form-select">
                             {% for term in terms %}
                                 {% if selected_term_id == term.id %}
                                     <option value="{{ term.id }}" selected>{{ term.name }}</option>
@@ -36,7 +36,7 @@
                                 <span class="required-field-marker">*</span>
                             </label>
                             <br>
-                            <select id="courseDepartment" name="courseDepartment" class="form-control">
+                            <select id="courseDepartment" name="courseDepartment" class="form-select">
                                 {% if not selected_department_id or selected_department_id == '0' %}
                                     <option value="0" selected>All Departments</option>
                                 {% else %}
@@ -56,7 +56,7 @@
                                 <span class="required-field-marker">*</span>
                             </label>
                             <br>
-                            <select id="courseCourseGroup" name="courseCourseGroup" class="form-control">
+                            <select id="courseCourseGroup" name="courseCourseGroup" class="form-select">
                                 {% if not selected_course_group_id or selected_course_group_id == '0' %}
                                     <option value="0" selected>All Course Groups</option>
                                 {% else %}
@@ -92,7 +92,7 @@
             <div class="row">
                 <h4>{{ potential_site_count }} courses ready for Canvas course site creation</h4>
                 <div class="col-sm-6 margin-bottom-md">
-                    <select id="templateSelect" class="form-control">
+                    <select id="templateSelect" class="form-select">
                         <option value="0">
                             No Template
                         </option>

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -38,12 +38,12 @@
                             <br>
                             <select id="courseDepartment" name="courseDepartment" class="form-control">
                                 {% if not selected_department_id or selected_department_id == '0' %}
-                                    <option value="dept:0" selected>Department</option>
+                                    <option value="0" selected>All Departments</option>
                                 {% else %}
-                                    <option value="dept:0">Department</option>
+                                    <option value="0">All Department</option>
                                 {% endif %}
                                 {% for department in departments %}
-                                    {% if selected_department_id and "dept:"|add:selected_department_id == department.id %}
+                                    {% if selected_department_id and selected_department_id == department.id %}
                                         <option value="{{ department.id }}" selected>{{ department.name }}</option>
                                     {% else %}
                                         <option value="{{ department.id }}">{{ department.name }}</option>
@@ -58,12 +58,12 @@
                             <br>
                             <select id="courseCourseGroup" name="courseCourseGroup" class="form-control">
                                 {% if not selected_course_group_id or selected_course_group_id == '0' %}
-                                    <option value="coursegroup:0" selected>Course Group</option>
+                                    <option value="0" selected>All Course Groups</option>
                                 {% else %}
-                                    <option value="coursegroup:0">Course Group</option>
+                                    <option value="0">All Course Groups</option>
                                 {% endif %}
                                 {% for course_group in course_groups %}
-                                    {% if selected_course_group_id and "coursegroup:"|add:selected_course_group_id == course_group.id %}
+                                    {% if selected_course_group_id and selected_course_group_id == course_group.id %}
                                         <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
                                     {% else %}
                                         <option value="{{ course_group.id }}">{{ course_group.name }}</option>

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -4,10 +4,8 @@ from typing import Optional
 
 import boto3
 from boto3.dynamodb.conditions import Key
-from botocore.exceptions import ClientError
-from canvas_api.helpers import accounts as canvas_api_accounts
 from canvas_sdk import RequestContext
-from coursemanager.models import CourseGroup, Department, Term
+from coursemanager.models import CourseGroup
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -19,19 +17,15 @@ from django_auth_lti import const
 from django_auth_lti.decorators import lti_role_required
 from lti_school_permissions.decorators import lti_permission_required
 
-from canvas_account_admin_tools.models import CanvasSchoolTemplate
-from common.utils import (get_canvas_site_template,
-                          get_canvas_site_templates_for_school,
+from common.utils import (get_canvas_site_templates_for_school,
                           get_course_group_data_for_school,
                           get_department_data_for_school,
-                          get_school_data_for_sis_account_id,
                           get_term_data_for_school)
 
 from .schema import JobRecord
 from .utils import (batch_write_item, generate_task_objects,
-                    get_course_instance_query_set,
-                    get_course_instances_without_canvas_sites,
-                    get_department_name_by_id, get_term_name_by_id)
+                    get_course_instance_query_set, get_department_name_by_id,
+                    get_term_name_by_id)
 
 logger = logging.getLogger(__name__)
 
@@ -127,11 +121,11 @@ def new_job(request):
             departments = get_department_data_for_school(sis_account_id)
         except Exception:
             logger.exception(f"Failed to get departments with sis_account_id {sis_account_id}")
-    
+
     if request.method == "POST":
         selected_term_id = request.POST.get("courseTerm", None)
-        selected_course_group_id = request.POST.get("courseCourseGroup").split(":")[1] if request.POST.get("courseCourseGroup", None) else None
-        selected_department_id = request.POST.get("courseDepartment").split(":")[1] if request.POST.get("courseDepartment", None) else None
+        selected_course_group_id = request.POST.get("courseCourseGroup", None)
+        selected_department_id = request.POST.get("courseDepartment", None)
 
         # Retrieve all course instances for the given term_id and account that do not have Canvas course sites
         # nor are set to be fed into Canvas via the automated feed


### PR DESCRIPTION
Resolves [TLT-4453](https://jira.huit.harvard.edu/browse/TLT-4453).

This PR:
- Updates Site Creator v2 to get Department + Course Group data from Coursemanager (instead of via the Canvas API) for use by the frontend.
- Updates the styling of the New Job dropdowns to better reflect their intended use.
- Updates the default text for Department/Course Group filters to "All Departments" and "All Course Groups".

Example of the changes involved in the last two bullet points above (circled section highlights the dropdown styling update):
![Screen Shot 2023-05-10 at 5 57 20 PM](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/43320443/ceea5106-bbde-42b9-ad0c-846ccaef3dfa)
