### PR TITLE
TLT-4564: Update error message when deleting secondarily-crosslisted course

### DIFF
--- a/canvas_site_deletion/views.py
+++ b/canvas_site_deletion/views.py
@@ -61,7 +61,7 @@ def lookup(request):
 
                 if ci.course_instance_id != int(cc['sis_course_id']):
                     logger.error(f'Course instance ID ({course_search_term}) does not match Canvas course SIS ID ({cc["sis_course_id"]}) for Canvas course {ci.canvas_course_id}. Aborting.')
-                    messages.error(request, f'Course instance ID ({course_search_term}) does not match Canvas course SIS ID ({cc["sis_course_id"]}) for Canvas course {ci.canvas_course_id}. Aborting.')
+                    messages.error(request, f'Cannot delete course {course_search_term} as it is involved in a crosslisting pair. To proceed, undo the existing crosslisting and retry the deletion.')
                     context['abort'] = True
             else:
                 logger.error(f'Course instance {ci.course_instance_id} does not have a Canvas course ID set.')

--- a/canvas_site_deletion/views.py
+++ b/canvas_site_deletion/views.py
@@ -61,7 +61,7 @@ def lookup(request):
 
                 if ci.course_instance_id != int(cc['sis_course_id']):
                     logger.error(f'Course instance ID ({course_search_term}) does not match Canvas course SIS ID ({cc["sis_course_id"]}) for Canvas course {ci.canvas_course_id}. Aborting.')
-                    messages.error(request, f'Cannot delete course {course_search_term} as it is involved in a crosslisting pair. To proceed, undo the existing crosslisting and retry the deletion.')
+                    messages.error(request, f'Cannot delete course {course_search_term} as it is secondarily-crosslisted with another course. To proceed, undo the existing crosslisting and retry the deletion.')
                     context['abort'] = True
             else:
                 logger.error(f'Course instance {ci.course_instance_id} does not have a Canvas course ID set.')


### PR DESCRIPTION
Using the Site Deletion tool, attempting to delete a secondarily-crosslisted course would provide the following message, creating confusion for users:

`Course instance ID ({course_search_term}) does not match Canvas course SIS ID ({cc["sis_course_id"]}) for Canvas course {ci.canvas_course_id}. Aborting.`

This message has been updated to better highlight why the deletion cannot proceed and steps needed to resolve the issue:

`Cannot delete course {course_search_term} as it is secondarily-crosslisted with another course. To proceed, undo the existing crosslisting and retry the deletion.`

### Testing

- Identified a secondarily-crosslisted course via the crosslisting tool
- Attempted to delete the course using the Site Deletion tool and was provided the new message

### Notes

- The primary course within a crosslisting _is_ able to be deleted. This functionality is unchanged from before.

