### PR TITLE
TLT-4478: allow single site creation in any sub-account

### DIFF
--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -112,6 +112,36 @@
                     </div>
                 </div>
 
+            <div class="col-sm-3 margin-bottom-md">
+            {% if departments %}
+                <label for="courseDepartment">Department
+                    <span class="required-field-marker">*</span>
+                </label>
+                <select id="courseDepartment" name="courseDepartment" class="form-select">
+                    {% for department in departments %}
+                        {% if selected_department_id and selected_department_id == department.id %}
+                            <option value="{{ department.id }}" selected>{{ department.name }}</option>
+                        {% else %}
+                            <option value="{{ department.id }}">{{ department.name }}</option>
+                        {% endif %}
+                    {% endfor %}
+                </select>
+            {% elif course_groups %}
+                <label for="courseCourseGroup">Course Group
+                    <span class="required-field-marker">*</span>
+                </label>
+                <select id="courseCourseGroup" name="courseCourseGroup" class="form-select">
+                    {% for course_group in course_groups %}
+                        {% if selected_course_group_id and selected_course_group_id == course_group.id %}
+                            <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
+                        {% else %}
+                            <option value="{{ course_group.id }}">{{ course_group.name }}</option>
+                        {% endif %}
+                    {% endfor %}
+                </select>
+            {% endif %}
+            </div>
+
                 <div class="col-sm-3 margin-bottom-md">
                     <label for="is_blueprint">Blueprint Course</label>
                     <div class="checkbox" style="margin-top: 0px">

--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -121,6 +121,8 @@
                     {% for department in departments %}
                         {% if selected_department_id and selected_department_id == department.id %}
                             <option value="{{ department.id }}" selected>{{ department.name }}</option>
+                        {% elif department.name == 'Informal Learning Experiences' %}
+                            <option value="{{ department.id }}" selected>{{ department.name }}</option>
                         {% else %}
                             <option value="{{ department.id }}">{{ department.name }}</option>
                         {% endif %}
@@ -133,6 +135,8 @@
                 <select id="courseCourseGroup" name="courseCourseGroup" class="form-select">
                     {% for course_group in course_groups %}
                         {% if selected_course_group_id and selected_course_group_id == course_group.id %}
+                            <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
+                        {% elif course_group.name == 'Informal Learning Experiences' %}
                             <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
                         {% else %}
                             <option value="{{ course_group.id }}">{{ course_group.name }}</option>

--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -50,7 +50,7 @@
                 <div class="col-sm-6 margin-bottom-md">
                     <label for="course-term">Term <span class="required-field-marker">*</span></label>
                     <div>
-                        <select id="course-term" name="course-term" class="form-control">
+                        <select id="course-term" name="course-term" class="form-select">
                             {% for term in terms %}
                             {{ term }}
                                 <option value="{{ term.id }}">{{ term.name }}</option>
@@ -63,7 +63,7 @@
                     <label for="course-code">New Course Code <span class="required-field-marker">*</span></label>
                     <div class="input-group" id="course-code-input-group">
                         <div class="col-sm-4 margin-bottom-md">
-                        <select id="course-code-type" name="course-code-type" class="form-control">
+                        <select id="course-code-type" name="course-code-type" class="form-select">
                             <option value="ILE">ILE</option>
                             <option value="SB">SB</option>
                             <option value="BLU" hidden>BLU</option>
@@ -74,7 +74,7 @@
                                class="form-control pull-right"
                                id="course-code"
                                name="course-code"
-                               minlength="3" 
+                               minlength="3"
                                maxlength="50"
                                required>
                             </div>
@@ -89,7 +89,7 @@
                            class="form-control"
                            id="course-title"
                            name="course-title"
-                           minlength="3" 
+                           minlength="3"
                            maxlength="50"
                            required>
                 </div>
@@ -103,7 +103,7 @@
                 <div class="col-sm-3 margin-bottom-md">
                     <label for="template-select">Template</label>
                     <div>
-                        <select id="template-select" name="template-select" class="form-control">
+                        <select id="template-select" name="template-select" class="form-select">
                             <option value="No template">No template</option>
                             {% for template in canvas_site_templates %}
                                 <option value="{{ template.canvas_course_id }}">{{ template.canvas_course_name }}</option>

--- a/canvas_site_creator/utils.py
+++ b/canvas_site_creator/utils.py
@@ -2,7 +2,8 @@ import json
 import logging
 
 from canvas_sdk import RequestContext
-from canvas_sdk.methods.content_migrations import  create_content_migration_courses
+from canvas_sdk.methods.content_migrations import \
+    create_content_migration_courses
 from canvas_sdk.methods.courses import create_new_course, update_course
 from canvas_sdk.methods.sections import create_course_section
 from coursemanager.models import CourseInstance
@@ -45,8 +46,10 @@ def create_canvas_course_and_section(data):
     is_blueprint = data['is_blueprint']
     template_id = data['template_id']
 
+    # The course may be associated with either a department or coursegroup (depending on the school)
+    department_or_course_group_id = course.department_id if course.department_id else course.course_group_id
     # If this is a blueprint course, create course at school level not in the ILE sub account
-    account_id = 'sis_account_id:%s' % (f'school:{course.school_id}' if is_blueprint else f'dept:{course.department_id}')
+    account_id = 'sis_account_id:%s' % (f'school:{course.school_id}' if is_blueprint else f'dept:{department_or_course_group_id}')
     # not using .get() default because we want to fall back on course_code
     # if short_title is an empty string
     course_code = course_instance.short_title.strip() or course.registrar_code

--- a/canvas_site_creator/views.py
+++ b/canvas_site_creator/views.py
@@ -61,8 +61,6 @@ def create_new_course(request):
         post_data = request.POST.dict()
 
         is_blueprint = True if post_data.get('is_blueprint') else False
-        # Associate blueprint courses with the schools ILE department
-        short_name = 'ILE' if post_data["course-code-type"] == 'BLU' else post_data["course-code-type"]
         selected_course_group_id = post_data.get("courseCourseGroup", None)
         selected_department_id = post_data.get("courseDepartment", None)
         term = Term.objects.get(term_id=post_data['course-term'])

--- a/canvas_site_creator/views.py
+++ b/canvas_site_creator/views.py
@@ -1,8 +1,8 @@
 import logging
 
 from canvas_api.helpers import accounts as canvas_api_accounts
-from coursemanager.models import (Course, CourseInstance, Department, School,
-                                  Term)
+from coursemanager.models import (Course, CourseGroup, CourseInstance,
+                                  Department, School, Term)
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -12,6 +12,8 @@ from django.views.decorators.http import require_http_methods
 from lti_school_permissions.decorators import lti_permission_required
 
 from common.utils import (get_canvas_site_templates_for_school,
+                          get_course_group_data_for_school,
+                          get_department_data_for_school,
                           get_term_data_for_school)
 
 from .utils import create_canvas_course_and_section
@@ -23,8 +25,12 @@ logger = logging.getLogger(__name__)
 @lti_permission_required(canvas_api_accounts.ACCOUNT_PERMISSION_MANAGE_COURSES)
 @require_http_methods(['GET', 'POST'])
 def create_new_course(request):
-    sis_account_id = request.LTI['custom_canvas_account_sis_id']
+    # Depending on the type of request (POST vs GET), these values may not be set.
+    # If they are not set, we will use the default values below.
+    selected_course_group_id = None
+    selected_department_id = None
 
+    sis_account_id = request.LTI['custom_canvas_account_sis_id']
     try:
         school_id = sis_account_id.split(':')[1]
         school = School.objects.get(school_id=school_id)
@@ -37,17 +43,38 @@ def create_new_course(request):
     canvas_site_templates = get_canvas_site_templates_for_school(school_id)
     terms, _current_term_id = get_term_data_for_school(sis_account_id)
 
+    course_groups = None
+    departments = None
+    if school_id == 'colgsas':
+        try:
+            course_groups = get_course_group_data_for_school(sis_account_id)
+        except Exception:
+            logger.exception(f"Failed to get course groups with sis_account_id {sis_account_id}")
+    else:
+        try:
+            departments = get_department_data_for_school(sis_account_id)
+        except Exception:
+            logger.exception(f"Failed to get departments with sis_account_id {sis_account_id}")
+
     if request.method == 'POST':
         # On POST, create new Course and CourseInstance records and then the course in Canvas
         post_data = request.POST.dict()
 
         is_blueprint = True if post_data.get('is_blueprint') else False
         # Associate blueprint courses with the schools ILE department
-        department_short_name = 'ILE' if post_data["course-code-type"] == 'BLU' else post_data["course-code-type"]
-        department = Department.objects.get(school=school_id, short_name=department_short_name)
+        short_name = 'ILE' if post_data["course-code-type"] == 'BLU' else post_data["course-code-type"]
+        selected_course_group_id = post_data.get("courseCourseGroup", None)
+        selected_department_id = post_data.get("courseDepartment", None)
         term = Term.objects.get(term_id=post_data['course-term'])
         course_code_type = post_data["course-code-type"]
         template_id = post_data['template-select'] if post_data['template-select'] != 'No template' else None
+
+        department = None
+        course_group = None
+        if selected_department_id:
+            department = Department.objects.get(department_id=selected_department_id)
+        else:
+            course_group = CourseGroup.objects.get(course_group_id=selected_course_group_id)
 
         logger.info(f'Creating Course and CourseInstance records from the posted site creator info.', extra=post_data)
 
@@ -56,7 +83,8 @@ def create_new_course(request):
                 registrar_code=f'{course_code_type}-{post_data["course-code"]}',
                 registrar_code_display=f'{course_code_type}-{post_data["course-code"]}',
                 school=school,
-                department=department
+                department=department,
+                course_group=course_group,
             )
         except IntegrityError:
             logger.error(f'The course code already exists. '
@@ -105,10 +133,14 @@ def create_new_course(request):
 
         return redirect('canvas_site_creator:create_new_course')
 
-    context = {'school_id': school_id,
-               'school_name': school.title_short,
-               'canvas_site_templates': canvas_site_templates,
-               'terms': terms,
-               'canvas_url': settings.CANVAS_URL}
+    context = {
+        'school_id': school_id,
+        'school_name': school.title_short,
+        'canvas_site_templates': canvas_site_templates,
+        'terms': terms,
+        'canvas_url': settings.CANVAS_URL,
+        'departments': departments,
+        'course_groups': course_groups,
+    }
 
     return render(request, 'canvas_site_creator/index.html', context)


### PR DESCRIPTION
This PR:
- Adds a dropdown to the tool's interface that allows users to select a department/coursegroup for the ILE/SB course to live in.
- Includes minor CSS updates (use `class="form-control"` instead of `class="form-select"` for all dropdowns to better indicate dropdown functionality).

Deployed and tested in QA.