### PR TITLE
TLT-4462: Update filtering of department/course group data

### DIFF
--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -14,7 +14,7 @@
 <body role="application">
     <div class="container-fluid">
         {% if terms %}
-            {% if course_group or department %}
+            {% if course_groups or departments %}
                 <form id="ci-filters" class="form-inline" method="POST" action="{% url 'bulk_site_creator:new_job' %}">{% csrf_token %}
                     <div class="row">
                         <div class="col-sm-6 margin-bottom-md">

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -14,83 +14,87 @@
 <body role="application">
     <div class="container-fluid">
         {% if terms %}
-            <form id="ci-filters" class="form-inline" method="POST" action="{% url 'bulk_site_creator:new_job' %}">{% csrf_token %}
-                <div class="row">
-                    <div class="col-sm-6 margin-bottom-md">
-                        <label for="courseTerm">Term
-                            <span class="required-field-marker">*</span>
-                        </label>
-                        <br>
-                        <select id="courseTerm" name="courseTerm" class="form-select">
-                            {% for term in terms %}
-                                {% if selected_term_id == term.id %}
-                                    <option value="{{ term.id }}" selected>{{ term.name }}</option>
-                                {% else %}
-                                    <option value="{{ term.id }}">{{ term.name }}</option>
-                                {% endif %}
-                            {% endfor %}
-                        </select>
-                        <br>
-                        {% if departments %}
-                            <label for="courseDepartment">Department
+            {% if course_group or department %}
+                <form id="ci-filters" class="form-inline" method="POST" action="{% url 'bulk_site_creator:new_job' %}">{% csrf_token %}
+                    <div class="row">
+                        <div class="col-sm-6 margin-bottom-md">
+                            <label for="courseTerm">Term
                                 <span class="required-field-marker">*</span>
                             </label>
                             <br>
-                            <select id="courseDepartment" name="courseDepartment" class="form-select">
-                                {% if not selected_department_id or selected_department_id == '0' %}
-                                    <option value="0" selected>All Departments</option>
-                                {% else %}
-                                    <option value="0">All Department</option>
-                                {% endif %}
-                                {% for department in departments %}
-                                    {% if selected_department_id and selected_department_id == department.id %}
-                                        <option value="{{ department.id }}" selected>{{ department.name }}</option>
+                            <select id="courseTerm" name="courseTerm" class="form-select">
+                                {% for term in terms %}
+                                    {% if selected_term_id == term.id %}
+                                        <option value="{{ term.id }}" selected>{{ term.name }}</option>
                                     {% else %}
-                                        <option value="{{ department.id }}">{{ department.name }}</option>
+                                        <option value="{{ term.id }}">{{ term.name }}</option>
                                     {% endif %}
                                 {% endfor %}
                             </select>
                             <br>
-                        {% elif course_groups %}
-                            <label for="courseCourseGroup">Course Group
-                                <span class="required-field-marker">*</span>
-                            </label>
-                            <br>
-                            <select id="courseCourseGroup" name="courseCourseGroup" class="form-select">
-                                {% if not selected_course_group_id or selected_course_group_id == '0' %}
-                                    <option value="0" selected>All Course Groups</option>
-                                {% else %}
-                                    <option value="0">All Course Groups</option>
-                                {% endif %}
-                                {% for course_group in course_groups %}
-                                    {% if selected_course_group_id and selected_course_group_id == course_group.id %}
-                                        <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
+                            {% if departments %}
+                                <label for="courseDepartment">Department
+                                    <span class="required-field-marker">*</span>
+                                </label>
+                                <br>
+                                <select id="courseDepartment" name="courseDepartment" class="form-select">
+                                    {% if not selected_department_id or selected_department_id == '0' %}
+                                        <option value="0" selected>All Departments</option>
                                     {% else %}
-                                        <option value="{{ course_group.id }}">{{ course_group.name }}</option>
+                                        <option value="0">All Department</option>
                                     {% endif %}
-                                {% endfor %}
-                            </select>
-                        {% endif %}
+                                    {% for department in departments %}
+                                        {% if selected_department_id and selected_department_id == department.id %}
+                                            <option value="{{ department.id }}" selected>{{ department.name }}</option>
+                                        {% else %}
+                                            <option value="{{ department.id }}">{{ department.name }}</option>
+                                        {% endif %}
+                                    {% endfor %}
+                                </select>
+                                <br>
+                            {% elif course_groups %}
+                                <label for="courseCourseGroup">Course Group
+                                    <span class="required-field-marker">*</span>
+                                </label>
+                                <br>
+                                <select id="courseCourseGroup" name="courseCourseGroup" class="form-select">
+                                    {% if not selected_course_group_id or selected_course_group_id == '0' %}
+                                        <option value="0" selected>All Course Groups</option>
+                                    {% else %}
+                                        <option value="0">All Course Groups</option>
+                                    {% endif %}
+                                    {% for course_group in course_groups %}
+                                        {% if selected_course_group_id and selected_course_group_id == course_group.id %}
+                                            <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
+                                        {% else %}
+                                            <option value="{{ course_group.id }}">{{ course_group.name }}</option>
+                                        {% endif %}
+                                    {% endfor %}
+                                </select>
+                            {% endif %}
+                        </div>
+                        <div class="col-md-12">
+                            <button id="find-courses-in-term"
+                                    type="submit"
+                                    class="btn btn-primary"
+                                    style="margin-top: 25px; margin-bottom: 25px;"
+                                    onclick="displayLoading()">
+                                Find Courses
+                            </button>
+                        </div>
                     </div>
-                    <div class="col-md-12">
-                        <button id="find-courses-in-term"
-                                type="submit"
-                                class="btn btn-primary"
-                                style="margin-top: 25px; margin-bottom: 25px;"
-                                onclick="displayLoading()">
-                            Find Courses
-                        </button>
-                    </div>
-                </div>
-            </form>
+                </form>
+            {% else %}
+                <h3>There are no active departments or course groups in this account.</h3>
+            {% endif %}
         {% else %}
-            No terms exist for this account
+                <h3>There are no terms available in this account.</h3>
         {% endif %}
 
         {% if potential_course_sites %}
             <hr>
             <div class="row">
-                <h4>{{ potential_site_count }} courses ready for Canvas course site creation</h4>
+                <h4>{{ potential_site_count }} courses ready for Canvas course site creation.</h4>
                 <div class="col-sm-6 margin-bottom-md">
                     <select id="templateSelect" class="form-select">
                         <option value="0">
@@ -185,10 +189,10 @@
 
             // For updating Create All/Create Selected button text when table body (or checkbox) is clicked.
             $("#course-table-body").on( "click", function() {
-                // Update button after n seconds to get accurate if row selected value 
+                // Update button after n seconds to get accurate if row selected value
                 // after DataTable has time to process checkbox click.
                 setTimeout(
-                    function() 
+                    function()
                     {
                         const create_btn_text = (table.rows( { selected: true } ).any()) ? "Create Selected" : "Create All";
                         $("#bsc-create-btn").html(`${create_btn_text}`);
@@ -202,7 +206,7 @@
                 const selectedTemplateText = $.trim($("#templateSelect :selected").text());
                 const selectedTemplateVal = $("#templateSelect").val();
                 const modalBodyTextBeginning = (selectedCourseCount == 0) ? `You are about to create ${totalTableRowItems}` : `You have selected ${selectedCourseCount}`;
-                
+
                 if (selectedTemplateText.toLowerCase() == "no template") {
                     $("#modal-body-text").text(`${modalBodyTextBeginning} courses for Canvas site creation with no template.`);
                 } else {
@@ -216,7 +220,7 @@
                         href: window.location.origin + "/courses/" + `${selectedTemplateVal}`
                     }).appendTo("#modal-body-text");
                 }
-            });            
+            });
 
             $('#confirmCreateButton').on('click', function () {
                 var selectedRows = table.rows( { selected: true } ).data();

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -27,7 +27,7 @@ django-canvas-lti-school-permissions @ git+ssh://git@github.com/Harvard-Universi
 
 django-harvardkey-cas @ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0
 
-django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.4
+django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@patrick/add-active-coursegrouops-and-departments-mv
 
 canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4
 

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -27,7 +27,7 @@ django-canvas-lti-school-permissions @ git+ssh://git@github.com/Harvard-Universi
 
 django-harvardkey-cas @ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0
 
-django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@patrick/add-active-coursegrouops-and-departments-mv
+django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@patricktonne/add-active-coursegrouops-and-departments-mv
 
 canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -98,7 +98,7 @@ def get_department_data_for_school(school_sis_account_id: str) -> list:
     school_id = school_sis_account_id.split(':')[1]
     try:
         query_set = MVActiveCGDept.objects.filter(
-            school_id=school_id, type='department'
+            school_id=school_id, type='DEPARTMENT'
         ).order_by('name')
     except MVActiveCGDept.DoesNotExist:
         return []
@@ -115,7 +115,7 @@ def get_course_group_data_for_school(school_sis_account_id: str) -> list:
     school_id = school_sis_account_id.split(':')[1]
     try:
         query_set = MVActiveCGDept.objects.filter(
-            school_id=school_id, type='course_group'
+            school_id=school_id, type='COURSE_GROUP'
         ).order_by('name')
     except MVActiveCGDept.DoesNotExist:
         return []

--- a/common/utils.py
+++ b/common/utils.py
@@ -6,14 +6,7 @@ from canvas_api.helpers import accounts as canvas_api_accounts_helper
 from canvas_sdk import RequestContext
 from canvas_sdk.methods import courses as canvas_api_courses
 from canvas_sdk.utils import get_all_list_data
-from coursemanager.models import (
-    Course,
-    CourseGroup,
-    CourseInstance,
-    Department,
-    MVActiveCGDept,
-    Term,
-)
+from coursemanager.models import MVActiveCGDept, Term
 from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone

--- a/common/utils.py
+++ b/common/utils.py
@@ -99,7 +99,7 @@ def get_department_data_for_school(school_sis_account_id: str) -> list:
     try:
         query_set = MVActiveCGDept.objects.filter(
             school_id=school_id, type='department'
-        )
+        ).order_by('name')
     except MVActiveCGDept.DoesNotExist:
         return []
 
@@ -116,7 +116,7 @@ def get_course_group_data_for_school(school_sis_account_id: str) -> list:
     try:
         query_set = MVActiveCGDept.objects.filter(
             school_id=school_id, type='course_group'
-        )
+        ).order_by('name')
     except MVActiveCGDept.DoesNotExist:
         return []
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -152,11 +152,11 @@ def _has_active_course_instance(courses: QuerySet[Course]) -> bool:
         return False
     for course in courses:
         try:
-            course_instances = CourseInstance.objects.filter(course=course).select_related("term").filter(term__end_date__gt=timezone.now()).order_by("-term__end_date")
+            course_instances = CourseInstance.objects.filter(course=course).select_related("term").filter(term__end_date__gt=timezone.now())
         except CourseInstance.DoesNotExist:
             return False
-        most_recent_course_instance = course_instances.first()
-        return True if most_recent_course_instance and _has_future_end_date_for_course_instance(most_recent_course_instance) else False
+        # if the above query returns any results, then the course has an active course instance
+        return True if course_instances else False
 
 def is_active_department(department: Department) -> bool:
     courses = _get_courses_from_department(department)

--- a/common/utils.py
+++ b/common/utils.py
@@ -132,15 +132,6 @@ def get_course_group_data_for_school(school_sis_account_id):
 
     return course_groups
 
-def _has_future_end_date_for_course_instance(course_instance: CourseInstance) -> bool:
-    date = course_instance.term.end_date
-    if not date:
-        # if no end_date is set, try using the term's conclude_date
-        date = course_instance.term.conclude_date
-    if date and date > timezone.now():
-        return True
-    return False
-
 def _get_courses_from_department(department: Department) -> QuerySet[Course]:
     return Course.objects.filter(department=department)
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -149,13 +149,14 @@ def _get_courses_from_course_group(course_group: CourseGroup) -> QuerySet[Course
 
 def _has_active_course_instance(courses: QuerySet[Course]) -> bool:
     for course in courses:
-        course_instances = CourseInstance.objects.filter(course=course).select_related("term").order_by("term__end_date")
+        course_instances = CourseInstance.objects.filter(course=course).select_related("term").order_by("-term__end_date")
         if not course_instances:
             return False
         most_recent_course_instance = course_instances.first()
         if most_recent_course_instance and _has_future_end_date_for_course_instance(most_recent_course_instance):
             return True
-    return False
+        else:
+            return False
 
 def is_active_department(department: Department) -> bool:
     courses = _get_courses_from_department(department)

--- a/common/utils.py
+++ b/common/utils.py
@@ -89,12 +89,9 @@ def get_department_data_for_school(school_sis_account_id: str) -> list:
     """
 
     school_id = school_sis_account_id.split(':')[1]
-    try:
-        query_set = MVActiveCGDept.objects.filter(
-            school_id=school_id, type='DEPARTMENT'
-        ).order_by('name')
-    except MVActiveCGDept.DoesNotExist:
-        return []
+    query_set = MVActiveCGDept.objects.filter(
+        school_id=school_id, type='DEPARTMENT'
+    ).order_by('name')
 
     return list(query_set.values('id', 'name')) if query_set else []
 
@@ -106,12 +103,9 @@ def get_course_group_data_for_school(school_sis_account_id: str) -> list:
     """
 
     school_id = school_sis_account_id.split(':')[1]
-    try:
-        query_set = MVActiveCGDept.objects.filter(
-            school_id=school_id, type='COURSE_GROUP'
-        ).order_by('name')
-    except MVActiveCGDept.DoesNotExist:
-        return []
+    query_set = MVActiveCGDept.objects.filter(
+        school_id=school_id, type='COURSE_GROUP'
+    ).order_by('name')
 
     return list(query_set.values('id', 'name')) if query_set else []
 


### PR DESCRIPTION
Resolves [TLT-4462](https://jira.huit.harvard.edu/browse/TLT-4462).

Depends on:
- django-coursemanager PR for model: https://github.com/Harvard-University-iCommons/django-coursemanager/pull/5.
- database-migration PR for MV SQL: https://github.com/Harvard-University-iCommons/database-migration/pull/16.

This PR:
- Updates the app to get all course groups and departments from a materialized view (`MV_ACTIVE_CG_DEPT`) that contains all active course groups/departments. This is to improve the performance of the app when users select "New Job", particularly within the Harvard College/GSAS sub-account (the largest sub-account).

### Testing
These changes have been deployed to QA. Testing involves clicking "New Job" from the app's index page. This will render a new page with a dropdown of departments/course groups.
