### PR TITLE
task/tlt-4555/idkjay/find_courses_renders_default

### DIFF
--- a/bulk_site_creator/views.py
+++ b/bulk_site_creator/views.py
@@ -177,9 +177,11 @@ def new_job(request):
 
         # Filter potential_course_sites_query by course group.
         if selected_course_group_id and selected_course_group_id != '0':
+            selected_course_group_id = int(selected_course_group_id)
             potential_course_sites_query = potential_course_sites_query.filter(course__course_group=selected_course_group_id)
         # Filter potential_course_sites_query by department.
         elif selected_department_id and selected_department_id != '0':
+            selected_department_id = int(selected_department_id)
             potential_course_sites_query = potential_course_sites_query.filter(course__department=selected_department_id)
 
     # TODO maybe better to use template tag unless used elsewhere?
@@ -252,10 +254,12 @@ def create_bulk_job(request: HttpRequest) -> Optional[JsonResponse]:
         # The value of 0 is for the default option of no selected Department/Course Group
         if school_id == 'colgsas':
             if course_group_id and course_group_id != '0':
+                course_group_id = int(course_group_id)
                 course_group_name = CourseGroup.objects.get(course_group_id=course_group_id).name
                 potential_course_sites_query = potential_course_sites_query.filter(course__course_group=course_group_id)
         else:
             if department_id and department_id != '0':
+                department_id = int(department_id)
                 department_name = Department.objects.get(department_id=department_id).name
                 potential_course_sites_query = potential_course_sites_query.filter(course__department=department_id)
 


### PR DESCRIPTION
- Fixed the type mismatch in `views.py` for the handling of `selected_course_group_id`, and `selected_department_id` when you filter `potential_course_sites_query` by course group or department and the handling of `course_group_id` and `department_id` which runs the same logic as the above case but when the `school_id == 'colgsas'`
- Deployed on `DEV`

![image](https://github-production-user-asset-6210df.s3.amazonaws.com/49657701/286368045-91420b67-6cf4-4776-9f65-0ed24efee6f2.gif?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240117%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240117T171247Z&X-Amz-Expires=300&X-Amz-Signature=c985d9c9f6eb74d45585976a25d022dc1faa9442c0ded476f14666e61a1c4581&X-Amz-SignedHeaders=host&actor_id=49657701&key_id=0&repo_id=43321944)

- Chris's Original PR comment
![image](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/49657701/3e9cd758-9cfd-4dd0-af57-c8747b10d8aa)