### PR TITLE
Update `account_id` when creating course in COLGSAS sub-account

### DIFF
--- a/canvas_site_creator/utils.py
+++ b/canvas_site_creator/utils.py
@@ -47,9 +47,12 @@ def create_canvas_course_and_section(data):
     template_id = data['template_id']
 
     # The course may be associated with either a department or coursegroup (depending on the school)
-    department_or_course_group_id = course.department_id if course.department_id else course.course_group_id
+    if course.department_id:
+        account_endpoint = f'dept:{course.department_id}'
+    else:
+        account_endpoint = f'coursegroup:{course.course_group_id}'
     # If this is a blueprint course, create course at school level not in the ILE sub account
-    account_id = 'sis_account_id:%s' % (f'school:{course.school_id}' if is_blueprint else f'dept:{department_or_course_group_id}')
+    account_id = 'sis_account_id:%s' % (f'school:{course.school_id}' if is_blueprint else account_endpoint)
     # not using .get() default because we want to fall back on course_code
     # if short_title is an empty string
     course_code = course_instance.short_title.strip() or course.registrar_code

--- a/canvas_site_creator/utils.py
+++ b/canvas_site_creator/utils.py
@@ -46,11 +46,13 @@ def create_canvas_course_and_section(data):
     is_blueprint = data['is_blueprint']
     template_id = data['template_id']
 
-    # The course may be associated with either a department or coursegroup (depending on the school)
-    if course.department_id:
-        account_endpoint = f'dept:{course.department_id}'
-    else:
+    # For FAS (colgsas) courses, we want to prefer the course_group, and for all other schools we want to
+    # ignore course_groups altogether.
+    if course.school_id == 'colgsas' and course.course_group_id:
         account_endpoint = f'coursegroup:{course.course_group_id}'
+    else:
+        account_endpoint = f'dept:{course.department_id}'
+
     # If this is a blueprint course, create course at school level not in the ILE sub account
     account_id = 'sis_account_id:%s' % (f'school:{course.school_id}' if is_blueprint else account_endpoint)
     # not using .get() default because we want to fall back on course_code


### PR DESCRIPTION
Update that came out of meeting with client services (see [Google doc](https://docs.google.com/document/d/1-qu6r8VD7GEwnC7WdGU7fIwgRQ3KCXIYnET4C2qh8zk/edit)).

This update resolves an issue where calls to create a course in the COLGSAS sub-account failed because the API endpoint was configured to search against sub-account path `dept:{account_id}` instead of (the correct) `coursegroup:{account_id}`.