### PR TITLE
TLT-4743: Reduce `maxlength` of `course-code` input to 46

### DIFF
--- a/canvas_site_creator/templates/canvas_site_creator/index.html
+++ b/canvas_site_creator/templates/canvas_site_creator/index.html
@@ -40,7 +40,7 @@
                                id="course-code"
                                name="course-code"
                                minlength="3"
-                               maxlength="50"
+                               maxlength="46"
                                required>
                             </div>
                     </div>


### PR DESCRIPTION
Resolves [TLT-4743](https://at-harvard.atlassian.net/browse/TLT-4743).

Tested in dev/qa. Reducing the max allowed input size to 46 will ensure that, after backend processing, the value inserted into the DB column is <= 50 characters.