### PR TITLE
Task/haydn9000/tlt 4465/address hls failures

### DIFF
--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -124,6 +124,7 @@ class TaskRecord:
             "section": str(self.section),
             "department_id": str(self.department_id),
             "course_group_id": str(self.course_group_id),
+            "sis_account_id": str(self.sis_account_id),
         }
 
 

--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -56,7 +56,6 @@ class JobRecord:
         return {
             "pk": str(self.pk),
             "sk": str(self.sk),
-            "sis_account_id": str(self.sis_account_id),
             "term_id": str(self.term_id),
             "sis_term_id": str(self.sis_term_id),
             "term_name": str(self.term_name),

--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -13,7 +13,6 @@ class JobRecord:
     def __init__(
         self,
         school: str,
-        sis_account_id: str,
         term_id: str,
         sis_term_id: str,
         term_name: Optional[str],
@@ -30,7 +29,6 @@ class JobRecord:
     ):
         self.pk = f"SCHOOL#{school.upper()}"
         self.sk = f"JOB#{str(ULID())}"
-        self.sis_account_id = sis_account_id
         self.term_id = term_id
         self.sis_term_id = sis_term_id
         self.term_name = term_name

--- a/bulk_site_creator/schema.py
+++ b/bulk_site_creator/schema.py
@@ -90,7 +90,8 @@ class TaskRecord:
         short_title: str,
         section: str,
         department_id: str,
-        course_group_id: str
+        course_group_id: str,
+        sis_account_id: str
     ):
         self.pk = job_record.sk
         self.sk = f"TASK#{str(ULID())}"
@@ -102,6 +103,7 @@ class TaskRecord:
         self.section = section
         self.department_id = department_id
         self.course_group_id = course_group_id
+        self.sis_account_id = sis_account_id
         self.created_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
         self.updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
 

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -37,6 +37,13 @@ def generate_task_objects(course_instances: list[dict], job: JobRecord):
             else:
                 course_code = ci.course.registrar_code
 
+            if ci.course.course_group:
+                sis_account_id = f"sis_account_id:coursegroup:{ci.course.course_group_id}"
+            elif ci.coursegroup.department:
+                sis_account_id = f"sis_account_id:department:{ci.course.department_id}"
+            else:
+                sis_account_id = f"sis_account_id:school:{ci.course.school_id}"
+
             task = TaskRecord(job_record=job,
                               course_instance_id=ci.course_instance_id,
                               course_code=course_code,
@@ -45,6 +52,7 @@ def generate_task_objects(course_instances: list[dict], job: JobRecord):
                               canvas_course_id=ci.canvas_course_id,
                               department_id=ci.course.department_id,
                               course_group_id=ci.course.course_group_id,
+                              sis_account_id=sis_account_id,
                               section=ci.section,
                               workflow_state='pending').to_dict()
             tasks.append(task)

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -38,11 +38,11 @@ def generate_task_objects(course_instances: list[dict], job: JobRecord):
                 course_code = ci.course.registrar_code
 
             if ci.course.course_group:
-                sis_account_id = ci.course.course_group_id
+                sis_account_id = f"coursegroup:{ci.course.course_group_id}"
             elif ci.course.department:
-                sis_account_id = ci.course.department_id
+                sis_account_id = f"dept:{ci.course.department_id}"
             else:
-                sis_account_id = ci.course.school_id
+                sis_account_id = f"school:{ci.course.school_id}"
 
             task = TaskRecord(job_record=job,
                               course_instance_id=ci.course_instance_id,

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -38,11 +38,11 @@ def generate_task_objects(course_instances: list[dict], job: JobRecord):
                 course_code = ci.course.registrar_code
 
             if ci.course.course_group:
-                sis_account_id = f"sis_account_id:coursegroup:{ci.course.course_group_id}"
+                sis_account_id = ci.course.course_group_id
             elif ci.course.department:
-                sis_account_id = f"sis_account_id:department:{ci.course.department_id}"
+                sis_account_id = ci.course.department_id
             else:
-                sis_account_id = f"sis_account_id:school:{ci.course.school_id}"
+                sis_account_id = ci.course.school_id
 
             task = TaskRecord(job_record=job,
                               course_instance_id=ci.course_instance_id,

--- a/bulk_site_creator/utils.py
+++ b/bulk_site_creator/utils.py
@@ -39,7 +39,7 @@ def generate_task_objects(course_instances: list[dict], job: JobRecord):
 
             if ci.course.course_group:
                 sis_account_id = f"sis_account_id:coursegroup:{ci.course.course_group_id}"
-            elif ci.coursegroup.department:
+            elif ci.course.department:
                 sis_account_id = f"sis_account_id:department:{ci.course.department_id}"
             else:
                 sis_account_id = f"sis_account_id:school:{ci.course.school_id}"

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -262,7 +262,6 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
 
     if potential_course_sites_query.count() > 0:
         job = JobRecord(
-            sis_account_id=sis_account_id,
             user_id=user_id,
             user_full_name=user_full_name,
             user_email=user_email,

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -227,9 +227,7 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
     create_all = table_data['create_all']
     course_instance_ids = table_data['course_instance_ids']
     template_id = table_data['template']
-    # TODO: Fix template_name, getting an error currently.
-    # template_name = get_canvas_site_template_name(template_id)
-    template_name = 'TODO'
+    template_name = get_canvas_site_template_name(template_id)
 
     if create_all:
         # Get all course instance records that will have Canvas sites created by filtering on the

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -227,7 +227,9 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
     create_all = table_data['create_all']
     course_instance_ids = table_data['course_instance_ids']
     template_id = table_data['template']
-    template_name = get_canvas_site_template_name(template_id)
+    # TODO: Fix template_name, getting an error currently.
+    # template_name = get_canvas_site_template_name(template_id)
+    template_name = 'TODO'
 
     if create_all:
         # Get all course instance records that will have Canvas sites created by filtering on the


### PR DESCRIPTION
Updated to address the issue where HLS jobs were failing because department ID was getting a None value.

NOTE:
- This change has been deployed in QA
- Related [PR here](https://github.com/Harvard-University-iCommons/uw-canvas-site-creator/pull/17) for changes in `uw-canvas-site-creator` for getting sis_account_id