### PR TITLE
TLT-4571: increase character limits for course-title and course-short-title

### DIFF
--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -55,7 +55,7 @@
                            id="course-title"
                            name="course-title"
                            minlength="3"
-                           maxlength="50"
+                           maxlength="500"
                            required>
                 </div>
                 <div class="col-sm-6 mt-3 mb-2 fw-bold">
@@ -63,7 +63,8 @@
                     <input type="text"
                            class="form-control"
                            id="course-short-title"
-                           name="course-short-title">
+                           name="course-short-title"
+                           maxlength="200">
                 </div>
                 <div class="col-sm-3 mt-3 mb-2 fw-bold">
                     <label for="template-select">Template</label>


### PR DESCRIPTION
Increases the `maxlength` attribute for the `course-title` field to 500 and adds a `maxlength` value of 200 for the `course-short-title` field in the ILE/SB Site Creator. These numbers match the max length of the corresponding database columns.