### PR TITLE
Ensure ILE/SB sub-accounts appear in single site creator

### DIFF
--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -142,13 +142,13 @@ def new_job(request):
     # Only display the Course Groups dropdown if the tool is launched in the COLGSAS sub-account
     if school_id == 'colgsas':
         try:
-            course_groups = get_course_group_data_for_school(sis_account_id, exclude_ile_sb=True)
+            course_groups = get_course_group_data_for_school(sis_account_id, include_ile_sb=False)
         except Exception:
             logger.exception(f"Failed to get course groups with sis_account_id {sis_account_id}")
     # For all other schools, display just the Departments dropdown
     else:
         try:
-            departments = get_department_data_for_school(sis_account_id, exclude_ile_sb=True)
+            departments = get_department_data_for_school(sis_account_id, include_ile_sb=False)
         except Exception:
             logger.exception(f"Failed to get departments with sis_account_id {sis_account_id}")
 

--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -135,11 +135,11 @@
                 <select id="courseCourseGroup" name="courseCourseGroup" class="form-select">
                     {% for course_group in course_groups %}
                         {% if selected_course_group_id and selected_course_group_id == course_group.id %}
-                            <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
+                            <option value="{{ course_group.id }} {{ course_group.name }}" selected>{{ course_group.name }}</option>
                         {% elif course_group.name == 'Informal Learning Experiences' %}
-                            <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
+                            <option value="{{ course_group.id }} {{ course_group.name }}" selected>{{ course_group.name }}</option>
                         {% else %}
-                            <option value="{{ course_group.id }}">{{ course_group.name }}</option>
+                            <option value="{{ course_group.id }} {{ course_group.name }}">{{ course_group.name }}</option>
                         {% endif %}
                     {% endfor %}
                 </select>

--- a/canvas_site_creator/views.py
+++ b/canvas_site_creator/views.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def create_new_course(request):
     # Depending on the type of request (POST vs GET), these values may not be set.
     # If they are not set, we will use the default values below.
-    selected_course_group_id = None
+    selected_course_group_data = None
     selected_department_id = None
 
     sis_account_id = request.LTI['custom_canvas_account_sis_id']
@@ -61,7 +61,7 @@ def create_new_course(request):
         post_data = request.POST.dict()
 
         is_blueprint = True if post_data.get('is_blueprint') else False
-        selected_course_group_id = post_data.get("courseCourseGroup", None)
+        selected_course_group_data = post_data.get("courseCourseGroup", None)
         selected_department_id = post_data.get("courseDepartment", None)
         term = Term.objects.get(term_id=post_data['course-term'])
         course_code_type = post_data["course-code-type"]
@@ -72,7 +72,14 @@ def create_new_course(request):
         if selected_department_id:
             department = Department.objects.get(department_id=selected_department_id)
         else:
-            course_group = CourseGroup.objects.get(course_group_id=selected_course_group_id)
+            # If the course group is "Informal Learning Experiences" or "Sandbox Courses", we need
+            # to search against the Department schema as ILE/SB sub-accounts are designated
+            # as departments.
+            course_group_id, name = selected_course_group_data.split(' ', 1)
+            if name.lower() == 'informal learning experiences' or name.lower() == 'sandbox courses':
+                department = Department.objects.get(department_id=course_group_id)
+            else:
+                course_group = CourseGroup.objects.get(course_group_id=course_group_id)
 
         logger.info(f'Creating Course and CourseInstance records from the posted site creator info.', extra=post_data)
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -101,12 +101,12 @@ def _get_department_data_for_school_excluding_ile_sb(school_sis_account_id: str)
     return base_query.exclude(Q(short_name='ILE') | Q(short_name='SB'))
 
 
-def get_department_data_for_school(school_sis_account_id: str, exclude_ile_sb=False) -> list:
+def get_department_data_for_school(school_sis_account_id: str, include_ile_sb=True) -> list:
     """
     Returns all departments for a given school. Either includes or excludes ILE and SB
-    departments, depending on the value of the exclude_ile_sb parameter.
+    departments, depending on the value of the include_ile_sb parameter.
     """
-    if exclude_ile_sb:
+    if not include_ile_sb:
         query_set = _get_department_data_for_school_excluding_ile_sb(school_sis_account_id)
     else:
         query_set = _get_department_data_for_school(school_sis_account_id)
@@ -138,14 +138,14 @@ def _get_ile_sb_course_group_data_for_school(school_sis_account_id: str) -> Quer
     )
 
 
-def get_course_group_data_for_school(school_sis_account_id: str, exclude_ile_sb=False) -> list:
+def get_course_group_data_for_school(school_sis_account_id: str, include_ile_sb=True) -> list:
     """
     Returns a list of course groups for a given school. Either includes or excludes
-    ILE and SB course groups, depending on the value of the exclude_ile_sb parameter.
+    ILE and SB course groups, depending on the value of the include_ile_sb parameter.
     """
     query_set = _get_course_group_data_for_school(school_sis_account_id)
 
-    if not exclude_ile_sb:
+    if include_ile_sb:
         ile_sb_query = _get_ile_sb_course_group_data_for_school(school_sis_account_id)
         query_set = query_set | ile_sb_query
 


### PR DESCRIPTION
This PR makes a few updates to ensure that ILE/SB sub-accounts appear in the single site creator dropdown. Conversely, ILE/SB sub-accounts have been removed from the bulk site creator dropdown.

This is accomplished by adding in an optional flag, `include_ile_sb`, to the `get_course_group_data_for_school` and `get_department_data_for_school` functions. This defaults to `True`, but can optionally be made `False` to prevent ILE/SB sub-accounts from returning in the results list.

Deployed to QA.