### PR TITLE
Add deprecation notice banner to Admin Console dashboard

### DIFF
--- a/canvas_account_admin_tools/templates/canvas_account_admin_tools/banner.html
+++ b/canvas_account_admin_tools/templates/canvas_account_admin_tools/banner.html
@@ -1,0 +1,35 @@
+{% comment %} CSS for the deprecation notice banner {% endcomment %}
+<style>
+    .deprecation-notice {
+        background-color: #fff3cd;
+        border-left: 5px solid #ffc107;
+        margin-bottom: 20px;
+        padding: 15px;
+        border-radius: 4px;
+    }
+    .deprecation-notice h4 {
+        color: #856404;
+        margin-top: 0;
+    }
+    .notice-buttons a {
+        margin-right: 10px;
+        display: inline-block;
+    }
+</style>
+
+{% comment %} HTML for the deprecation notice banner {% endcomment %}
+<div class="deprecation-notice">
+    <h4><i class="fa fa-exclamation-triangle"></i> Important: Tool Deprecation Notice</h4>
+    <p>
+        This Admin Console is being deprecated and will be replaced by the new <strong>Canvas Admin Console</strong>.
+        Please review the documentation and provide feedback on the transition.
+    </p>
+    <div class="notice-buttons">
+        <a href="https://harvard.az1.qualtrics.com/jfe/form/SV_egQqQCeikUX85wO" class="btn btn-sm btn-warning" target="_blank">
+            <i class="fa fa-comment"></i> Provide Feedback
+        </a>
+        <a href="https://harvardwiki.atlassian.net/wiki/x/ZgKsD" class="btn btn-sm btn-info" target="_blank">
+            <i class="fa fa-book"></i> View Documentation
+        </a>
+    </div>
+</div>

--- a/canvas_account_admin_tools/templates/canvas_account_admin_tools/dashboard_account.html
+++ b/canvas_account_admin_tools/templates/canvas_account_admin_tools/dashboard_account.html
@@ -14,6 +14,8 @@
       </nav>
     </header>
 
+    {% include "canvas_account_admin_tools/banner.html" %}
+
     {% if search_courses_allowed %}
       <div class="card card_color">
         <a href="{% url 'course_info:index' %}" id="course-info">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Adds a deprecation notice banner to inform users that the Admin Console is being deprecated and will be replaced by the new Canvas Admin Console.
    - Includes a button that links to a Qualtrics survey to gather user feedback.
    - Includes a button that links to Wiki documentation for the new Canvas Admin Console (CAC).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Closes [TLT-5039](https://at-harvard.atlassian.net/browse/TLT-5039)
- Related Issue(s) #

## QA Instructions, Screenshots, Recordings

Deployed ind DEV ([test account here](https://harvard.beta.instructure.com/accounts/749/external_tools/21863))

Screenshot of banner:
<img width="1024" alt="screenshot_" src="https://github.com/user-attachments/assets/c3112bd2-f684-4614-ab03-313360a8fffd" />

## Regression Testing

- ✅ Verified the deprecation notice banner appears properly above the tool cards on the Admin Console dashboard.
- ✅ Confirmed that all existing dashboard functionality continues to work normally with the banner in place.

## [optional] Are there any post deployment tasks we need to perform?

None