### PR TITLE
Cross Listing Tool switch button is broken

### DIFF
--- a/cross_list_courses/templates/add_new.html
+++ b/cross_list_courses/templates/add_new.html
@@ -72,7 +72,11 @@
                                     {% endif %}
                                     </i>
                                 </td>
-                                <td><i class="fa fa-exchange fa-2x btn btn-info" onclick="swapCourses(this);" aria-hidden="true"></i></td>
+                                <td>
+                                    <a href="#" class="btn btn-info" onclick="swapCourses(this);" aria-hidden="true">
+                                        <i class="fa-solid fa-arrow-right-arrow-left fa-2x"></i>
+                                    </a>
+                                </td>
                                 <td>
                                     {{ mapping.secondary_school_id | upper }}
                                     <b>


### PR DESCRIPTION
- Fixed switch button on Cross Listing Tool by putting the `<i>` inside a `<a>` and updating the font-awsome class
- Deployed on DEV
 
![image](https://github.com/user-attachments/assets/e604d016-5534-43a2-8479-f2988072526b)
