### PR TITLE
task/tlt-4604/idkjay/limit_deletion_to_sites_under_current_sub_account

### DIFF
--- a/canvas_site_deletion/views.py
+++ b/canvas_site_deletion/views.py
@@ -103,7 +103,8 @@ def delete(request, pk):
         account_ids = get_account_hierarchy(ci.canvas_course_id)
 
         if current_tool_launch_account_id not in account_ids:
-            logger.error(f'User {request.user} is trying to delete the Canvas site associated with course_instance {pk} but is not in the correct account or sub-account where they have launched the site deletion tool.')
+            logger.error(f'User {request.user} is trying to delete the Canvas site associated with course_instance {pk} but is not in the correct account or sub-account where they have launched the site deletion tool.', 
+                         extra={"course_instance_id": pk, "account_ids": account_ids, "user_id": request.user})
             messages.error(request, f'You must be under the correct account or sub-account in order to delete Canvas course {canvas_course_id} and course_instance {pk}.')
             return render(request, 'canvas_site_deletion/index.html')
 

--- a/canvas_site_deletion/views.py
+++ b/canvas_site_deletion/views.py
@@ -176,7 +176,7 @@ def delete(request, pk):
     return render(request, 'canvas_site_deletion/index.html')
 
 
-def get_account_hierarchy(course_id) -> str:
+def get_account_hierarchy(course_id) -> list:
     """
     Get the list of accounts associated with a given course ID
     """

--- a/canvas_site_deletion/views.py
+++ b/canvas_site_deletion/views.py
@@ -5,7 +5,7 @@ from canvas_sdk import RequestContext
 from canvas_sdk.exceptions import CanvasAPIError
 from canvas_sdk.methods import courses, sections
 from canvas_sdk.utils import get_all_list_data
-from coursemanager.models import CourseInstance, CourseSite, SiteMap
+from coursemanager.models import CourseInstance, CourseSite, SiteMap, Course
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -94,13 +94,14 @@ def delete(request, pk):
         ci = CourseInstance.active_and_deleted.get(course_instance_id=pk)
 
         canvas_course_id = ci.canvas_course_id
+        canvas_site_school_id = ci.term.school.school_id
+        canvas_course_instance_id = ci.course_instance_id
         ts = int(time.time())
 
         # if school_id of the Canvas course does not match the sub-account id, deletion will not be possible
-        current_sub_account_id = custom_canvas_account_sis_id.split(":")[1]
-        canvas_site_school_id = ci.term.school.school_id
+        tool_launch_school = get_tool_launch_school(custom_canvas_account_sis_id, canvas_course_instance_id)
 
-        if canvas_site_school_id != current_sub_account_id:
+        if canvas_site_school_id != tool_launch_school:
             messages.error(request, f'You must be under the correct sub-account in order to delete Canvas course {canvas_course_id} and course_instance {pk}.')
             return render(request, 'canvas_site_deletion/index.html')
 

--- a/canvas_site_deletion/views.py
+++ b/canvas_site_deletion/views.py
@@ -171,3 +171,25 @@ def delete(request, pk):
     messages.success(request, f"Successfully deleted Canvas course {canvas_course_id} and cleaned up course_instance {pk}")
 
     return render(request, 'canvas_site_deletion/index.html')
+
+
+def get_tool_launch_school(custom_canvas_account_sis_id, ci_course_instance_id) -> str:
+    """
+    Get the school that this tool is being launched in.
+    """
+    try:
+        tool_launch_school = "unknown"  # Initialize tool_launch_school
+        if custom_canvas_account_sis_id.startswith('coursegroup:'):
+            tool_launch_school = "colgsas"
+        elif custom_canvas_account_sis_id.startswith('dept:'):
+            dept_id = custom_canvas_account_sis_id.split(':')[1]
+            ci = CourseInstance.objects.get(course_instance_id=ci_course_instance_id)
+            course_id = ci.course_id
+            course = Course.objects.get(course_id=course_id, department_id=dept_id)
+            tool_launch_school = course.school_id
+        else:
+            tool_launch_school = custom_canvas_account_sis_id.split(':')[1]
+    except Exception:
+        logger.exception('Error getting launch school')
+
+    return tool_launch_school

--- a/canvas_site_deletion/views.py
+++ b/canvas_site_deletion/views.py
@@ -187,13 +187,7 @@ def get_account_hierarchy(course_id) -> list:
     canvas_course_account_id = canvas_course["account_id"] 
     account_ids.append(canvas_course_account_id)
 
-    # traverse account hierarchy in both directions
-    # first downwards to find sub-accounts
-    sub_accounts = get_sub_accounts_of_account(SDK_CONTEXT, canvas_course_account_id).json()
-    for sub_account in sub_accounts:
-        account_ids.append(sub_account["id"])
-
-    # then upwards to find parent accounts
+    # then work up the tree, grabbing account IDs of parent accounts
     while True: 
         account_object = get_single_account(SDK_CONTEXT, canvas_course_account_id).json()
         parent_account_id = account_object.get("parent_account_id")
@@ -201,6 +195,7 @@ def get_account_hierarchy(course_id) -> list:
         if parent_account_id is None:
             break
         account_ids.append(parent_account_id)
+
         canvas_course_account_id = parent_account_id
-    
+
     return account_ids


### PR DESCRIPTION
- Added a check to make sure you are in the right sub-account in order to delete a Canvas course
- Added a function to pull current school account id of where tool was launched
- Currently, you can delete a sub-sub-account (department or coursegroup) course whether you're in that same sub-sub-account or the sub-account above it. 
- You can also delete courses of the sub-account while inside the sub-sub-account. 
- For above two points, we can add extra protections later.

Note
- Tested and deployed on `QA`