### PR TITLE
TLT-4899: Revert job status stuck in queued state

### DIFF
--- a/bulk_course_settings/templates/bulk_course_settings/job_detail.html
+++ b/bulk_course_settings/templates/bulk_course_settings/job_detail.html
@@ -54,7 +54,7 @@
                     {% endif %}
                 </div>
                 <div class="col-sm-2">
-                    {% if job.related_job_id is None and job.workflow_status == 'COMPLETED_SUCCESS' and not reversion_job and job.details_total_count > 0 %}
+                    {% if job.related_job_id is None and job.workflow_status == 'COMPLETED_SUCCESS' and not reversion_job and job.details_total_count > 0 and job.details_total_count != job.details_skipped_count %}
                         <a href="{% url 'bulk_course_settings:revert_setting' job.school_id job.id %}" class="btn btn-primary pull-right">Revert Job</a>
                     {% else %}
                         <a class="btn btn-default disabled pull-right">Revert Job</a>

--- a/bulk_course_settings/views.py
+++ b/bulk_course_settings/views.py
@@ -180,7 +180,7 @@ class BulkSettingsRevertView(LTIPermissionRequiredMixin, LoginRequiredMixin, Vie
 
 			job_details_list = _create_job_details(job=new_bulk_job, course_id_list=related_job_details_course_id_list)
 
-			utils.send_job_to_queueing_lambda(related_bulk_job.id, job_details_list, setting_to_be_modified, desired_setting)
+			utils.send_job_to_queueing_lambda(new_bulk_job.id, job_details_list, setting_to_be_modified, desired_setting)
 
 			# logger.info('Queued reversion job {} for related job {}'.format(new_bulk_job.id, related_bulk_job.id))
 			messages.success(request, 'Reversion job was created successfully.')

--- a/bulk_course_settings/views.py
+++ b/bulk_course_settings/views.py
@@ -1,10 +1,11 @@
 import logging
 from typing import Dict, List
 
-from django.db.models import Count, Q
+from coursemanager.models import CourseInstance, Term
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import PermissionDenied
+from django.db.models import Count, Q
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views import View
@@ -16,9 +17,7 @@ from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from bulk_course_settings import constants, utils
 from bulk_course_settings.forms import CreateBulkSettingsForm
-from bulk_course_settings.models import Job, Details
-
-from coursemanager.models import Term, CourseInstance, Course
+from bulk_course_settings.models import Details, Job
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Resolves [TLT-4899](https://at-harvard.atlassian.net/browse/TLT-4899).

This PR:
- Ensures that when reverting a bulk job, we send over the ID of the new job to the Lambda (as opposed to the ID of the original job that we're reverting). That way, the state of the reversion can be accurately tracked.
- Disables the Revert Job button when all courses in a job were skipped. This is to prevent an issue where a reversion of this kind of job gets stuck in a "Queued" state.

![Screenshot 2025-01-09 at 6 23 56 PM](https://github.com/user-attachments/assets/57dbcba2-826e-422a-91d9-92d3575104a9)

## Testing
This branch was deployed/tested on QA.

Testing was performed via creating a new bulk settings job, then reverting that job.