### PR TITLE
TLT-4562: Add subtitle column to course dropdown

### DIFF
--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -116,6 +116,7 @@
                             <th>SIS ID</th>
                             <th>Course Code</th>
                             <th>Course Title</th>
+                            <th>Course Subtitle</th>
                             <th>Course Section</th>
                         </tr>
                     </thead>
@@ -126,6 +127,7 @@
                             <td>{{ potential_course_site.course_instance_id }}</td>
                             <td>{{ potential_course_site.short_title }}</td>
                             <td>{{ potential_course_site.title }}</td>
+                            <td>{{ potential_course_site.sub_title }}</td>
                             <td>{{ potential_course_site.section }}</td>
                         </tr>
                     {% endfor %}
@@ -200,7 +202,7 @@
             function updateButtonText() {
                 const create_btn_text = (table.rows({ selected: true }).any()) ? "Create Selected" : "Create All";
                 $("#bsc-create-btn").html(`${create_btn_text}`);
-            };  
+            };
 
             $("#course-table-body").on( "click", function() {
                 // Update button after n seconds to get accurate if row selected value
@@ -212,11 +214,11 @@
             let courseTable = $('#course-table').DataTable();
             let totalRows = table.rows().count();
             let totalRowsChecked = 0;
-            
+
             $('.selectAll').on('change', function() {
                 let checked = $(this).prop('checked');
                 courseTable.rows().select(checked);
-            
+
                 // Get the number of selected rows throughout whole table
                 totalRowsChecked = courseTable.rows({ selected: true }).count();
 
@@ -225,18 +227,18 @@
                     let cell = this.node();
                     $(cell).find('input[type="checkbox"][name="chkbx"]').prop('checked', checked);
                 });
-            
+
                 // Check if totalRowsChecked is less than totalRows and update "selectAll" checkbox accordingly
                 if (totalRowsChecked < totalRows) {
                     $(this).prop('checked', false);
                 };
                 updateButtonText()
             });
-            
+
             // Handle individual row checkbox changes
             courseTable.on('select deselect', function(e, dt, type, indexes) {
                 let selectedCount = courseTable.rows({ selected: true }).count();
-                
+
                 // Update the "selectAll" checkbox based on selectedCount
                 $('.selectAll').prop('checked', selectedCount === totalRows);
             });


### PR DESCRIPTION
Adds a `Course Subtitle` column to the bulk site creator course list.

Most sub-accounts appear to populate the `sub_title` attribute (though not all). See below for examples.

Deployed to QA.

## Examples throughout various sub-accounts

### How things look when a sub-account _does_ populate the `sub_title` attribute
HMS:
![Screen Shot 2024-01-25 at 2 42 41 PM](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/43320443/c3a247d5-8e84-4414-988b-128eca5166d4)

Harvard College/GSAS:
![Screen Shot 2024-01-26 at 12 44 29 PM](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/43320443/4d3a7ff7-bed1-422e-80d4-7c2aee0bbcbf)

HSPH:
![Screen Shot 2024-01-26 at 10 35 08 AM](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/43320443/fe7634fe-9a1c-48e9-a34e-3550b8286e0f)

HKS:
![Screen Shot 2024-01-26 at 10 34 35 AM](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/43320443/ece61263-75c9-42e4-a0cc-6ff670d2cbce)

### How things look when a sub-account _does not_ populate the `sub_title` attribute

DCE:
![Screen Shot 2024-01-26 at 10 34 53 AM](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/43320443/28d12cd8-ea39-4ca6-9269-65a7a3a75b84)

HLS:
![Screen Shot 2024-01-26 at 10 34 44 AM](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/43320443/97ef3026-20b8-47e3-b775-0305586a36d2)


