### PR TITLE
Task/haydn9000/tlt 4601/set up project structure

### DIFF
--- a/canvas_account_admin_tools/settings/base.py
+++ b/canvas_account_admin_tools/settings/base.py
@@ -393,6 +393,11 @@ LOGGING = {
             'handlers': ['console', 'default'],
             'propagate': False,
         },
+        'course_info_v2': {
+            'level': _DEFAULT_LOG_LEVEL,
+            'handlers': ['console', 'default'],
+            'propagate': False,
+        },
         'cross_list_courses': {
             'level': _DEFAULT_LOG_LEVEL,
             'handlers': ['console', 'default'],

--- a/course_info_v2/admin.py
+++ b/course_info_v2/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/course_info_v2/apps.py
+++ b/course_info_v2/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 
 
-class CourseInfoV2(AppConfig):
-    name = 'course_info_v2'
+class CourseInfoV2Config(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "course_info_v2"

--- a/course_info_v2/models.py
+++ b/course_info_v2/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/course_info_v2/templates/course_info_v2/base.html
+++ b/course_info_v2/templates/course_info_v2/base.html
@@ -1,0 +1,30 @@
+{% extends "icommons_ui/base_lti.html" %}
+{% load collections %}
+{% load django_helpers %}
+
+{% block title %}Courses{% endblock title %}
+
+{% block stylesheet %}
+    {{ block.super }}
+    <link rel="stylesheet" type="text/css"
+          href="https://static.tlt.harvard.edu/shared/DataTables-1.13.2/css/dataTables.bootstrap5.min.css"
+          media="screen"/>
+    <link rel="stylesheet" type="text/css"
+          href="https://static.tlt.harvard.edu/shared/Select-1.6.0/css/select.bootstrap5.min.css"
+          media="screen"/>
+{% endblock stylesheet %}
+
+{% block javascript %}
+    {{ block.super }}
+    <script src="https://static.tlt.harvard.edu/shared/DataTables-1.13.2/js/jquery.dataTables.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/DataTables-1.13.2/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/Select-1.6.0/js/select.bootstrap5.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/Select-1.6.0/js/select.dataTables.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/Select-1.6.0/js/select.jqueryui.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/Select-1.6.0/js/dataTables.select.min.js"></script>
+
+    <script>
+        window.globals.STATIC_URL = '{% settings_value "STATIC_URL" %}';
+        window.globals.CANVAS_URL = '{% settings_value "CANVAS_URL" %}';
+    </script>
+{% endblock javascript %}

--- a/course_info_v2/templates/course_info_v2/course_details.html
+++ b/course_info_v2/templates/course_info_v2/course_details.html
@@ -1,4 +1,4 @@
-{% extends "canvas_site_creator/base.html" %}
+{% extends "course_info_v2/base.html" %}
 
 {% block breadcrumb %}
     <a href="{% url "dashboard_account" %}">Admin Console</a>

--- a/course_info_v2/templates/course_info_v2/course_details.html
+++ b/course_info_v2/templates/course_info_v2/course_details.html
@@ -1,0 +1,9 @@
+{% extends "canvas_site_creator/base.html" %}
+
+{% block breadcrumb %}
+    <a href="{% url "dashboard_account" %}">Admin Console</a>
+    <small><i class="fa fa-chevron-right"></i></small>
+    <a href="{% url 'course_info_v2:index' %}">Courses</a>
+    <small><i class="fa fa-chevron-right"></i></small>
+    <a href="{% url 'course_info_v2:details' %}">placehoder for course</a>
+{% endblock breadcrumb %}

--- a/course_info_v2/templates/course_info_v2/course_search.html
+++ b/course_info_v2/templates/course_info_v2/course_search.html
@@ -1,0 +1,7 @@
+{% extends "canvas_site_creator/base.html" %}
+
+{% block breadcrumb %}
+    <a href="{% url "dashboard_account" %}">Admin Console</a>
+    <small><i class="fa fa-chevron-right"></i></small>
+    Courses
+{% endblock breadcrumb %}

--- a/course_info_v2/templates/course_info_v2/course_search.html
+++ b/course_info_v2/templates/course_info_v2/course_search.html
@@ -1,4 +1,4 @@
-{% extends "canvas_site_creator/base.html" %}
+{% extends "course_info_v2/base.html" %}
 
 {% block breadcrumb %}
     <a href="{% url "dashboard_account" %}">Admin Console</a>

--- a/course_info_v2/tests.py
+++ b/course_info_v2/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/course_info_v2/urls.py
+++ b/course_info_v2/urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from course_info_v2 import views
 
 urlpatterns = [
-    path('', views.index, name='index'),
+    path("", views.index, name="index"),
 ]

--- a/course_info_v2/urls.py
+++ b/course_info_v2/urls.py
@@ -1,7 +1,9 @@
+from posixpath import relpath
 from django.urls import path
 
 from course_info_v2 import views
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("details/", views.index, name="details")
 ]

--- a/course_info_v2/views.py
+++ b/course_info_v2/views.py
@@ -1,5 +1,13 @@
+import logging
+
 from django.shortcuts import render
+
+logger = logging.getLogger(__name__)
 
 
 def index(request):
-    pass
+    return render(request, "course_info_v2/course_search.html", {})
+
+
+def details(request):
+    return render(request, "course_info_v2/course_details.html", {})

--- a/course_info_v2/views.py
+++ b/course_info_v2/views.py
@@ -6,8 +6,8 @@ logger = logging.getLogger(__name__)
 
 
 def index(request):
-    return render(request, "course_info_v2/course_search.html", {})
+    return render(request, "course_info_v2/course_search.html", context={})
 
 
 def details(request):
-    return render(request, "course_info_v2/course_details.html", {})
+    return render(request, "course_info_v2/course_details.html", context={})

--- a/course_info_v2/views.py
+++ b/course_info_v2/views.py
@@ -1,2 +1,5 @@
+from django.shortcuts import render
+
+
 def index(request):
     pass


### PR DESCRIPTION
Course Info V2 Setup Project Structure

- Created a feature branch in CAAT `feature/course_info_v2` (see [branches here](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/branches))
    - Protected feature branch in GitHub (also added rule to prevent merging without a PR. We could remove this if not desired)

- Updated already existing Course Info V2 app in CAAT.
- In CAAT urls Course Info V2 urls already included.
- In CAAT settings `base.py` the Course Info V2 already added to the list of apps.
- Added a base template that extends [django-icommons-ui](https://github.com/Harvard-University-iCommons/django-icommons-ui) which will use the latest jQuery and Bootstrap. Base template should contains DataTables as all extending template will be using it.
- Created templates for each screen. Each template is blank and only contain breadcrumbs placeholders.
    - `course_search.html` - Initial page to be displayed upon tool load.
    - `course_details.html` - Details page for course data.
- Setup logger configs.