### PR TITLE
Task/haydn9000/tlt 4578/handle term that does not exist

### DIFF
--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -27,9 +27,7 @@ django-canvas-lti-school-permissions @ git+ssh://git@github.com/Harvard-Universi
 
 django-harvardkey-cas @ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0
 
-# django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.7
-# TODO: Remove line bellow and uncomment line above once django-coursemanager has been merged and tagged with v0.7
-django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@task/haydn9000/tlt-4585/remove-CanvasCourseInstance-and-CoursePerson-models
+django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.7
 
 canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4.3
 

--- a/canvas_account_admin_tools/requirements/base.txt
+++ b/canvas_account_admin_tools/requirements/base.txt
@@ -27,7 +27,9 @@ django-canvas-lti-school-permissions @ git+ssh://git@github.com/Harvard-Universi
 
 django-harvardkey-cas @ git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v3.0
 
-django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.5
+# django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.7
+# TODO: Remove line bellow and uncomment line above once django-coursemanager has been merged and tagged with v0.7
+django-coursemanager @ git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@task/haydn9000/tlt-4585/remove-CanvasCourseInstance-and-CoursePerson-models
 
 canvas_python_sdk @ git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.4.3
 

--- a/canvas_site_creator/utils.py
+++ b/canvas_site_creator/utils.py
@@ -69,8 +69,7 @@ def create_canvas_course_and_section(data):
         course_course_code=course_code,
         course_name=title,
         course_sis_course_id=course_instance_id,
-        # course_term_id=term_id
-        course_term_id=23452345  #TODO for testing purposes only, delete once done and uncomment above.
+        course_term_id=term_id
     )
 
     try:

--- a/canvas_site_creator/utils.py
+++ b/canvas_site_creator/utils.py
@@ -69,7 +69,8 @@ def create_canvas_course_and_section(data):
         course_course_code=course_code,
         course_name=title,
         course_sis_course_id=course_instance_id,
-        course_term_id=term_id
+        # course_term_id=term_id
+        course_term_id=23452345  #TODO for testing purposes only, delete once done and uncomment above.
     )
 
     try:

--- a/canvas_site_creator/views.py
+++ b/canvas_site_creator/views.py
@@ -143,12 +143,13 @@ def create_new_course(request):
                                  f'Course <a href="{ settings.CANVAS_URL }/courses/{ course_instance.canvas_course_id }" target="_blank">{ course_instance.canvas_course_id }</a> successfully created.')
         else:
             # Roll back the database changes so user can try again later.
-            print(f"c_id =============================================================== {course.course_id}")
             print(f"ci_id=============================================================== {course_instance.course_instance_id}")
-            Course.objects.filter(pk=course.course_id).delete()
+            print(f"c_id =============================================================== {course.course_id}")
             CourseInstance.objects.filter(pk=course_instance.course_instance_id).delete()
-            # course.delete()
+            Course.objects.filter(pk=course.course_id).delete()
             # course_instance.delete()
+            # course.delete()
+            
 
             messages.add_message(request,
                                  messages.ERROR,

--- a/canvas_site_creator/views.py
+++ b/canvas_site_creator/views.py
@@ -142,9 +142,18 @@ def create_new_course(request):
                                  messages.SUCCESS,
                                  f'Course <a href="{ settings.CANVAS_URL }/courses/{ course_instance.canvas_course_id }" target="_blank">{ course_instance.canvas_course_id }</a> successfully created.')
         else:
+            # Roll back the database changes so user can try again later.
+            print(f"c_id =============================================================== {course.course_id}")
+            print(f"ci_id=============================================================== {course_instance.course_instance_id}")
+            Course.objects.filter(pk=course.course_id).delete()
+            CourseInstance.objects.filter(pk=course_instance.course_instance_id).delete()
+            # course.delete()
+            # course_instance.delete()
+
             messages.add_message(request,
                                  messages.ERROR,
                                  'The course could not successfully be created. '
+                                 'This could be due to either the term or account missing in Canvas. '
                                  'Please try again or contact support if the issue persists.')
 
         return redirect('canvas_site_creator:create_new_course')

--- a/canvas_site_creator/views.py
+++ b/canvas_site_creator/views.py
@@ -143,13 +143,8 @@ def create_new_course(request):
                                  f'Course <a href="{ settings.CANVAS_URL }/courses/{ course_instance.canvas_course_id }" target="_blank">{ course_instance.canvas_course_id }</a> successfully created.')
         else:
             # Roll back the database changes so user can try again later.
-            print(f"ci_id=============================================================== {course_instance.course_instance_id}")
-            print(f"c_id =============================================================== {course.course_id}")
-            CourseInstance.objects.filter(pk=course_instance.course_instance_id).delete()
-            Course.objects.filter(pk=course.course_id).delete()
-            # course_instance.delete()
-            # course.delete()
-            
+            course_instance.delete()
+            course.delete()            
 
             messages.add_message(request,
                                  messages.ERROR,


### PR DESCRIPTION
- Added some more detail to the error message shown to the user to tell them that either the term or account was missing in Canvas.
- Fully roll back the database changes so user can try again later.

Note:
- Deployed in dev
- These changes depend on [this django-coursemanager PR](https://github.com/Harvard-University-iCommons/django-coursemanager/pull/7) to be merged and tagged with new version that can be used in this project.
    - Once merged and tagged, before merging this project update the base requirements file to use the new version of [django-coursemanager](https://github.com/Harvard-University-iCommons/django-coursemanager).