### PR TITLE
Bump django-coursemanager version to v0.5

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -27,7 +27,7 @@ django-canvas-lti-school-permissions @ git+ssh://git@github.com/Harvard-Universi
 
 django-harvardkey-cas @ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0
 
-django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@patricktonne/add-active-coursegrouops-and-departments-mv
+django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.5
 
 canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4
 


### PR DESCRIPTION
Cleanup from [TLT-4462](https://jira.huit.harvard.edu/browse/TLT-4462).