### PR TITLE
TLT-4635: Handle filtering when using Select All checkbox

### DIFF
--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -210,32 +210,44 @@
                 setTimeout(updateButtonText, 125); // 1/8 second wait
             });
 
-            // Select All functionality
-            $('.selectAll').on('change', function() {
+            $('.selectAll').on('change', function(event) {
+                element = this;
+            });
+
+            $('.selectAll').on('click', function(event) {
+//                event.preventDefault();
+//                var isIndeterminate = this.checked
                 if(this.checked) {
                     selectRows(table);
+                    updateSelectAllCheckbox(table);
                 } else {
                     deselectRows(table);
+                    $(this).prop('checked', false);
+                    $(this).prop('indeterminate', false);
                 }
                 updateButtonText();
             });
 
-            // Clear any selections if the user changes the filter
-            table.on('search', function() {
-                deselectRows(table);
-                $('.selectAll').prop('checked', false);
+            table.on('select deselect', function (e, dt, type, indexes) {
+                updateSelectAllCheckbox(table);
             });
 
-            // Handle Select All checkbox state when individual rows are selected/deselected
-            table.on('select deselect', function () {
-                // Get the number of rows currently displayed (considers any applied filtering)
-                const info = table.page.info();
-                const rowsDisplayed = info.recordsDisplay;
+            function updateSelectAllCheckbox(table) {
+                var selectedRows = table.rows({ selected: true }).count();
+                var totalRows = table.rows().count();
+                var filteredRows = table.rows({ search: 'applied' }).count();
 
-                const allSelected = table.rows({ selected: true }).count() === rowsDisplayed;
-
-                $('.selectAll').prop('checked', allSelected);
-            });
+                if (selectedRows === totalRows) {
+                    $('.selectAll').prop('indeterminate', false);
+                    $('.selectAll').prop('checked', true);
+                } else if (selectedRows > 0) {
+                    $('.selectAll').prop('indeterminate', true);
+                    $('.selectAll').prop('checked', false);
+                } else {
+                    $('.selectAll').prop('indeterminate', false);
+                    $('.selectAll').prop('checked', false);
+                }
+            }
 
             // For updating modal body text.
             $("#bsc-create-btn").on( "click", function() {

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -226,6 +226,17 @@
                 $('.selectAll').prop('checked', false);
             });
 
+            // Handle Select All checkbox state when individual rows are selected/deselected
+            table.on('select deselect', function () {
+                // Get the number of rows currently displayed (considers any applied filtering)
+                const info = table.page.info();
+                const rowsDisplayed = info.recordsDisplay;
+
+                const allSelected = table.rows({ selected: true }).count() === rowsDisplayed;
+
+                $('.selectAll').prop('checked', allSelected);
+            });
+
             // For updating modal body text.
             $("#bsc-create-btn").on( "click", function() {
                 const totalTableRowItems = table.rows().count();

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -198,32 +198,33 @@
                 }
             });
 
-            // For updating Create All/Create Selected button text when row or checkbox is clicked
-            function updateButtonText() {
-                const create_btn_text = (table.rows({ selected: true }).any()) ? "Create Selected" : "Create All";
-                $("#bsc-create-btn").html(`${create_btn_text}`);
-            };
-
             $("#course-table-body").on( "click", function() {
                 // Update button after n seconds to get accurate if row selected value
                 // after DataTable has time to process checkbox click
                 setTimeout(updateButtonText, 125); // 1/8 second wait
             });
 
-            $('.selectAll').on('change', function(event) {
-                element = this;
-            });
-
             $('.selectAll').on('click', function(event) {
-//                event.preventDefault();
-//                var isIndeterminate = this.checked
                 if(this.checked) {
-                    selectRows(table);
-                    updateSelectAllCheckbox(table);
+                    // Previous checkbox state could either be indeterminate
+                    // or unchecked, so determine previous state via selected
+                    // row count
+                    const selectedRowCount = getSelectedRowCount(table);
+                    if (selectedRowCount > 0) {
+                        // At least one row previously selected, so going from
+                        // indeterminate state to unchecked state
+                        deselectRows(table);
+                        updateSelectAllCheckbox(table)
+                    }
+                    else {
+                        // Zero rows previously selected, so going from unchecked state
+                        // to checked state
+                        selectRows(table);
+                        updateSelectAllCheckbox(table)
+                    }
                 } else {
                     deselectRows(table);
-                    $(this).prop('checked', false);
-                    $(this).prop('indeterminate', false);
+                    updateSelectAllCheckbox(table)
                 }
                 updateButtonText();
             });
@@ -231,23 +232,6 @@
             table.on('select deselect', function (e, dt, type, indexes) {
                 updateSelectAllCheckbox(table);
             });
-
-            function updateSelectAllCheckbox(table) {
-                var selectedRows = table.rows({ selected: true }).count();
-                var totalRows = table.rows().count();
-                var filteredRows = table.rows({ search: 'applied' }).count();
-
-                if (selectedRows === totalRows) {
-                    $('.selectAll').prop('indeterminate', false);
-                    $('.selectAll').prop('checked', true);
-                } else if (selectedRows > 0) {
-                    $('.selectAll').prop('indeterminate', true);
-                    $('.selectAll').prop('checked', false);
-                } else {
-                    $('.selectAll').prop('indeterminate', false);
-                    $('.selectAll').prop('checked', false);
-                }
-            }
 
             // For updating modal body text.
             $("#bsc-create-btn").on( "click", function() {
@@ -352,5 +336,42 @@
             });
         };
 
+        // For updating Create All/Create Selected button text when row or checkbox is clicked
+        function updateButtonText() {
+            const create_btn_text = (table.rows({ selected: true }).any()) ? "Create Selected" : "Create All";
+            $("#bsc-create-btn").html(`${create_btn_text}`);
+        };
+
+        function getSelectedRowCount(table) {
+            return table.rows({ selected: true }).count();
+        };
+
+        function setIndeterminate(table) {
+            $('.selectAll').prop('indeterminate', true);
+            $('.selectAll').prop('checked', false);
+        };
+
+        function setChecked(table) {
+            $('.selectAll').prop('indeterminate', false);
+            $('.selectAll').prop('checked', true);
+        };
+
+        function setUnchecked(table) {
+            $('.selectAll').prop('indeterminate', false);
+            $('.selectAll').prop('checked', false);
+        };
+
+        function updateSelectAllCheckbox(table) {
+            var selectedRows = table.rows({ selected: true }).count();
+            var totalRows = table.rows().count();
+
+            if (selectedRows === totalRows) {
+                setChecked(table);
+            } else if (selectedRows > 0) {
+                setIndeterminate(table);
+            } else {
+                setUnchecked(table);
+            }
+        };
 	</script>
 {% endblock javascript %}

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -220,12 +220,10 @@
                 updateButtonText();
             });
 
-            // Handle individual row checkbox changes
-            courseTable.on('select deselect', function(e, dt, type, indexes) {
-                let selectedCount = courseTable.rows({ selected: true }).count();
-
-                // Update the "selectAll" checkbox based on selectedCount
-                $('.selectAll').prop('checked', selectedCount === totalRows);
+            // Clear any selections if the user changes the filter
+            table.on('search', function() {
+                deselectRows(table);
+                $('.selectAll').prop('checked', false);
             });
 
             // For updating modal body text.

--- a/bulk_site_creator/templates/bulk_site_creator/new_job.html
+++ b/bulk_site_creator/templates/bulk_site_creator/new_job.html
@@ -211,28 +211,13 @@
             });
 
             // Select All functionality
-            let courseTable = $('#course-table').DataTable();
-            let totalRows = table.rows().count();
-            let totalRowsChecked = 0;
-
             $('.selectAll').on('change', function() {
-                let checked = $(this).prop('checked');
-                courseTable.rows().select(checked);
-
-                // Get the number of selected rows throughout whole table
-                totalRowsChecked = courseTable.rows({ selected: true }).count();
-
-                // Check off every row found in the table
-                table.cells(null, 0).every(function(e) {
-                    let cell = this.node();
-                    $(cell).find('input[type="checkbox"][name="chkbx"]').prop('checked', checked);
-                });
-
-                // Check if totalRowsChecked is less than totalRows and update "selectAll" checkbox accordingly
-                if (totalRowsChecked < totalRows) {
-                    $(this).prop('checked', false);
-                };
-                updateButtonText()
+                if(this.checked) {
+                    selectRows(table);
+                } else {
+                    deselectRows(table);
+                }
+                updateButtonText();
             });
 
             // Handle individual row checkbox changes
@@ -322,5 +307,29 @@
             }
             return ciIDList;
         };
+
+        function selectRows(table) {
+            // If no filter, select all rows
+            if(table.search() === '') {
+                table.rows().select();
+                table.rows().nodes().each(function(row) {
+                    $(row).find('input[type="checkbox"]').prop('checked', true);
+                });
+            } else {
+                // Select only the filtered rows
+                table.rows({ search: 'applied' }).select();
+                table.rows({ search: 'applied' }).nodes().each(function(row) {
+                    $(row).find('input[type="checkbox"]').prop('checked', true);
+                });
+            }
+        };
+
+        function deselectRows(table) {
+            table.rows().deselect();
+            table.rows().nodes().each(function(row) {
+                $(row).find('input[type="checkbox"]').prop('checked', false);
+            });
+        };
+
 	</script>
 {% endblock javascript %}


### PR DESCRIPTION
## Summary
This PR:
- Updates the Select All checkbox to account for any filters applied by the user (via the Search input). Now, if a user applies a filter to the data set, the Select All checkbox will only select that subset of rows (as opposed to the total, unfiltered data set). This was not previously the case.

## Testing

This branch has been deployed to dev + qa.

Performed two test runs to ensure that only the selected rows are submitted within the batch job.

Test run 1 - submit filtered job (20 rows). 
- Expected 20 courses; resulted in 20 created courses

![Screen Shot 2024-04-02 at 2 27 49 PM](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/43320443/4171fdbc-4ff5-48ef-b012-c16f110e768e)

Test run 2 - submit unfiltered job (312 rows).
- Expected 312 courses; resulted in 312 created courses

![Screen Shot 2024-04-02 at 2 32 50 PM](https://github.com/Harvard-University-iCommons/canvas_account_admin_tools/assets/43320443/d623b962-a594-4bab-8cd5-032d032d795b)
