### PR TITLE
Only try to extract params from the request body if body is not empty

### DIFF
--- a/canvas_account_admin_tools/views.py
+++ b/canvas_account_admin_tools/views.py
@@ -218,7 +218,7 @@ def icommons_rest_api_proxy(request, path):
     response = proxy_view(request, url, request_args)
     try:
         params = request.GET
-        if request.method in ['PATCH', 'POST']:
+        if request.method in ['PATCH', 'POST'] and bool(request.body):
             try:
                 params = json.loads(request.body)
             except json.decoder.JSONDecodeError:


### PR DESCRIPTION
This section of the code tries to extract parameters from API requests that are proxied through CAAT to the iCommons API in order to log them. 

Some part of the frontend JS code makes a lot of PATCH or POST requests with an empty body which was breaking the `json.loads()` call at line 223. This hotfix just checks to make sure that the body is not empty before we try to load it. 