### PR TITLE
TLT-4468 - Bugfix - Jobs with no template fail

### DIFF
--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -226,8 +226,8 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
     department_name = None
     create_all = table_data['create_all']
     course_instance_ids = table_data['course_instance_ids']
-    template_id = table_data['template']
-    template_name = get_canvas_site_template_name(template_id)
+    template_id = None if table_data['template'] == '0' else table_data['template']
+    template_name = 'No template' if not template_id else get_canvas_site_template_name(template_id)
 
     if create_all:
         # Get all course instance records that will have Canvas sites created by filtering on the

--- a/common/utils.py
+++ b/common/utils.py
@@ -176,6 +176,7 @@ def get_canvas_site_templates_for_school(school_id):
 
     return templates
 
+
 def get_canvas_site_template(school_id, template_canvas_course_id):
     """
     Get the Canvas site template given the school and the Canvas template site canvas course id.


### PR DESCRIPTION
Check the submitted template ID and if it is the "No template" option (value of 0), then set. the ID to None and template name to 'No template'