### PR TITLE
Bug/haydn9000/tlt 4467/fix datatable sorting on date field

### DIFF
--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -38,14 +38,14 @@
     </div>
 
     <div class="row container-fluid">
-        <h3>
+        <h4 class="mt-4">
             Bulk Creation Jobs:
             <a href="{% url 'bulk_site_creator:index' %}" class="btn btn-primary float-end ms-2" role="button" 
                 aria-pressed="true" aria-label="refresh page" title="Refresh page" data-bs-toggle="tooltip" 
                 data-bs-placement="top" data-bs-title="Refresh page"><i class="fa-solid fa-rotate-right"></i>
             </a>
             <a href="{% url 'bulk_site_creator:new_job' %}" class="btn btn-primary" style="float: right;">New Job</a>
-        </h3>
+        </h4>
         <table class="datatable table table-striped table-bordered dataTable no-footer">
             <thead>
                 <tr>

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -49,6 +49,7 @@
         <table class="datatable table table-striped">
             <thead>
                 <tr>
+                    <th>Created At ISO8601</th><!-- Hidden Column used for DataTable sorting -->
                     <th>Created At</th>
                     <th>Term</th>
                     <th>Started By</th>
@@ -59,10 +60,11 @@
             <tbody>
             {% for bulk_job in jobs_for_school %}
                 <tr>
+                    <td>{{ bulk_job.created_at }}</td>
                     <td>
                         <a href="{% url 'bulk_site_creator:job_detail' job_id=bulk_job.sk %}"
                         data-bs-toggle="tooltip" data-bs-placement="top" title="View job detail"
-                        data-job-id="{{ bulk_job.sk }}">{{ bulk_job.created_at }}</a>
+                        data-job-id="{{ bulk_job.sk }}">{{ bulk_job.created_at_datetime }}</a>
                     </td>
                     <td>{{ bulk_job.term_name }}</td>
                     <td>{{ bulk_job.user_full_name }}</td>
@@ -92,7 +94,17 @@
     <script>
         $(document).ready(function () {
             $('.datatable').DataTable({
-                "order": [],
+                "columnDefs": [
+                    {
+                        "orderable": false,
+                        "targets": [0, 1, 2, 3, 4, 5],
+                    },
+                    {
+                        "visible": false, 
+                        "target": 0,
+                    }
+                ],
+                "order": [[0, "desc"]],
             });
 
             // Enable tooltips (Bootstrap 5.2.x).

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -92,7 +92,7 @@
     <script>
         $(document).ready(function () {
             $('.datatable').DataTable({
-                order: [[0, 'desc']],
+                "order": [],
             });
 
             // Enable tooltips (Bootstrap 5.2.x).

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -46,7 +46,7 @@
             </a>
             <a href="{% url 'bulk_site_creator:new_job' %}" class="btn btn-primary" style="float: right;">New Job</a>
         </h4>
-        <table class="datatable table table-striped table-bordered dataTable no-footer">
+        <table class="datatable table table-striped">
             <thead>
                 <tr>
                     <th>Created At</th>

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -49,7 +49,6 @@
         <table class="datatable table table-striped">
             <thead>
                 <tr>
-                    <th>Created At ISO8601</th><!-- Hidden Column used for DataTable sorting -->
                     <th>Created At</th>
                     <th>Term</th>
                     <th>Started By</th>
@@ -60,11 +59,15 @@
             <tbody>
             {% for bulk_job in jobs_for_school %}
                 <tr>
-                    <td>{{ bulk_job.created_at }}</td>
-                    <td>
+                    <!-- 
+                        `data-order`: DataTables sorting on Unix version of created_at time.
+                        DataTables doc: https://datatables.net/manual/data/orthogonal-data#HTML-5
+                        Django doc: https://docs.djangoproject.com/en/4.2/ref/templates/builtins/#date
+                    -->
+                    <td data-order="{{ bulk_job.created_at | date:'U' }}">
                         <a href="{% url 'bulk_site_creator:job_detail' job_id=bulk_job.sk %}"
                         data-bs-toggle="tooltip" data-bs-placement="top" title="View job detail"
-                        data-job-id="{{ bulk_job.sk }}">{{ bulk_job.created_at_datetime }}</a>
+                        data-job-id="{{ bulk_job.sk }}">{{ bulk_job.created_at }}</a>
                     </td>
                     <td>{{ bulk_job.term_name }}</td>
                     <td>{{ bulk_job.user_full_name }}</td>
@@ -97,12 +100,8 @@
                 "columnDefs": [
                     {
                         "orderable": false,
-                        "targets": [0, 1, 2, 3, 4, 5],
+                        "targets": [1, 2, 3, 4],
                     },
-                    {
-                        "visible": false, 
-                        "target": 0,
-                    }
                 ],
                 "order": [[0, "desc"]],
             });

--- a/bulk_site_creator/templates/bulk_site_creator/index.html
+++ b/bulk_site_creator/templates/bulk_site_creator/index.html
@@ -15,22 +15,22 @@
         {% for message in messages %}
             {% if message.level_tag == "success" %}
                 <div class="alert alert-success alert-dismissible fade show" role="alert">
-                    <button type="button" class="btn-close" data-bs-dismiss="alert">&times;</button>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     {{ message }}
                 </div>
             {% elif message.level_tag == "error" %}
                 <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                    <button type="button" class="btn-close" data-bs-dismiss="alert">&times;</button>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     {{ message }}
                 </div>
             {% elif message.level_tag == "warning" %}
                 <div class="alert alert-warning alert-dismissible fade show" role="alert">
-                    <button type="button" class="btn-close" data-bs-dismiss="alert">&times;</button>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     {{ message }}
                 </div>
             {% else %}
                 <div class="alert alert-dismissible fade show" role="alert">
-                    <button type="button" class="btn-close" data-bs-dismiss="alert">&times;</button>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     {{ message }}
                 </div>
             {% endif %}

--- a/bulk_site_creator/templates/bulk_site_creator/job_detail.html
+++ b/bulk_site_creator/templates/bulk_site_creator/job_detail.html
@@ -15,7 +15,7 @@
       <div class="container-fluid">
         <div class="row">
           <div class="col-sm-12">
-              <h3>Courses processed by this job</h3>
+              <h4 class="mt-4">Courses processed by this job</h4>
           </div>
         </div>
         <div class="row">
@@ -53,7 +53,7 @@
                   </a>
                 </div>
                 <div class="col-sm-12">
-                    <table class="datatable table table-striped table-bordered dataTable no-footer" id="details_table">
+                    <table class="datatable table table-striped" id="details_table">
                         <thead>
                             <th>Canvas Course ID</th>
                             <th>SIS ID</th>

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -108,7 +108,7 @@
                     <br>
                     <p>You may select individual courses from the list below to customize your Canvas course site creation job.</p>
                 </div>
-                <table id="course-table" class="datatable table table-striped table-bordered dataTable no-footer">
+                <table id="course-table" class="datatable table table-striped">
                     <thead>
                         <tr>
                             <th></th>

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -61,8 +61,10 @@ def index(request):
     logger.debug(f'Retrieving jobs for school {school_key}.')
     jobs_for_school = table.query(**query_params)['Items']
 
-    # Update string timestamp to datetime.
-    [item.update(created_at=parse_datetime(item['created_at']))
+    # Add new key with datetime version of created_at (ISO8601) timestamp.
+    # This is done so we can display a human readable datetime to end user, 
+    # but sort table data using created_at (ISO8601) timestamp which DataTables support.
+    [item.update(created_at_datetime=parse_datetime(item['created_at']))
      for item in jobs_for_school]
 
     context = {

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -61,10 +61,8 @@ def index(request):
     logger.debug(f'Retrieving jobs for school {school_key}.')
     jobs_for_school = table.query(**query_params)['Items']
 
-    # Add new key with datetime version of created_at (ISO8601) timestamp.
-    # This is done so we can display a human readable datetime to end user, 
-    # but sort table data using created_at (ISO8601) timestamp which DataTables support.
-    [item.update(created_at_datetime=parse_datetime(item['created_at']))
+    # Update created_at (ISO8601) string timestamp to datetime.
+    [item.update(created_at=parse_datetime(item['created_at']))
      for item in jobs_for_school]
 
     context = {


### PR DESCRIPTION
- Fixed DataTable sorting on date time field on index view
- Some UI tweaks to better match other apps in CAAT (see screenshots below)
    - Updated table header text from h3 to h4 and added top spacing
    - Removed table borders
    - Fixed dismissable alert showing 2 x (close) buttons.


<img width="1172" alt="Screenshot 2023-06-12 at 12 51 21 PM" src="https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/108423994/c9340259-8f87-4a82-a951-a6d9647ac4a1">
<img width="1162" alt="Screenshot 2023-06-12 at 12 45 47 PM" src="https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/108423994/4f5eedfc-d145-4f2c-bddc-6623962d3328">
<img width="1172" alt="Screenshot 2023-06-12 at 12 48 26 PM" src="https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/108423994/32915037-b6a8-45ba-9bce-75df39da96aa">
<img width="1172" alt="Screenshot 2023-06-12 at 12 47 00 PM" src="https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/108423994/05ee0891-e23c-40ca-a7c1-193cfeca4a0f">