### PR TITLE
TLT-4499: Add a default option for the dropdown

### DIFF
--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -123,7 +123,7 @@
                     {% for department in departments %}
                         {% if selected_department_id and selected_department_id == department.id %}
                             <option value="{{ department.id }}" selected>{{ department.name }}</option>
-                        {% elif department.name == 'Informal Learning Experiences' %}
+                        {% elif department.id == -1 %}
                             <option value="{{ department.id }}" selected>{{ department.name }}</option>
                         {% else %}
                             <option value="{{ department.id }}">{{ department.name }}</option>
@@ -138,7 +138,7 @@
                     {% for course_group in course_groups %}
                         {% if selected_course_group_id and selected_course_group_id == course_group.id %}
                             <option value="{{ course_group.id }} {{ course_group.name }}" selected>{{ course_group.name }}</option>
-                        {% elif course_group.name == 'Informal Learning Experiences' %}
+                        {% elif course_group.id == -1 %}
                             <option value="{{ course_group.id }} {{ course_group.name }}" selected>{{ course_group.name }}</option>
                         {% else %}
                             <option value="{{ course_group.id }} {{ course_group.name }}">{{ course_group.name }}</option>

--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -119,11 +119,10 @@
                 <label for="courseDepartment">Department
                     <span class="required-field-marker">*</span>
                 </label>
-                <select id="courseDepartment" name="courseDepartment" class="form-select">
+                <select id="courseDepartment" name="courseDepartment" class="form-select" required>
+                    <option value="">Select a department</option>
                     {% for department in departments %}
                         {% if selected_department_id and selected_department_id == department.id %}
-                            <option value="{{ department.id }}" selected>{{ department.name }}</option>
-                        {% elif department.id == -1 %}
                             <option value="{{ department.id }}" selected>{{ department.name }}</option>
                         {% else %}
                             <option value="{{ department.id }}">{{ department.name }}</option>
@@ -134,11 +133,10 @@
                 <label for="courseCourseGroup">Course Group
                     <span class="required-field-marker">*</span>
                 </label>
-                <select id="courseCourseGroup" name="courseCourseGroup" class="form-select">
+                <select id="courseCourseGroup" name="courseCourseGroup" class="form-select" required>
+                    <option value="">Select a course group</option>
                     {% for course_group in course_groups %}
                         {% if selected_course_group_id and selected_course_group_id == course_group.id %}
-                            <option value="{{ course_group.id }} {{ course_group.name }}" selected>{{ course_group.name }}</option>
-                        {% elif course_group.id == -1 %}
                             <option value="{{ course_group.id }} {{ course_group.name }}" selected>{{ course_group.name }}</option>
                         {% else %}
                             <option value="{{ course_group.id }} {{ course_group.name }}">{{ course_group.name }}</option>

--- a/canvas_site_creator/views.py
+++ b/canvas_site_creator/views.py
@@ -56,12 +56,6 @@ def create_new_course(request):
         except Exception:
             logger.exception(f"Failed to get departments with sis_account_id {sis_account_id}")
 
-    # Append a default option for display in the UI
-    if departments:
-        departments.append({'id': -1, 'name': 'Select a department'})
-    else:
-        course_groups.append({'id': -1, 'name': 'Select a course group'})
-
     if request.method == 'POST':
         # On POST, create new Course and CourseInstance records and then the course in Canvas
         post_data = request.POST.dict()
@@ -76,23 +70,9 @@ def create_new_course(request):
         department = None
         course_group = None
         if selected_department_id:
-            if selected_department_id == '-1':
-                # User did not select a department from the dropdown
-                messages.add_message(request,
-                        messages.ERROR,
-                        'Please select a department from the dropdown.')
-                return redirect('canvas_site_creator:create_new_course')
-
             department = Department.objects.get(department_id=selected_department_id)
-        else:
+        elif selected_course_group_data:
             course_group_id, name = selected_course_group_data.split(' ', 1)
-            if course_group_id == '-1':
-                # User did not select a course group from the dropdown
-                messages.add_message(request,
-                        messages.ERROR,
-                        'Please select a course group from the dropdown.')
-                return redirect('canvas_site_creator:create_new_course')
-
             # If the course group is "Informal Learning Experiences" or "Sandbox Courses", we need
             # to search against the Department schema as ILE/SB sub-accounts are designated
             # as departments.
@@ -100,6 +80,12 @@ def create_new_course(request):
                 department = Department.objects.get(department_id=course_group_id)
             else:
                 course_group = CourseGroup.objects.get(course_group_id=course_group_id)
+        else:
+            logger.warning(f"ILE/SB site creation data missing department/course group ID. POST data={post_data}")
+            messages.add_message(request,
+                    messages.ERROR,
+                    'Unexpected error processing submission. Please try again.')
+            return redirect('canvas_site_creator:create_new_course')
 
         logger.info(f'Creating Course and CourseInstance records from the posted site creator info.', extra=post_data)
 


### PR DESCRIPTION
Updates in this PR:
- added a default option on page load for the course group/department dropdown in the single site creator (`Select a department` or `Select a course group`, depending on the sub-account).
- the tool will raise an error if the user fails to select a non-default option for the dropdown, providing the user with a message in the UI.

Deployed to dev.