### PR TITLE
Use the active_and_deleted model manager in Site Deletion tool

### DIFF
--- a/canvas_site_deletion/views.py
+++ b/canvas_site_deletion/views.py
@@ -22,6 +22,7 @@ SDK_SETTINGS = settings.CANVAS_SDK_SETTINGS
 SDK_SETTINGS.pop('session_inactivity_expiration_time_secs', None)
 SDK_CONTEXT = RequestContext(**SDK_SETTINGS)
 
+
 @login_required
 @lti_role_required(const.ADMINISTRATOR)
 @lti_permission_required(settings.PERMISSION_CANVAS_SITE_DELETION)
@@ -45,7 +46,7 @@ def lookup(request):
 
     if course_search_term.isnumeric():
         try:
-            ci = CourseInstance.objects.get(course_instance_id=course_search_term)
+            ci = CourseInstance.active_and_deleted.get(course_instance_id=course_search_term)
             context['course_instance'] = ci
 
             if ci.canvas_course_id:
@@ -87,8 +88,9 @@ def lookup(request):
 @lti_permission_required(settings.PERMISSION_CANVAS_SITE_DELETION)
 @require_http_methods(['GET', 'POST'])
 def delete(request, pk):
+    canvas_course_id = None
     try:
-        ci = CourseInstance.objects.get(course_instance_id=pk)
+        ci = CourseInstance.active_and_deleted.get(course_instance_id=pk)
         canvas_course_id = ci.canvas_course_id
         ts = int(time.time())
 
@@ -149,7 +151,6 @@ def delete(request, pk):
 
         except Exception as e:
             logger.error(f'Error removing associated site_map/course_site from {pk}, error: {e}')
-
 
     except Exception as e:
         logger.exception('Could not cleanup  the course instance for Canvas '


### PR DESCRIPTION
Will get all course instance records vs the filtering of deleted=1 defined in the default objects get_queryset

When a course instance has the deleted flag as true, currently the tool will not be able to query to find and delete the entered course instance ID. 