### PR TITLE
Task/tlt 4555/idkjay/find courses renders default

### DIFF
--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -35,15 +35,17 @@
                                 </label>
                                 <br>
                                 <select id="courseDepartment" name="courseDepartment" class="form-select">
-                                    {% if not selected_department_id or selected_department_id == '0' %}
-                                        <option value="0" selected>All Departments</option>
-                                    {% else %}
+                                    <!-- Always show the default option first -->
                                         <option value="0">All Departments</option>
+                                    
+                                    <!-- Display the selected department if there's one selected -->
+                                    {% if selected_department_id and selected_department_id != '0' %}
+                                        <option value="{{ selected_department_id }}" selected>{{ selected_department_name }}</option>
                                     {% endif %}
+
                                     {% for department in departments %}
-                                        {% if selected_department_id and selected_department_id == department.id %}
-                                            <option value="{{ department.id }}" selected>{{ department.name }}</option>
-                                        {% else %}
+                                        <!-- Skip the option if it's the selected department -->
+                                        {% if not selected_department_id == department.id %}
                                             <option value="{{ department.id }}">{{ department.name }}</option>
                                         {% endif %}
                                     {% endfor %}

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -36,7 +36,7 @@
                                 <br>
                                 <select id="courseDepartment" name="courseDepartment" class="form-select">
                                     <!-- Always show the default option first -->
-                                        <option value="0">All Departments</option>
+                                    <option value="0">All Departments</option>
                                     
                                     <!-- Display the selected department if there's one selected -->
                                     {% if selected_department_id and selected_department_id != '0' %}
@@ -57,15 +57,17 @@
                                 </label>
                                 <br>
                                 <select id="courseCourseGroup" name="courseCourseGroup" class="form-select">
-                                    {% if not selected_course_group_id or selected_course_group_id == '0' %}
-                                        <option value="0" selected>All Course Groups</option>
-                                    {% else %}
-                                        <option value="0">All Course Groups</option>
+                                    <!-- Always show the default option first -->
+                                    <option value="0">All Course Groups</option>
+
+                                    <!-- Display the selected course group if there's one selected -->
+                                    {% if selected_course_group_id and selected_course_group_id != '0' %}
+                                        <option value="{{ selected_course_group_id }}" selected>{{ selected_course_group_name }}</option>
                                     {% endif %}
+
                                     {% for course_group in course_groups %}
-                                        {% if selected_course_group_id and selected_course_group_id == course_group.id %}
-                                            <option value="{{ course_group.id }}" selected>{{ course_group.name }}</option>
-                                        {% else %}
+                                        <!-- Skip the option if it's the selected course group -->
+                                        {% if not selected_course_group_id == course_group.id %}
                                             <option value="{{ course_group.id }}">{{ course_group.name }}</option>
                                         {% endif %}
                                     {% endfor %}

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -222,6 +222,8 @@ def new_job(request):
         'selected_term_id': selected_term_id,
         'selected_course_group_id': selected_course_group_id,
         'selected_department_id': selected_department_id,
+        'selected_department_name': selected_department_name,
+        'selected_course_group_name': selected_course_group_name,
         'canvas_url': settings.CANVAS_URL,
     }
     return render(request, "bulk_site_creator/new_job.html", context=context)

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -137,7 +137,9 @@ def new_job(request):
     course_groups = []
     selected_term_id = None
     selected_course_group_id = None
+    selected_course_group_name = None
     selected_department_id = None
+    selected_department_name = None
 
     # Only display the Course Groups dropdown if the tool is launched in the COLGSAS sub-account
     if school_id == 'colgsas':

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -168,6 +168,15 @@ def new_job(request):
             if selected_department_id and selected_department_id != '0':
                 selected_department_name = Department.objects.get(department_id=selected_department_id).name
 
+        # Temporarily remove the selected_department_id or selected_course_group_id from the departments or course_groups list if it exists
+        if selected_department_id:
+            selected_department_id = int(selected_department_id)  
+            departments = [dept for dept in departments if dept['id'] != selected_department_id]
+
+        if selected_course_group_id:
+            selected_course_group_id  = int(selected_course_group_id)    
+            course_groups = [course_group for course_group in course_groups if course_group['id'] != selected_course_group_id]
+
         logging_dept_cg_text = f' and course group ID {selected_course_group_id}' if selected_course_group_id \
             else f' and department ID {selected_department_id}' if selected_department_id \
             else ' and no selected department or course group.'

--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -158,6 +158,14 @@ def new_job(request):
         selected_course_group_id = request.POST.get("courseCourseGroup", None)
         selected_department_id = request.POST.get("courseDepartment", None)
 
+        # Retrieve Course Group or Department name 
+        if school_id == 'colgsas':
+            if selected_course_group_id and selected_course_group_id != '0':
+                selected_course_group_name = CourseGroup.objects.get(course_group_id=selected_course_group_id).name
+        else:
+            if selected_department_id and selected_department_id != '0':
+                selected_department_name = Department.objects.get(department_id=selected_department_id).name
+
         logging_dept_cg_text = f' and course group ID {selected_course_group_id}' if selected_course_group_id \
             else f' and department ID {selected_department_id}' if selected_department_id \
             else ' and no selected department or course group.'


### PR DESCRIPTION
- Refactored logic to allow for the selected department or course group to show up as the visible select option after the Find Courses button is clicked
- Added logic to `views.py` to help facilitate the rendering of the `departments` or `course_groups` list and to retrieve the name of the selected department or course group from the Coursemanager database.

![tlt4555](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/49657701/91420b67-6cf4-4776-9f65-0ed24efee6f2)

Note:
- Deployed on `DEV`