### PR TITLE
Task/idkjay/tlt 4584/add loading message and spinner

### DIFF
--- a/bulk_course_settings/templates/bulk_course_settings/create_new_job.html
+++ b/bulk_course_settings/templates/bulk_course_settings/create_new_job.html
@@ -31,10 +31,41 @@
             <input type="hidden" name="school_id" value="{{ school_id }}" />
             <div class="row" style="padding-top: 1em">
                 <div class="col-sm-12">
-                    <input type="submit" class="btn btn-primary pull-right" value="Submit" />
+                    <button type="button" ng-cloak class="btn btn-primary" id="bsc-create-btn" data-bs-toggle="modal" data-bs-target="#confirmCreate">Submit</button>
                     <a href="{% url 'bulk_course_settings:job_list' %}" class="btn btn-default">Cancel</a>
                 </div>
             </div>
         </form>
-    </div>
+        
+        <!-- Confirmation Modal -->
+        <div class="modal fade" id="confirmCreate" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="staticBackdropLabel">Confirm Bulk Course Settings Job Creation</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <span id="modal-body-text"></span>
+                        You are about to create a Bulk Course Settings job. It may take up to a minute to process. <br>
+                        Are you sure you would like to proceed? You can revert your changes afterwards if necessary.
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-primary" id="confirmCreateButton">Yes</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            document.getElementById('confirmCreateButton').addEventListener('click', function () {
+                // Disable the "Yes" button and display loading spinner
+                this.disabled = true;
+                this.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Loading...';
+                
+                // Submit the form
+                document.querySelector('form').submit();
+            });
+        </script>
 {% endblock content %}

--- a/bulk_course_settings/templates/bulk_course_settings/create_new_job.html
+++ b/bulk_course_settings/templates/bulk_course_settings/create_new_job.html
@@ -48,7 +48,7 @@
                     <div class="modal-body">
                         <span id="modal-body-text"></span>
                         You are about to create a Bulk Course Settings job. It may take up to a minute to process. <br>
-                        Are you sure you would like to proceed? You can revert your changes afterwards if necessary.
+                        Are you sure you would like to proceed?
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>

--- a/bulk_course_settings/templates/bulk_course_settings/job_list.html
+++ b/bulk_course_settings/templates/bulk_course_settings/job_list.html
@@ -35,9 +35,9 @@
                     <tr>
                         <td><a href="{% url 'bulk_course_settings:job_detail' job_id=job.id %}"> {{ job.id }} </a> </td>
                         <td>{{ job.created_at }}</td>
-                        {% if job.term_name %}}
+                        {% if job.term_name %}
                             <td>{{ job.term_name }}</td>
-                        {% else %}}
+                        {% else %}
                             <td>{{ job.get_term_name }}</td>
                         {% endif %}
                         <td>{{ job.get_setting_to_be_modified_display }}</td>

--- a/bulk_course_settings/views.py
+++ b/bulk_course_settings/views.py
@@ -55,7 +55,7 @@ class BulkSettingsCreateView(LTIPermissionRequiredMixin, LoginRequiredMixin, Suc
 	form_class = CreateBulkSettingsForm
 	template_name = 'bulk_course_settings/create_new_job.html'
 	model = Job
-	success_message = 'Job was created successfully'
+	success_message = 'Job was created successfully.'
 	permission = 'bulk_course_settings'
 
 	def get_context_data(self, **kwargs):
@@ -83,13 +83,13 @@ class BulkSettingsCreateView(LTIPermissionRequiredMixin, LoginRequiredMixin, Suc
 		if not all((audit_user_id, account_sis_id)):
 			raise DRFValidationError(
 				'Invalid LTI session: custom_canvas_user_login_id and '
-				'custom_canvas_account_sis_id required')
+				'custom_canvas_account_sis_id required.')
 
 		sis_account_id = f'sis_account_id:{account_sis_id}'
 		meta_term_id = f'sis_term_id:{meta_term_id}'
 
 		if not all((sis_account_id, meta_term_id)):
-			raise DRFValidationError('Both account and term are required')
+			raise DRFValidationError('Both account and term are required.')
 
 		job = form.instance
 		job.save()
@@ -150,8 +150,8 @@ class BulkSettingsRevertView(LTIPermissionRequiredMixin, LoginRequiredMixin, Vie
 	def get(self, request, school_id, job_id):
 		job_has_already_been_reverted = Job.objects.filter(related_job_id=job_id)
 		if job_has_already_been_reverted:
-			logger.info('Job {} has already been reverted'.format(job_id))
-			messages.error(request, 'Job has already been reverted')
+			logger.info('Job {} has already been reverted.'.format(job_id))
+			messages.error(request, 'Job has already been reverted.')
 		else:
 			related_bulk_job = Job.objects.get(id=job_id)
 			setting_to_be_modified = related_bulk_job.setting_to_be_modified
@@ -183,7 +183,7 @@ class BulkSettingsRevertView(LTIPermissionRequiredMixin, LoginRequiredMixin, Vie
 			utils.send_job_to_queueing_lambda(related_bulk_job.id, job_details_list, setting_to_be_modified, desired_setting)
 
 			# logger.info('Queued reversion job {} for related job {}'.format(new_bulk_job.id, related_bulk_job.id))
-			messages.success(request, 'Reversion job was created successfully')
+			messages.success(request, 'Reversion job was created successfully.')
 
 		url = reverse('bulk_course_settings:job_list')
 		if 'resource_link_id' not in url:


### PR DESCRIPTION
- Added loading message and spinner 
- Message will ask for confirmation on creation of bulk course settings job
- Spinner will keep spinning until job is successfully submitted 

Note
- Deployed in `DEV`
- [Test Account here](https://harvard.beta.instructure.com/accounts/39/)

![tlt4584v1](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/49657701/ae0f3c06-4423-46dd-8dae-ef335ef73359)

Questions:
1. How does the team feel about having the loading message pop up like that? Would you prefer the spinner to show up immediately on the Submit button instead of having to go through a confirmation?

2. If you like having the loading message pop up, any thoughts on the content of the message itself? Is the message too long or is part of it unnecessary?
![image](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/49657701/29eb85b4-4bd9-427f-9736-c0030e72903f)

3. And should the order of the Cancel/Yes buttons on the loading message line up with the order of the Submit/Cancel buttons on the previous page? Like such:
![image](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/49657701/2beded5d-0c60-477e-9c61-62e8f6b7c272)

